### PR TITLE
FMV3-M2-02: add deterministic read-only profile detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,10 @@ registry for Helianthus.
 ## Status
 
 M2-01 defines immutable profile and observation contracts and consumes the
-public M1-06 opaque runtime-acquisition API. Production observations use a
-bounded attempt ledger and a caller-supplied transactional publication
-boundary. Offline fixture replay is a separate nonpublishable result.
-
-The repository contains no concrete detector, probe plan, qualification
-record, standard-family profile, vendor overlay, or vendor fixture. Those
-surfaces belong to later M2 milestones and require a separate operator request.
+public M1-06 opaque runtime-acquisition API. M2-02 adds bounded, deterministic,
+read-only profile detection over the immutable catalog. The repository still
+contains no standard-family profile, vendor overlay, qualification record, or
+vendor fixture; those belong to later milestones and require public evidence.
 
 ## One Registry, Multiple Vendors
 
@@ -42,14 +39,16 @@ This repository owns:
 - a transactional publication interface joining the irreversible external
   effect and terminal publication decision;
 - strict bounded serialization for contracts, observations, and ledger state;
-  and
+- bounded read-only probe plans and deterministic qualification-aware profile
+  detection; and
 - evidence-gated vendor overlay declarations for future milestones.
 
 This repository does not own:
 
 - sockets, serial ports, endpoint scheduling, retries, or transport recovery;
 - Modbus TCP/RTU framing or arbitrary protocol operations;
-- concrete detection, probe execution, or hardware qualification;
+- transport I/O behind the caller-supplied read-only probe interface or
+  hardware qualification execution;
 - canonical energy/PV publication policy;
 - gateway composition or private output bindings.
 
@@ -68,9 +67,10 @@ Fixture bytes use `FixtureReplayer.Replay`. `FixtureReplay` has a fixture
 content identity and immutable replay facts, but no runtime capability,
 production sample ID, seal, or publish method.
 
-The detailed API contract is in [`docs/m2-01-api.md`](docs/m2-01-api.md). The
-cross-repository architecture remains documented in the public Helianthus
-protocol documentation repository.
+The detailed contracts are in [`docs/m2-01-api.md`](docs/m2-01-api.md) and
+[`docs/m2-02-detection.md`](docs/m2-02-detection.md). The cross-repository
+architecture remains documented in the public Helianthus protocol
+documentation repository.
 
 ## Development
 
@@ -88,7 +88,7 @@ Run:
 
 The offline gate validates
 [`policy/registry-boundary.json`](policy/registry-boundary.json) against the
-current tree. It enforces the one-registry and M2-01 contracts-only boundary,
+current tree. It enforces the one-registry public semantic boundary,
 the public Modbus dependency, product import restrictions, forbidden ownership
 directories, vendor neutrality for future standard-family source, and public
 evidence for future vendor overlays. Python mutation tests prove that forbidden
@@ -103,8 +103,8 @@ Work remains one issue and one pull request at a time, with squash merge,
 proportionate test-first evidence, applicable public documentation/evidence,
 and blocker-driven review of the current head.
 
-Completion of M2-01 is a hard stop. Gateway work or another milestone starts
-only after a separate operator request.
+The current execution cycle stops after M3-03 and before all gateway work in
+M4-01. Crossing that boundary requires a separate operator request.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
 

--- a/decision_serialization.go
+++ b/decision_serialization.go
@@ -1,0 +1,377 @@
+package modbusreg
+
+import (
+	"fmt"
+	"sort"
+)
+
+type detectionCandidateEvidenceDTO struct {
+	ProfileID            string               `json:"profile_id"`
+	ProfileVersion       string               `json:"profile_version"`
+	Score                uint32               `json:"score"`
+	Reason               DetectionReason      `json:"reason"`
+	MatchedGates         []ProbeIdentityField `json:"matched_gates"`
+	ProbeEvidenceIDs     []string             `json:"probe_evidence_ids"`
+	DetectorVersion      string               `json:"detector_version"`
+	QualificationVersion string               `json:"qualification_version"`
+}
+
+type detectionDecisionDTO struct {
+	SchemaVersion          string                          `json:"schema_version"`
+	Outcome                DetectionOutcome                `json:"outcome"`
+	Reason                 DetectionReason                 `json:"reason"`
+	SelectedProfileID      string                          `json:"selected_profile_id"`
+	SelectedProfileVersion string                          `json:"selected_profile_version"`
+	Evidence               []detectionCandidateEvidenceDTO `json:"evidence"`
+}
+
+func validDetectionOutcome(outcome DetectionOutcome) bool {
+	switch outcome {
+	case DetectionMatched, DetectionNoMatch, DetectionAmbiguous:
+		return true
+	default:
+		return false
+	}
+}
+
+func validDetectionReason(reason DetectionReason) bool {
+	switch reason {
+	case DetectionReasonSelected,
+		DetectionReasonEqualBest,
+		DetectionReasonLowerScore,
+		DetectionReasonIdentityMismatch,
+		DetectionReasonFirmwareMismatch,
+		DetectionReasonInvalidIdentity,
+		DetectionReasonFixtureOptInRequired,
+		DetectionReasonCandidateDisabled,
+		DetectionReasonProfileDefaultOff,
+		DetectionReasonProfileRevoked,
+		DetectionReasonProfileSuperseded,
+		DetectionReasonProfileUnqualified,
+		DetectionReasonReadError,
+		DetectionReasonProbeException,
+		DetectionReasonIncompleteProbe,
+		DetectionReasonInvalidProbeResult,
+		DetectionReasonContextCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func identityFieldRank(field ProbeIdentityField) int {
+	switch field {
+	case ProbeIdentityManufacturer:
+		return 0
+	case ProbeIdentityModel:
+		return 1
+	case ProbeIdentityFirmware:
+		return 2
+	default:
+		return -1
+	}
+}
+
+func validEvidenceOrder(evidence []DetectionCandidateEvidence) bool {
+	for index := 1; index < len(evidence); index++ {
+		previous := evidence[index-1]
+		current := evidence[index]
+		if previous.ProfileID >= current.ProfileID {
+			return false
+		}
+	}
+	return true
+}
+
+func validateDetectionEvidence(
+	evidence DetectionCandidateEvidence,
+	limits DetectionLimits,
+) error {
+	if !validIdentity(evidence.ProfileID) ||
+		!evidence.ProfileVersion.valid() ||
+		evidence.Score == 0 ||
+		!validDetectionReason(evidence.Reason) ||
+		!evidence.DetectorVersion.valid() ||
+		!evidence.QualificationVersion.valid() ||
+		len(evidence.MatchedGates) > limits.MaxPlanDeclarations ||
+		len(evidence.ProbeEvidenceIDs) != len(evidence.MatchedGates) {
+		return fmt.Errorf("detection candidate evidence is invalid")
+	}
+	previousRank := -1
+	seenEvidenceIDs := make(map[string]struct{}, len(evidence.ProbeEvidenceIDs))
+	for index, field := range evidence.MatchedGates {
+		rank := identityFieldRank(field)
+		if rank <= previousRank {
+			return fmt.Errorf("detection candidate gates are not canonical")
+		}
+		previousRank = rank
+		evidenceID := evidence.ProbeEvidenceIDs[index]
+		if !validProbeEvidenceID(evidenceID, limits.MaxEvidenceIDBytes) {
+			return fmt.Errorf("detection candidate evidence identity is invalid")
+		}
+		if _, duplicate := seenEvidenceIDs[evidenceID]; duplicate {
+			return fmt.Errorf("detection candidate evidence identity is duplicated")
+		}
+		seenEvidenceIDs[evidenceID] = struct{}{}
+	}
+	gateCount := len(evidence.MatchedGates)
+	switch evidence.Reason {
+	case DetectionReasonSelected,
+		DetectionReasonEqualBest,
+		DetectionReasonLowerScore:
+		if gateCount != 3 {
+			return fmt.Errorf("ranked detection evidence lacks complete gates")
+		}
+	case DetectionReasonIdentityMismatch:
+		if gateCount > 1 {
+			return fmt.Errorf("identity mismatch evidence has impossible gates")
+		}
+	case DetectionReasonFirmwareMismatch:
+		if gateCount != 2 {
+			return fmt.Errorf("firmware mismatch evidence has impossible gates")
+		}
+	default:
+		if gateCount != 0 {
+			return fmt.Errorf("detection evidence reason has impossible gates")
+		}
+	}
+	return nil
+}
+
+func validateDetectionDecision(
+	decision DetectionDecision,
+	limits DetectionLimits,
+) error {
+	if err := validateDetectionLimits(limits); err != nil {
+		return err
+	}
+	if !validDetectionOutcome(decision.outcome) ||
+		!validDetectionReason(decision.reason) ||
+		len(decision.evidence) == 0 ||
+		len(decision.evidence) > MaxProfileDependencies ||
+		!validEvidenceOrder(decision.evidence) {
+		return fmt.Errorf("detection decision is invalid")
+	}
+	selectedCount := 0
+	equalBestCount := 0
+	lowerScoreCount := 0
+	var equalBestScore uint32
+	var selectedScore uint32
+	var detectorVersion Version
+	overallReasonPresent := false
+	for index, evidence := range decision.evidence {
+		if err := validateDetectionEvidence(evidence, limits); err != nil {
+			return err
+		}
+		if index == 0 {
+			detectorVersion = evidence.DetectorVersion
+		} else if evidence.DetectorVersion != detectorVersion {
+			return fmt.Errorf("detection evidence contract versions disagree")
+		}
+		switch evidence.Reason {
+		case DetectionReasonSelected:
+			selectedCount++
+			selectedScore = evidence.Score
+		case DetectionReasonEqualBest:
+			if equalBestCount == 0 {
+				equalBestScore = evidence.Score
+			} else if evidence.Score != equalBestScore {
+				return fmt.Errorf("ambiguous candidates do not have equal scores")
+			}
+			equalBestCount++
+		case DetectionReasonLowerScore:
+			lowerScoreCount++
+		}
+		overallReasonPresent = overallReasonPresent || evidence.Reason == decision.reason
+	}
+	switch decision.outcome {
+	case DetectionMatched:
+		if decision.reason != DetectionReasonSelected ||
+			!validIdentity(decision.selectedProfileID) ||
+			!decision.selectedProfileVersion.valid() ||
+			selectedCount != 1 || equalBestCount != 0 {
+			return fmt.Errorf("matched detection decision is inconsistent")
+		}
+		found := false
+		for _, evidence := range decision.evidence {
+			if evidence.Reason == DetectionReasonSelected {
+				found = evidence.ProfileID == decision.selectedProfileID &&
+					evidence.ProfileVersion == decision.selectedProfileVersion
+			}
+		}
+		if !found {
+			return fmt.Errorf("selected profile is absent from decision evidence")
+		}
+		for _, evidence := range decision.evidence {
+			if evidence.Reason == DetectionReasonLowerScore &&
+				evidence.Score >= selectedScore {
+				return fmt.Errorf("matched detection ranking is inconsistent")
+			}
+		}
+	case DetectionAmbiguous:
+		if decision.reason != DetectionReasonEqualBest ||
+			decision.selectedProfileID != "" ||
+			decision.selectedProfileVersion.valid() ||
+			selectedCount != 0 || equalBestCount < 2 {
+			return fmt.Errorf("ambiguous detection decision is inconsistent")
+		}
+		for _, evidence := range decision.evidence {
+			if evidence.Reason == DetectionReasonLowerScore &&
+				evidence.Score >= equalBestScore {
+				return fmt.Errorf("ambiguous detection ranking is inconsistent")
+			}
+		}
+	case DetectionNoMatch:
+		if decision.reason == DetectionReasonSelected ||
+			decision.reason == DetectionReasonEqualBest ||
+			decision.reason == DetectionReasonLowerScore ||
+			decision.selectedProfileID != "" ||
+			decision.selectedProfileVersion.valid() ||
+			selectedCount != 0 || equalBestCount != 0 || lowerScoreCount != 0 ||
+			!overallReasonPresent {
+			return fmt.Errorf("no-match detection decision is inconsistent")
+		}
+	default:
+		return fmt.Errorf("detection decision outcome is invalid")
+	}
+	return nil
+}
+
+func detectionDecisionToDTO(
+	decision DetectionDecision,
+) detectionDecisionDTO {
+	evidence := make([]detectionCandidateEvidenceDTO, len(decision.evidence))
+	for index, item := range decision.evidence {
+		evidence[index] = detectionCandidateEvidenceDTO{
+			ProfileID:            item.ProfileID,
+			ProfileVersion:       item.ProfileVersion.String(),
+			Score:                item.Score,
+			Reason:               item.Reason,
+			MatchedGates:         append([]ProbeIdentityField{}, item.MatchedGates...),
+			ProbeEvidenceIDs:     append([]string{}, item.ProbeEvidenceIDs...),
+			DetectorVersion:      item.DetectorVersion.String(),
+			QualificationVersion: item.QualificationVersion.String(),
+		}
+	}
+	selectedVersion := ""
+	if decision.selectedProfileVersion.valid() {
+		selectedVersion = decision.selectedProfileVersion.String()
+	}
+	return detectionDecisionDTO{
+		SchemaVersion:          schemaVersionV1.String(),
+		Outcome:                decision.outcome,
+		Reason:                 decision.reason,
+		SelectedProfileID:      decision.selectedProfileID,
+		SelectedProfileVersion: selectedVersion,
+		Evidence:               evidence,
+	}
+}
+
+// MarshalDetectionDecision emits the canonical bounded durable decision form.
+func MarshalDetectionDecision(decision DetectionDecision) ([]byte, error) {
+	limits := DefaultDetectionLimits()
+	if decision.maxDecisionBytes > 0 {
+		limits.MaxDecisionBytes = decision.maxDecisionBytes
+	}
+	if err := validateDetectionDecision(decision, limits); err != nil {
+		return nil, err
+	}
+	encoded, err := marshalBounded(detectionDecisionToDTO(decision))
+	if err != nil {
+		return nil, err
+	}
+	if len(encoded) > limits.MaxDecisionBytes {
+		return nil, fmt.Errorf("detection decision exceeds the configured byte bound")
+	}
+	return encoded, nil
+}
+
+func detectionEvidenceFromDTO(
+	record detectionCandidateEvidenceDTO,
+) (DetectionCandidateEvidence, error) {
+	profileVersion, err := parseRequiredVersion("profile_version", record.ProfileVersion)
+	if err != nil {
+		return DetectionCandidateEvidence{}, err
+	}
+	detectorVersion, err := parseRequiredVersion("detector_version", record.DetectorVersion)
+	if err != nil {
+		return DetectionCandidateEvidence{}, err
+	}
+	qualificationVersion, err := parseRequiredVersion(
+		"qualification_version",
+		record.QualificationVersion,
+	)
+	if err != nil {
+		return DetectionCandidateEvidence{}, err
+	}
+	return DetectionCandidateEvidence{
+		ProfileID:            record.ProfileID,
+		ProfileVersion:       profileVersion,
+		Score:                record.Score,
+		Reason:               record.Reason,
+		MatchedGates:         append([]ProbeIdentityField(nil), record.MatchedGates...),
+		ProbeEvidenceIDs:     append([]string(nil), record.ProbeEvidenceIDs...),
+		DetectorVersion:      detectorVersion,
+		QualificationVersion: qualificationVersion,
+	}, nil
+}
+
+// UnmarshalDetectionDecision strictly reconstructs one canonical bounded
+// decision. Unknown, missing, duplicate, and case-folded keys are rejected.
+func UnmarshalDetectionDecision(data []byte) (DetectionDecision, error) {
+	var record detectionDecisionDTO
+	if err := decodeStrict(data, &record); err != nil {
+		return DetectionDecision{}, err
+	}
+	schemaVersion, err := parseRequiredVersion("schema_version", record.SchemaVersion)
+	if err != nil || schemaVersion != schemaVersionV1 {
+		return DetectionDecision{}, fmt.Errorf("detection decision schema is incompatible")
+	}
+	selectedVersion := Version{}
+	if record.SelectedProfileVersion != "" {
+		selectedVersion, err = parseRequiredVersion(
+			"selected_profile_version",
+			record.SelectedProfileVersion,
+		)
+		if err != nil {
+			return DetectionDecision{}, err
+		}
+	}
+	evidence := make([]DetectionCandidateEvidence, len(record.Evidence))
+	for index, item := range record.Evidence {
+		evidence[index], err = detectionEvidenceFromDTO(item)
+		if err != nil {
+			return DetectionDecision{}, err
+		}
+	}
+	if !sort.SliceIsSorted(evidence, func(first, second int) bool {
+		if evidence[first].ProfileID != evidence[second].ProfileID {
+			return evidence[first].ProfileID < evidence[second].ProfileID
+		}
+		return compareVersion(
+			evidence[first].ProfileVersion,
+			evidence[second].ProfileVersion,
+		) < 0
+	}) {
+		return DetectionDecision{}, fmt.Errorf("detection evidence is not canonical")
+	}
+	decision := DetectionDecision{
+		outcome:                record.Outcome,
+		reason:                 record.Reason,
+		selectedProfileID:      record.SelectedProfileID,
+		selectedProfileVersion: selectedVersion,
+		evidence:               evidence,
+		maxDecisionBytes:       MaxSerializedContractBytes,
+	}
+	if err := validateDetectionDecision(decision, DefaultDetectionLimits()); err != nil {
+		return DetectionDecision{}, err
+	}
+	reencoded, err := MarshalDetectionDecision(decision)
+	if err != nil {
+		return DetectionDecision{}, err
+	}
+	if len(reencoded) > MaxSerializedContractBytes {
+		return DetectionDecision{}, fmt.Errorf("detection decision exceeds the byte bound")
+	}
+	return decision, nil
+}

--- a/detector_concurrency_test.go
+++ b/detector_concurrency_test.go
@@ -127,6 +127,48 @@ func TestDetectionCancellationStopsTheBoundedPlan(t *testing.T) {
 	}
 }
 
+type cancelAfterSuccessfulRead struct {
+	cancel  context.CancelFunc
+	results map[string]reg.ProbeReadResult
+	reads   int
+}
+
+func (reader *cancelAfterSuccessfulRead) ReadProbe(
+	_ context.Context,
+	request reg.ProbeReadRequest,
+) (reg.ProbeReadResult, error) {
+	reader.reads++
+	if reader.reads == 3 {
+		reader.cancel()
+	}
+	return reader.results[request.DeclarationID()], nil
+}
+
+func TestDetectionCancellationAfterSuccessfulReadStillFailsClosed(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.cancel-after-read",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, _ := reg.NewCatalog(profile)
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, false))
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := &cancelAfterSuccessfulRead{
+		cancel:  cancel,
+		results: detectionReader(t).results,
+	}
+	decision, err := detector.Detect(ctx, reader, reg.DetectionOptions{})
+	if !errors.Is(err, context.Canceled) ||
+		decision.Outcome() != reg.DetectionNoMatch ||
+		decision.Reason() != reg.DetectionReasonContextCancelled ||
+		reader.reads != 3 {
+		t.Fatalf("cancel-after-read detection=(%+v,%v), reads=%d", decision, err, reader.reads)
+	}
+}
+
 type orderedBlockingReader struct {
 	mu      sync.Mutex
 	results map[string]reg.ProbeReadResult

--- a/detector_concurrency_test.go
+++ b/detector_concurrency_test.go
@@ -1,0 +1,197 @@
+package modbusreg_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func TestConcurrentDetectionsAreDeterministicAndIndependent(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.concurrent",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, err := reg.NewCatalog(profile)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, false))
+	reader := detectionReader(t)
+	const workers = 32
+	start := make(chan struct{})
+	results := make(chan []byte, workers)
+	errorsFound := make(chan error, workers)
+	var wait sync.WaitGroup
+	wait.Add(workers)
+	for index := 0; index < workers; index++ {
+		go func() {
+			defer wait.Done()
+			<-start
+			decision, detectErr := detector.Detect(
+				context.Background(),
+				reader,
+				reg.DetectionOptions{},
+			)
+			if detectErr != nil {
+				errorsFound <- detectErr
+				return
+			}
+			encoded, marshalErr := reg.MarshalDetectionDecision(decision)
+			if marshalErr != nil {
+				errorsFound <- marshalErr
+				return
+			}
+			results <- encoded
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errorsFound)
+	for err := range errorsFound {
+		t.Fatalf("concurrent detection: %v", err)
+	}
+	var canonical []byte
+	count := 0
+	for encoded := range results {
+		count++
+		if canonical == nil {
+			canonical = encoded
+			continue
+		}
+		if !reflect.DeepEqual(encoded, canonical) {
+			t.Fatal("concurrent detection produced non-deterministic evidence")
+		}
+	}
+	if count != workers {
+		t.Fatalf("decisions=%d want %d", count, workers)
+	}
+	if reads := reader.declarationOrder(); len(reads) != workers*3 {
+		t.Fatalf("reads=%d want %d", len(reads), workers*3)
+	}
+}
+
+type cancellingProbeReader struct {
+	mu    sync.Mutex
+	reads int
+}
+
+func (reader *cancellingProbeReader) ReadProbe(
+	ctx context.Context,
+	_ reg.ProbeReadRequest,
+) (reg.ProbeReadResult, error) {
+	reader.mu.Lock()
+	reader.reads++
+	reader.mu.Unlock()
+	<-ctx.Done()
+	return reg.ProbeReadResult{}, ctx.Err()
+}
+
+func (reader *cancellingProbeReader) readCount() int {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	return reader.reads
+}
+
+func TestDetectionCancellationStopsTheBoundedPlan(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.cancelled-detection",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, _ := reg.NewCatalog(profile)
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, false))
+	reader := &cancellingProbeReader{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	decision, err := detector.Detect(ctx, reader, reg.DetectionOptions{})
+	if !errors.Is(err, context.Canceled) ||
+		decision.Outcome() != reg.DetectionNoMatch ||
+		decision.Reason() != reg.DetectionReasonContextCancelled ||
+		decision.SelectedProfileID() != "" {
+		t.Fatalf("cancelled detection=(%+v,%v)", decision, err)
+	}
+	if reads := reader.readCount(); reads > 1 {
+		t.Fatalf("cancelled detection continued for %d reads", reads)
+	}
+}
+
+type orderedBlockingReader struct {
+	mu      sync.Mutex
+	results map[string]reg.ProbeReadResult
+	entered chan string
+	release chan struct{}
+	reads   []string
+}
+
+func (reader *orderedBlockingReader) ReadProbe(
+	ctx context.Context,
+	request reg.ProbeReadRequest,
+) (reg.ProbeReadResult, error) {
+	reader.mu.Lock()
+	reader.reads = append(reader.reads, request.DeclarationID())
+	result := reader.results[request.DeclarationID()]
+	reader.mu.Unlock()
+	select {
+	case reader.entered <- request.DeclarationID():
+	case <-ctx.Done():
+		return reg.ProbeReadResult{}, ctx.Err()
+	}
+	select {
+	case <-reader.release:
+		return result, nil
+	case <-ctx.Done():
+		return reg.ProbeReadResult{}, ctx.Err()
+	}
+}
+
+func TestOneDetectionNeverExecutesProbeDeclarationsConcurrently(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.ordered-probes",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, _ := reg.NewCatalog(profile)
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, false))
+	base := detectionReader(t)
+	reader := &orderedBlockingReader{
+		results: base.results,
+		entered: make(chan string),
+		release: make(chan struct{}),
+	}
+	done := make(chan error, 1)
+	go func() {
+		decision, err := detector.Detect(context.Background(), reader, reg.DetectionOptions{})
+		if err == nil && decision.Outcome() != reg.DetectionMatched {
+			err = errors.New("detection did not match")
+		}
+		done <- err
+	}()
+	for _, want := range []string{
+		"manufacturer-identity",
+		"model-identity",
+		"firmware-identity",
+	} {
+		if got := <-reader.entered; got != want {
+			t.Fatalf("probe order=%q want %q", got, want)
+		}
+		reader.release <- struct{}{}
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+}

--- a/detector_contract_test.go
+++ b/detector_contract_test.go
@@ -339,6 +339,62 @@ func TestDetectorUsesStrictIdentityAndSemanticFirmwareGates(t *testing.T) {
 	}
 }
 
+func TestDetectorFirmwareComparisonDoesNotUseMachineIntegers(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.large-firmware",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, _ := reg.NewCatalog(profile)
+	minimum := strings.Repeat("8", 120) + ".0.0"
+	actual := strings.Repeat("9", 120) + ".0.0"
+	maximum := "1" + strings.Repeat("0", 120) + ".0.0"
+	candidate, err := reg.NewDetectionCandidate(reg.DetectionCandidateSpec{
+		ProfileID:      profile.ID(),
+		ProfileVersion: profile.Version(),
+		Score:          1,
+		Enabled:        true,
+		Manufacturer:   reg.IdentityStringGateSpec{Expected: "manufacturer-alpha"},
+		Model:          reg.IdentityStringGateSpec{Expected: "model-series-a"},
+		Firmware: reg.FirmwareGateSpec{
+			MinimumInclusive: version(t, minimum),
+			MaximumExclusive: version(t, maximum),
+		},
+	}, detectionLimits())
+	if err != nil {
+		t.Fatalf("NewDetectionCandidate: %v", err)
+	}
+	planSpec := detectionPlan(t).Spec()
+	planSpec.Declarations[2].WordCount = uint16(len(detectionWords(actual)))
+	plan, err := reg.NewProbePlan(planSpec, detectionLimits())
+	if err != nil {
+		t.Fatalf("NewProbePlan: %v", err)
+	}
+	detector, err := reg.NewProfileDetector(reg.ProfileDetectorSpec{
+		DetectorVersion: version(t, "1.0.0"),
+		Plan:            plan,
+		Catalog:         catalog,
+		Candidates:      []reg.DetectionCandidate{candidate},
+		Limits:          detectionLimits(),
+	})
+	if err != nil {
+		t.Fatalf("NewProfileDetector: %v", err)
+	}
+	reader := detectionReader(t)
+	reader.results["firmware-identity"] = mustProbeResult(
+		t,
+		actual,
+		"probe-evidence-large-firmware",
+	)
+	decision, err := detector.Detect(context.Background(), reader, reg.DetectionOptions{})
+	if err != nil || decision.Outcome() != reg.DetectionMatched {
+		t.Fatalf("large numeric firmware decision=(%+v,%v)", decision, err)
+	}
+}
+
 func TestDetectorRankingIsCatalogOrderIndependentAndTiesAreAmbiguous(t *testing.T) {
 	first := detectionProfile(t, "example.standard.alpha", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
 	second := detectionProfile(t, "example.standard.beta", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
@@ -373,6 +429,19 @@ func TestDetectorRankingIsCatalogOrderIndependentAndTiesAreAmbiguous(t *testing.
 	evidence := decision.Evidence()
 	if len(evidence) != 2 || evidence[0].ProfileID != first.ID() || evidence[1].ProfileID != second.ID() {
 		t.Fatalf("ambiguity evidence is not identity-sorted: %+v", evidence)
+	}
+	encoded, err := reg.MarshalDetectionDecision(decision)
+	if err != nil {
+		t.Fatalf("MarshalDetectionDecision: %v", err)
+	}
+	var contradictory map[string]any
+	if err := json.Unmarshal(encoded, &contradictory); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	contradictory["evidence"].([]any)[1].(map[string]any)["detector_version"] = "2.0.0"
+	malformed, _ := json.Marshal(contradictory)
+	if _, err := reg.UnmarshalDetectionDecision(malformed); err == nil {
+		t.Fatal("contradictory detector contract versions were accepted")
 	}
 }
 
@@ -681,9 +750,91 @@ func TestDetectionBoundsAndImmutableSerializableEvidence(t *testing.T) {
 	if _, err := reg.UnmarshalDetectionDecision(unknown); err == nil {
 		t.Fatal("unknown decision field was accepted")
 	}
+	missingObject := make(map[string]any)
+	if err := json.Unmarshal(encoded, &missingObject); err != nil {
+		t.Fatalf("json.Unmarshal(missing fixture): %v", err)
+	}
+	delete(missingObject, "reason")
+	missing, _ := json.Marshal(missingObject)
+	if _, err := reg.UnmarshalDetectionDecision(missing); err == nil {
+		t.Fatal("decision with a missing field was accepted")
+	}
+	caseFolded := strings.Replace(
+		string(encoded),
+		`"outcome"`,
+		`"Outcome"`,
+		1,
+	)
+	if _, err := reg.UnmarshalDetectionDecision([]byte(caseFolded)); err == nil {
+		t.Fatal("case-folded decision field was accepted")
+	}
+	duplicate := strings.Replace(
+		string(encoded),
+		`"outcome":"matched"`,
+		`"outcome":"matched","outcome":"matched"`,
+		1,
+	)
+	if _, err := reg.UnmarshalDetectionDecision([]byte(duplicate)); err == nil {
+		t.Fatal("duplicate decision field was accepted")
+	}
+	impossibleObject := make(map[string]any)
+	if err := json.Unmarshal(encoded, &impossibleObject); err != nil {
+		t.Fatalf("json.Unmarshal(impossible fixture): %v", err)
+	}
+	impossibleEvidence := impossibleObject["evidence"].([]any)[0].(map[string]any)
+	impossibleEvidence["matched_gates"] = []any{}
+	impossibleEvidence["probe_evidence_ids"] = []any{}
+	impossible, _ := json.Marshal(impossibleObject)
+	if _, err := reg.UnmarshalDetectionDecision(impossible); err == nil {
+		t.Fatal("selected evidence without matched gates was accepted")
+	}
 	if _, err := reg.UnmarshalDetectionDecision(
 		[]byte(strings.Repeat("x", reg.MaxSerializedContractBytes+1)),
 	); err == nil {
 		t.Fatal("oversized decision was accepted")
+	}
+}
+
+func TestDetectorRejectsDuplicateAndInexactCatalogBindingsBeforeReads(t *testing.T) {
+	profile := detectionProfile(t, "example.standard.bound", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	catalog, _ := reg.NewCatalog(profile)
+	candidate := detectionCandidate(t, profile, 1, true, false)
+	base := reg.ProfileDetectorSpec{
+		DetectorVersion: version(t, "1.0.0"),
+		Plan:            detectionPlan(t),
+		Catalog:         catalog,
+		Candidates:      []reg.DetectionCandidate{candidate, candidate},
+		Limits:          detectionLimits(),
+	}
+	if _, err := reg.NewProfileDetector(base); err == nil {
+		t.Fatal("duplicate candidate profile binding was accepted")
+	}
+
+	otherProfile := detectionProfile(t, "example.standard.bound", "2.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	inexact := detectionCandidate(t, otherProfile, 1, true, false)
+	base.Candidates = []reg.DetectionCandidate{inexact}
+	if _, err := reg.NewProfileDetector(base); err == nil {
+		t.Fatal("candidate with an inexact catalog version was accepted")
+	}
+
+	wrongContractSpec := profile.Spec()
+	wrongContractSpec.ID = "example.standard.wrong-contract"
+	wrongContractSpec.DetectorVersion = version(t, "2.0.0")
+	wrongContract, err := reg.NewProfileDescriptor(wrongContractSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(wrong contract): %v", err)
+	}
+	wrongCatalog, _ := reg.NewCatalog(wrongContract)
+	base.Catalog = wrongCatalog
+	base.Candidates = []reg.DetectionCandidate{detectionCandidate(t, wrongContract, 1, true, false)}
+	if _, err := reg.NewProfileDetector(base); err == nil {
+		t.Fatal("profile with an inexact detector contract was accepted")
+	}
+
+	base.Catalog = catalog
+	base.Candidates = []reg.DetectionCandidate{candidate}
+	base.Limits.MaxDecisionBytes = 100
+	if _, err := reg.NewProfileDetector(base); err == nil {
+		t.Fatal("detector with an infeasible decision bound was accepted")
 	}
 }

--- a/detector_contract_test.go
+++ b/detector_contract_test.go
@@ -1,0 +1,689 @@
+package modbusreg_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+type recordedProbeReader struct {
+	mu      sync.Mutex
+	results map[string]reg.ProbeReadResult
+	errors  map[string]error
+	reads   []reg.ProbeReadRequest
+}
+
+func (reader *recordedProbeReader) ReadProbe(
+	_ context.Context,
+	request reg.ProbeReadRequest,
+) (reg.ProbeReadResult, error) {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	reader.reads = append(reader.reads, request)
+	if err := reader.errors[request.DeclarationID()]; err != nil {
+		return reg.ProbeReadResult{}, err
+	}
+	return reader.results[request.DeclarationID()], nil
+}
+
+func (reader *recordedProbeReader) declarationOrder() []string {
+	reader.mu.Lock()
+	defer reader.mu.Unlock()
+	result := make([]string, len(reader.reads))
+	for index, request := range reader.reads {
+		result[index] = request.DeclarationID()
+	}
+	return result
+}
+
+func detectionWords(value string) []uint16 {
+	encoded := []byte(value)
+	if len(encoded)%2 != 0 {
+		encoded = append(encoded, 0)
+	}
+	words := make([]uint16, len(encoded)/2)
+	for index := range words {
+		words[index] = uint16(encoded[index*2])<<8 | uint16(encoded[index*2+1])
+	}
+	for len(words) < 16 {
+		words = append(words, 0)
+	}
+	return words
+}
+
+func mustProbeResult(
+	t *testing.T,
+	value string,
+	evidenceID string,
+) reg.ProbeReadResult {
+	t.Helper()
+	result, err := reg.NewProbeReadResult(reg.ProbeReadResultSpec{
+		Status:     reg.ProbeReadSucceeded,
+		Words:      detectionWords(value),
+		EvidenceID: evidenceID,
+	})
+	if err != nil {
+		t.Fatalf("NewProbeReadResult: %v", err)
+	}
+	return result
+}
+
+func detectionLimits() reg.DetectionLimits {
+	return reg.DefaultDetectionLimits()
+}
+
+func detectionPlan(t *testing.T) reg.ProbePlan {
+	t.Helper()
+	plan, err := reg.NewProbePlan(reg.ProbePlanSpec{
+		Version: version(t, "1.0.0"),
+		Declarations: []reg.ProbeDeclarationSpec{
+			{
+				ID:            "manufacturer-identity",
+				Function:      reg.ProbeReadHoldingRegisters,
+				Address:       100,
+				WordCount:     16,
+				IdentityField: reg.ProbeIdentityManufacturer,
+				Encoding:      reg.ProbeIdentityASCII,
+			},
+			{
+				ID:            "model-identity",
+				Function:      reg.ProbeReadInputRegisters,
+				Address:       140,
+				WordCount:     16,
+				IdentityField: reg.ProbeIdentityModel,
+				Encoding:      reg.ProbeIdentityASCII,
+			},
+			{
+				ID:            "firmware-identity",
+				Function:      reg.ProbeReadHoldingRegisters,
+				Address:       180,
+				WordCount:     16,
+				IdentityField: reg.ProbeIdentityFirmware,
+				Encoding:      reg.ProbeIdentityASCII,
+			},
+		},
+	}, detectionLimits())
+	if err != nil {
+		t.Fatalf("NewProbePlan: %v", err)
+	}
+	return plan
+}
+
+func detectionProfile(
+	t *testing.T,
+	id string,
+	profileVersion string,
+	maturity reg.ProfileMaturity,
+	state reg.ProfileState,
+	defaultEnabled bool,
+) reg.ProfileDescriptor {
+	t.Helper()
+	spec := profileFixture(t).Spec()
+	spec.ID = id
+	spec.Version = version(t, profileVersion)
+	spec.Maturity = maturity
+	spec.State = state
+	spec.DefaultEnabled = defaultEnabled
+	spec.SupersededByID = ""
+	spec.SupersededByVersion = reg.Version{}
+	profile, err := reg.NewProfileDescriptor(spec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(%s): %v", id, err)
+	}
+	return profile
+}
+
+func detectionCandidate(
+	t *testing.T,
+	profile reg.ProfileDescriptor,
+	score uint32,
+	enabled bool,
+	fixtureOnly bool,
+) reg.DetectionCandidate {
+	t.Helper()
+	candidate, err := reg.NewDetectionCandidate(reg.DetectionCandidateSpec{
+		ProfileID:      profile.ID(),
+		ProfileVersion: profile.Version(),
+		Score:          score,
+		Enabled:        enabled,
+		FixtureOnly:    fixtureOnly,
+		Manufacturer: reg.IdentityStringGateSpec{
+			Expected: "manufacturer-alpha",
+		},
+		Model: reg.IdentityStringGateSpec{
+			Expected: "model-series-a",
+		},
+		Firmware: reg.FirmwareGateSpec{
+			MinimumInclusive: version(t, "1.9.0"),
+			MaximumExclusive: version(t, "2.0.0"),
+		},
+	}, detectionLimits())
+	if err != nil {
+		t.Fatalf("NewDetectionCandidate(%s): %v", profile.ID(), err)
+	}
+	return candidate
+}
+
+func detectionReader(t *testing.T) *recordedProbeReader {
+	t.Helper()
+	return &recordedProbeReader{
+		results: map[string]reg.ProbeReadResult{
+			"manufacturer-identity": mustProbeResult(
+				t,
+				"manufacturer-alpha",
+				"probe-evidence-manufacturer",
+			),
+			"model-identity": mustProbeResult(
+				t,
+				"model-series-a",
+				"probe-evidence-model",
+			),
+			"firmware-identity": mustProbeResult(
+				t,
+				"1.10.0",
+				"probe-evidence-firmware",
+			),
+		},
+		errors: make(map[string]error),
+	}
+}
+
+func newDetector(
+	t *testing.T,
+	catalog reg.Catalog,
+	candidates ...reg.DetectionCandidate,
+) *reg.ProfileDetector {
+	t.Helper()
+	detector, err := reg.NewProfileDetector(reg.ProfileDetectorSpec{
+		DetectorVersion: version(t, "1.0.0"),
+		Plan:            detectionPlan(t),
+		Catalog:         catalog,
+		Candidates:      candidates,
+		Limits:          detectionLimits(),
+	})
+	if err != nil {
+		t.Fatalf("NewProfileDetector: %v", err)
+	}
+	return detector
+}
+
+func TestProbeContractIsReadOnlyBoundedAndTransportNeutral(t *testing.T) {
+	plan := detectionPlan(t)
+	declarations := plan.Declarations()
+	if len(declarations) != 3 ||
+		declarations[0].Function != reg.ProbeReadHoldingRegisters ||
+		declarations[1].Function != reg.ProbeReadInputRegisters {
+		t.Fatalf("probe declarations=%+v", declarations)
+	}
+	declarations[0].ID = "mutated"
+	if plan.Declarations()[0].ID != "manufacturer-identity" {
+		t.Fatal("probe plan declarations are mutable through an accessor")
+	}
+
+	readerType := reflect.TypeOf((*reg.ProbeReader)(nil)).Elem()
+	if readerType.NumMethod() != 1 || readerType.Method(0).Name != "ReadProbe" {
+		t.Fatalf("probe reader surface=%v", readerType)
+	}
+	requestType := reflect.TypeOf(reg.ProbeReadRequest{})
+	for index := 0; index < requestType.NumField(); index++ {
+		name := strings.ToLower(requestType.Field(index).Name)
+		for _, forbidden := range []string{"endpoint", "transport", "write", "socket", "serial"} {
+			if strings.Contains(name, forbidden) {
+				t.Fatalf("probe request exposes forbidden field %q", name)
+			}
+		}
+	}
+
+	invalidFunctions := []reg.ProbeFunction{"", reg.ProbeFunction("fc06"), reg.ProbeFunction("write")}
+	for _, function := range invalidFunctions {
+		_, err := reg.NewProbePlan(reg.ProbePlanSpec{
+			Version: version(t, "1.0.0"),
+			Declarations: []reg.ProbeDeclarationSpec{{
+				ID:            "invalid-function",
+				Function:      function,
+				Address:       1,
+				WordCount:     1,
+				IdentityField: reg.ProbeIdentityManufacturer,
+				Encoding:      reg.ProbeIdentityASCII,
+			}},
+		}, detectionLimits())
+		if err == nil {
+			t.Fatalf("probe function %q was accepted", function)
+		}
+	}
+}
+
+func TestDetectorExecutesDeclarationsOnceInDeclaredOrder(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.detectable",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, err := reg.NewCatalog(profile)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 100, true, false))
+	reader := detectionReader(t)
+	decision, err := detector.Detect(context.Background(), reader, reg.DetectionOptions{})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if decision.Outcome() != reg.DetectionMatched ||
+		decision.SelectedProfileID() != profile.ID() ||
+		decision.SelectedProfileVersion() != profile.Version() {
+		t.Fatalf("decision=%+v", decision)
+	}
+	wantOrder := []string{
+		"manufacturer-identity",
+		"model-identity",
+		"firmware-identity",
+	}
+	if got := reader.declarationOrder(); !reflect.DeepEqual(got, wantOrder) {
+		t.Fatalf("read order=%v want %v", got, wantOrder)
+	}
+}
+
+func TestDetectorUsesStrictIdentityAndSemanticFirmwareGates(t *testing.T) {
+	profile := detectionProfile(
+		t,
+		"example.standard.semantic-version",
+		"1.0.0",
+		reg.MaturityQualified,
+		reg.ProfileActive,
+		true,
+	)
+	catalog, _ := reg.NewCatalog(profile)
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, false))
+
+	tests := []struct {
+		name       string
+		field      string
+		value      string
+		wantReason reg.DetectionReason
+	}{
+		{name: "semantic 1.10 exceeds 1.9", field: "firmware-identity", value: "1.10.0"},
+		{name: "manufacturer case differs", field: "manufacturer-identity", value: "Manufacturer-Alpha", wantReason: reg.DetectionReasonIdentityMismatch},
+		{name: "model suffix differs", field: "model-identity", value: "model-series-a-plus", wantReason: reg.DetectionReasonIdentityMismatch},
+		{name: "firmware below range", field: "firmware-identity", value: "1.8.99", wantReason: reg.DetectionReasonFirmwareMismatch},
+		{name: "firmware upper bound excluded", field: "firmware-identity", value: "2.0.0", wantReason: reg.DetectionReasonFirmwareMismatch},
+		{name: "firmware is not semantic", field: "firmware-identity", value: "release-1.10", wantReason: reg.DetectionReasonInvalidIdentity},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := detectionReader(t)
+			reader.results[test.field] = mustProbeResult(t, test.value, "probe-evidence-case")
+			decision, err := detector.Detect(context.Background(), reader, reg.DetectionOptions{})
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			if test.wantReason == "" {
+				if decision.Outcome() != reg.DetectionMatched {
+					t.Fatalf("semantic firmware was not matched: %+v", decision)
+				}
+				return
+			}
+			if decision.Outcome() != reg.DetectionNoMatch || decision.Reason() != test.wantReason {
+				t.Fatalf("decision=(%q,%q)", decision.Outcome(), decision.Reason())
+			}
+		})
+	}
+}
+
+func TestDetectorRankingIsCatalogOrderIndependentAndTiesAreAmbiguous(t *testing.T) {
+	first := detectionProfile(t, "example.standard.alpha", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	second := detectionProfile(t, "example.standard.beta", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	firstCandidate := detectionCandidate(t, first, 20, true, false)
+	secondCandidate := detectionCandidate(t, second, 10, true, false)
+
+	for _, profiles := range [][]reg.ProfileDescriptor{{first, second}, {second, first}} {
+		catalog, err := reg.NewCatalog(profiles...)
+		if err != nil {
+			t.Fatalf("NewCatalog: %v", err)
+		}
+		detector := newDetector(t, catalog, secondCandidate, firstCandidate)
+		decision, err := detector.Detect(context.Background(), detectionReader(t), reg.DetectionOptions{})
+		if err != nil || decision.Outcome() != reg.DetectionMatched ||
+			decision.SelectedProfileID() != first.ID() {
+			t.Fatalf("permuted selection=(%+v,%v)", decision, err)
+		}
+	}
+
+	tied := detectionCandidate(t, second, 20, true, false)
+	catalog, _ := reg.NewCatalog(first, second)
+	decision, err := newDetector(t, catalog, firstCandidate, tied).Detect(
+		context.Background(),
+		detectionReader(t),
+		reg.DetectionOptions{},
+	)
+	if err != nil || decision.Outcome() != reg.DetectionAmbiguous ||
+		decision.Reason() != reg.DetectionReasonEqualBest ||
+		decision.SelectedProfileID() != "" {
+		t.Fatalf("equal-best decision=(%+v,%v)", decision, err)
+	}
+	evidence := decision.Evidence()
+	if len(evidence) != 2 || evidence[0].ProfileID != first.ID() || evidence[1].ProfileID != second.ID() {
+		t.Fatalf("ambiguity evidence is not identity-sorted: %+v", evidence)
+	}
+}
+
+func TestDetectorExplicitNoMatchAndFixtureOptIn(t *testing.T) {
+	profile := detectionProfile(t, "example.standard.fixture-candidate", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	catalog, _ := reg.NewCatalog(profile)
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, true))
+
+	decision, err := detector.Detect(context.Background(), detectionReader(t), reg.DetectionOptions{})
+	if err != nil || decision.Outcome() != reg.DetectionNoMatch ||
+		decision.Reason() != reg.DetectionReasonFixtureOptInRequired {
+		t.Fatalf("fixture default decision=(%+v,%v)", decision, err)
+	}
+	decision, err = detector.Detect(
+		context.Background(),
+		detectionReader(t),
+		reg.DetectionOptions{AllowFixtureOnly: true},
+	)
+	if err != nil || decision.Outcome() != reg.DetectionMatched {
+		t.Fatalf("fixture opt-in decision=(%+v,%v)", decision, err)
+	}
+
+	reader := detectionReader(t)
+	reader.results["model-identity"] = mustProbeResult(t, "unknown-model", "probe-evidence-no-match")
+	decision, err = detector.Detect(
+		context.Background(),
+		reader,
+		reg.DetectionOptions{AllowFixtureOnly: true},
+	)
+	if err != nil || decision.Outcome() != reg.DetectionNoMatch ||
+		decision.Reason() != reg.DetectionReasonIdentityMismatch {
+		t.Fatalf("explicit no-match=(%+v,%v)", decision, err)
+	}
+}
+
+func TestActiveSelectionRejectsIneligibleProfilesBeforeScoring(t *testing.T) {
+	eligible := detectionProfile(t, "example.standard.eligible", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	disabled := detectionProfile(t, "example.standard.disabled", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	defaultOff := detectionProfile(t, "example.standard.default-off", "1.0.0", reg.MaturityQualified, reg.ProfileActive, false)
+	unqualified := detectionProfile(t, "example.standard.unqualified", "1.0.0", reg.MaturityExperimental, reg.ProfileActive, false)
+	revoked := detectionProfile(t, "example.standard.revoked", "1.0.0", reg.MaturityQualified, reg.ProfileRevoked, false)
+	replacement := detectionProfile(t, "example.standard.replacement", "2.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	supersededSpec := detectionProfile(t, "example.standard.superseded", "1.0.0", reg.MaturityQualified, reg.ProfileActive, false).Spec()
+	supersededSpec.State = reg.ProfileSuperseded
+	supersededSpec.SupersededByID = replacement.ID()
+	supersededSpec.SupersededByVersion = replacement.Version()
+	superseded, err := reg.NewProfileDescriptor(supersededSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(superseded): %v", err)
+	}
+	catalog, err := reg.NewCatalog(
+		revoked,
+		defaultOff,
+		eligible,
+		unqualified,
+		disabled,
+		superseded,
+		replacement,
+	)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	detector := newDetector(t, catalog,
+		detectionCandidate(t, revoked, 100, true, false),
+		detectionCandidate(t, disabled, 100, false, false),
+		detectionCandidate(t, defaultOff, 100, true, false),
+		detectionCandidate(t, unqualified, 100, true, false),
+		detectionCandidate(t, superseded, 100, true, false),
+		detectionCandidate(t, eligible, 1, true, false),
+	)
+	decision, err := detector.Detect(context.Background(), detectionReader(t), reg.DetectionOptions{})
+	if err != nil || decision.Outcome() != reg.DetectionMatched ||
+		decision.SelectedProfileID() != eligible.ID() {
+		t.Fatalf("active selection=(%+v,%v)", decision, err)
+	}
+	reasons := make(map[string]reg.DetectionReason)
+	for _, evidence := range decision.Evidence() {
+		reasons[evidence.ProfileID] = evidence.Reason
+	}
+	want := map[string]reg.DetectionReason{
+		revoked.ID():     reg.DetectionReasonProfileRevoked,
+		disabled.ID():    reg.DetectionReasonCandidateDisabled,
+		defaultOff.ID():  reg.DetectionReasonProfileDefaultOff,
+		unqualified.ID(): reg.DetectionReasonProfileUnqualified,
+		superseded.ID():  reg.DetectionReasonProfileSuperseded,
+	}
+	for profileID, reason := range want {
+		if reasons[profileID] != reason {
+			t.Fatalf("reason[%s]=%q want %q", profileID, reasons[profileID], reason)
+		}
+	}
+}
+
+func TestDetectorFailsClosedOnProbeFailuresAndIdentityConflicts(t *testing.T) {
+	profile := detectionProfile(t, "example.standard.fail-closed", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	catalog, _ := reg.NewCatalog(profile)
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 10, true, false))
+	exception, err := reg.NewProbeReadResult(reg.ProbeReadResultSpec{
+		Status:        reg.ProbeReadException,
+		EvidenceID:    "probe-evidence-exception",
+		ExceptionCode: 2,
+	})
+	if err != nil {
+		t.Fatalf("NewProbeReadResult(exception): %v", err)
+	}
+	incomplete, err := reg.NewProbeReadResult(reg.ProbeReadResultSpec{
+		Status:     reg.ProbeReadSucceeded,
+		Words:      []uint16{1},
+		EvidenceID: "probe-evidence-incomplete",
+	})
+	if err != nil {
+		t.Fatalf("NewProbeReadResult(incomplete): %v", err)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*recordedProbeReader)
+		reason reg.DetectionReason
+	}{
+		{name: "reader error", mutate: func(reader *recordedProbeReader) {
+			reader.errors["manufacturer-identity"] = errors.New("forced read failure")
+		}, reason: reg.DetectionReasonReadError},
+		{name: "modbus exception", mutate: func(reader *recordedProbeReader) { reader.results["manufacturer-identity"] = exception }, reason: reg.DetectionReasonProbeException},
+		{name: "incomplete words", mutate: func(reader *recordedProbeReader) { reader.results["manufacturer-identity"] = incomplete }, reason: reg.DetectionReasonIncompleteProbe},
+		{name: "missing result", mutate: func(reader *recordedProbeReader) { delete(reader.results, "manufacturer-identity") }, reason: reg.DetectionReasonInvalidProbeResult},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reader := detectionReader(t)
+			test.mutate(reader)
+			decision, err := detector.Detect(context.Background(), reader, reg.DetectionOptions{})
+			if err != nil || decision.Outcome() != reg.DetectionNoMatch ||
+				decision.Reason() != test.reason || decision.SelectedProfileID() != "" {
+				t.Fatalf("fail-closed decision=(%+v,%v)", decision, err)
+			}
+		})
+	}
+
+	base := detectionPlan(t).Spec()
+	duplicateID := base
+	duplicateID.Declarations = append(
+		append([]reg.ProbeDeclarationSpec(nil), base.Declarations...),
+		base.Declarations[0],
+	)
+	if _, err := reg.NewProbePlan(duplicateID, detectionLimits()); err == nil {
+		t.Fatal("duplicate probe declaration was accepted")
+	}
+	contradictory := base
+	secondManufacturer := base.Declarations[1]
+	secondManufacturer.ID = "second-manufacturer"
+	secondManufacturer.IdentityField = reg.ProbeIdentityManufacturer
+	contradictory.Declarations = append(
+		append([]reg.ProbeDeclarationSpec(nil), base.Declarations...),
+		secondManufacturer,
+	)
+	if _, err := reg.NewProbePlan(contradictory, detectionLimits()); err == nil {
+		t.Fatal("contradictory identity producers were accepted")
+	}
+}
+
+func TestDetectionBoundsAndImmutableSerializableEvidence(t *testing.T) {
+	profile := detectionProfile(t, "example.standard.evidence", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	catalog, _ := reg.NewCatalog(profile)
+	limits := detectionLimits()
+	invalidLimits := []reg.DetectionLimits{
+		{},
+		func() reg.DetectionLimits { value := limits; value.MaxPlanDeclarations = 0; return value }(),
+		func() reg.DetectionLimits { value := limits; value.MaxReads = 0; return value }(),
+		func() reg.DetectionLimits { value := limits; value.MaxWordsPerRead = 0; return value }(),
+		func() reg.DetectionLimits { value := limits; value.MaxTotalWords = 0; return value }(),
+		func() reg.DetectionLimits { value := limits; value.MaxIdentityBytes = 0; return value }(),
+		func() reg.DetectionLimits { value := limits; value.MaxEvidenceIDBytes = 0; return value }(),
+		func() reg.DetectionLimits {
+			value := limits
+			value.MaxDecisionBytes = reg.MaxSerializedContractBytes + 1
+			return value
+		}(),
+	}
+	for index, invalid := range invalidLimits {
+		_, err := reg.NewProfileDetector(reg.ProfileDetectorSpec{
+			DetectorVersion: version(t, "1.0.0"),
+			Plan:            detectionPlan(t),
+			Catalog:         catalog,
+			Candidates:      []reg.DetectionCandidate{detectionCandidate(t, profile, 1, true, false)},
+			Limits:          invalid,
+		})
+		if err == nil {
+			t.Fatalf("invalid limits %d were accepted", index)
+		}
+	}
+
+	maximumWords, err := reg.NewProbeReadResult(reg.ProbeReadResultSpec{
+		Status:     reg.ProbeReadSucceeded,
+		Words:      make([]uint16, limits.MaxWordsPerRead),
+		EvidenceID: strings.Repeat("e", limits.MaxEvidenceIDBytes),
+	})
+	if err != nil || len(maximumWords.Words()) != limits.MaxWordsPerRead {
+		t.Fatalf("maximum probe result was rejected: %v", err)
+	}
+	if _, err := reg.NewProbeReadResult(reg.ProbeReadResultSpec{
+		Status:     reg.ProbeReadSucceeded,
+		Words:      make([]uint16, limits.MaxWordsPerRead+1),
+		EvidenceID: "probe-evidence-oversized-words",
+	}); err == nil {
+		t.Fatal("oversized probe words were accepted")
+	}
+	if _, err := reg.NewProbeReadResult(reg.ProbeReadResultSpec{
+		Status:     reg.ProbeReadSucceeded,
+		Words:      []uint16{1},
+		EvidenceID: strings.Repeat("e", limits.MaxEvidenceIDBytes+1),
+	}); err == nil {
+		t.Fatal("oversized probe evidence ID was accepted")
+	}
+
+	basePlan := detectionPlan(t)
+	for name, constrained := range map[string]reg.DetectionLimits{
+		"plan declarations": func() reg.DetectionLimits {
+			value := limits
+			value.MaxPlanDeclarations = len(basePlan.Declarations()) - 1
+			return value
+		}(),
+		"executed reads": func() reg.DetectionLimits {
+			value := limits
+			value.MaxReads = len(basePlan.Declarations()) - 1
+			return value
+		}(),
+		"aggregate words": func() reg.DetectionLimits {
+			value := limits
+			value.MaxTotalWords = 16
+			return value
+		}(),
+	} {
+		_, err := reg.NewProfileDetector(reg.ProfileDetectorSpec{
+			DetectorVersion: version(t, "1.0.0"),
+			Plan:            basePlan,
+			Catalog:         catalog,
+			Candidates:      []reg.DetectionCandidate{detectionCandidate(t, profile, 1, true, false)},
+			Limits:          constrained,
+		})
+		if err == nil {
+			t.Fatalf("%s bound was not enforced", name)
+		}
+	}
+	if _, err := reg.NewDetectionCandidate(reg.DetectionCandidateSpec{
+		ProfileID:      profile.ID(),
+		ProfileVersion: profile.Version(),
+		Score:          1,
+		Enabled:        true,
+		Manufacturer: reg.IdentityStringGateSpec{
+			Expected: strings.Repeat("i", limits.MaxIdentityBytes+1),
+		},
+		Model: reg.IdentityStringGateSpec{Expected: "model-series-a"},
+		Firmware: reg.FirmwareGateSpec{
+			MinimumInclusive: version(t, "1.0.0"),
+			MaximumExclusive: version(t, "2.0.0"),
+		},
+	}, limits); err == nil {
+		t.Fatal("oversized identity gate was accepted")
+	}
+
+	detector := newDetector(t, catalog, detectionCandidate(t, profile, 1, true, false))
+	decision, err := detector.Detect(context.Background(), detectionReader(t), reg.DetectionOptions{})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	evidence := decision.Evidence()
+	if len(evidence) != 1 ||
+		evidence[0].ProfileID != profile.ID() ||
+		evidence[0].ProfileVersion != profile.Version() ||
+		evidence[0].Reason != reg.DetectionReasonSelected ||
+		evidence[0].DetectorVersion != profile.DetectorVersion() ||
+		evidence[0].QualificationVersion != profile.QualificationVersion() ||
+		!reflect.DeepEqual(evidence[0].MatchedGates, []reg.ProbeIdentityField{
+			reg.ProbeIdentityManufacturer,
+			reg.ProbeIdentityModel,
+			reg.ProbeIdentityFirmware,
+		}) || len(evidence[0].ProbeEvidenceIDs) != 3 {
+		t.Fatalf("decision evidence=%+v", evidence)
+	}
+	evidence[0].ProfileID = "mutated"
+	evidence[0].MatchedGates[0] = "mutated"
+	evidence[0].ProbeEvidenceIDs[0] = "mutated"
+	if fresh := decision.Evidence(); fresh[0].ProfileID != profile.ID() ||
+		fresh[0].MatchedGates[0] != reg.ProbeIdentityManufacturer ||
+		fresh[0].ProbeEvidenceIDs[0] != "probe-evidence-manufacturer" {
+		t.Fatal("decision evidence is mutable through an accessor")
+	}
+
+	encoded, err := reg.MarshalDetectionDecision(decision)
+	if err != nil || len(encoded) > limits.MaxDecisionBytes {
+		t.Fatalf("MarshalDetectionDecision=(%d,%v)", len(encoded), err)
+	}
+	restored, err := reg.UnmarshalDetectionDecision(encoded)
+	if err != nil {
+		t.Fatalf("UnmarshalDetectionDecision: %v", err)
+	}
+	reencoded, err := reg.MarshalDetectionDecision(restored)
+	if err != nil || !reflect.DeepEqual(reencoded, encoded) {
+		t.Fatalf("decision round trip changed: %v", err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(encoded, &object); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	object["unknown"] = true
+	unknown, _ := json.Marshal(object)
+	if _, err := reg.UnmarshalDetectionDecision(unknown); err == nil {
+		t.Fatal("unknown decision field was accepted")
+	}
+	if _, err := reg.UnmarshalDetectionDecision(
+		[]byte(strings.Repeat("x", reg.MaxSerializedContractBytes+1)),
+	); err == nil {
+		t.Fatal("oversized decision was accepted")
+	}
+}

--- a/docs/m2-02-detection.md
+++ b/docs/m2-02-detection.md
@@ -1,0 +1,80 @@
+# M2-02 Deterministic Profile Detection
+
+Status: RED-phase contract skeleton. The API and behavior described here are
+acceptance targets exercised by compile-failing tests. No detector is
+implemented yet.
+
+## Boundary
+
+M2-02 owns bounded, deterministic, read-only profile detection over the
+existing immutable `Catalog`. It does not own a transport endpoint, Modbus
+framing, writes, device qualification execution, vendor facts, profile corpus,
+gateway composition, or publication.
+
+The caller supplies the only runtime dependency:
+
+```go
+type ProbeReader interface {
+    ReadProbe(context.Context, ProbeReadRequest) (ProbeReadResult, error)
+}
+```
+
+`ProbeReadRequest` can represent only FC03 or FC04, a declaration identity,
+an address, and a positive bounded word count. It cannot represent an endpoint,
+connection, write operation, retry policy, or framing choice. Declarations run
+once, serially, and in immutable plan order.
+
+## Proposed Contract
+
+The RED tests target these constructor-owned values:
+
+- `ProbePlan` from `ProbePlanSpec` and ordered `ProbeDeclarationSpec` values;
+- `ProbeReadResult` from `ProbeReadResultSpec`;
+- `DetectionCandidate` from `DetectionCandidateSpec`;
+- `ProfileDetector` from `ProfileDetectorSpec`; and
+- `DetectionDecision` with bounded strict JSON marshal and unmarshal helpers.
+
+Probe declarations associate bounded ASCII register words with exactly one of
+manufacturer, model, or firmware identity. Duplicate declaration identities,
+duplicate identity producers, unsupported functions, empty reads, and values
+outside configured limits are invalid.
+
+Each candidate binds one exact catalog profile ID and version to exact
+manufacturer/model gates, a semantic firmware range, a finite score, explicit
+runtime enablement, and an optional fixture-only disposition. Candidate and
+plan versions must agree with the profile's detector and qualification contract
+versions.
+
+## Decisions
+
+The closed outcomes are matched, no-match, and ambiguous. Every outcome has a
+closed reason. Equal highest eligible scores are ambiguous; lexical profile
+identity is used only to order evidence and never to choose a winner. Catalog
+or candidate input permutation cannot change the decision.
+
+Active selection excludes revoked and superseded profiles, unqualified
+profiles, profiles that default off, explicitly disabled candidates, and
+fixture-only candidates without explicit caller opt-in. Ineligible candidates
+may appear in bounded decision evidence with their rejection reason, but cannot
+win regardless of score.
+
+Read errors, Modbus exceptions, incomplete word counts, invalid encodings,
+missing results, malformed firmware, and duplicate or contradictory identity
+sources fail closed without selecting a profile. Context cancellation stops the
+remaining plan.
+
+Decision evidence is immutable and includes exact profile ID/version, score,
+reason, matched gates, ordered probe evidence IDs, detector version, and
+qualification version. Accessors return independent copies. Strict JSON rejects
+unknown, missing, malformed, and oversized input.
+
+## Bounds
+
+`DetectionLimits` closes plan declarations, executed reads, words per read,
+aggregate words, decoded identity bytes, evidence-ID bytes, and serialized
+decision bytes. Every limit is finite and positive, and decision serialization
+cannot exceed `MaxSerializedContractBytes`.
+
+This document must not be read as implementation or qualification evidence.
+GREEN implementation, standard-family declarations, vendor overlays, and the
+M2-03 evidence corpus require their own scoped work.

--- a/docs/m2-02-detection.md
+++ b/docs/m2-02-detection.md
@@ -1,8 +1,8 @@
 # M2-02 Deterministic Profile Detection
 
-Status: RED-phase contract skeleton. The API and behavior described here are
-acceptance targets exercised by compile-failing tests. No detector is
-implemented yet.
+Status: implemented registry contract. This package supplies deterministic
+detection declarations, execution, decisions, and strict decision
+serialization. It does not supply a profile corpus or perform qualification.
 
 ## Boundary
 
@@ -24,15 +24,23 @@ an address, and a positive bounded word count. It cannot represent an endpoint,
 connection, write operation, retry policy, or framing choice. Declarations run
 once, serially, and in immutable plan order.
 
-## Proposed Contract
+## Contract
 
-The RED tests target these constructor-owned values:
+The implementation exposes these constructor-owned immutable values:
 
 - `ProbePlan` from `ProbePlanSpec` and ordered `ProbeDeclarationSpec` values;
 - `ProbeReadResult` from `ProbeReadResultSpec`;
 - `DetectionCandidate` from `DetectionCandidateSpec`;
 - `ProfileDetector` from `ProfileDetectorSpec`; and
-- `DetectionDecision` with bounded strict JSON marshal and unmarshal helpers.
+- `DetectionDecision`, serialized through `MarshalDetectionDecision` and
+  `UnmarshalDetectionDecision`.
+
+Constructors reject zero values and malformed or infeasible declarations.
+Slice inputs and outputs are defensively copied. A `ProfileDetector` retains an
+independent plan, exact catalog profiles, exact candidate profile versions, and
+the detector and qualification contract versions carried by those profiles.
+One detector can be used concurrently because each `Detect` call owns its read
+and evaluation state.
 
 Probe declarations associate bounded ASCII register words with exactly one of
 manufacturer, model, or firmware identity. Duplicate declaration identities,
@@ -40,10 +48,16 @@ duplicate identity producers, unsupported functions, empty reads, and values
 outside configured limits are invalid.
 
 Each candidate binds one exact catalog profile ID and version to exact
-manufacturer/model gates, a semantic firmware range, a finite score, explicit
-runtime enablement, and an optional fixture-only disposition. Candidate and
-plan versions must agree with the profile's detector and qualification contract
-versions.
+case-sensitive manufacturer/model gates, a half-open semantic firmware range,
+a positive score, explicit runtime enablement, and an optional fixture-only
+disposition. The plan version and detector version must equal every bound
+profile's detector contract version. Decision evidence retains each bound
+profile's exact detector and qualification versions.
+
+Firmware comparison uses numeric semantic-version components without integer
+conversion, so component size cannot overflow a machine integer. Aliases,
+pre-release forms, leading-zero aliases, and non-numeric components are not
+accepted.
 
 ## Decisions
 
@@ -59,22 +73,29 @@ may appear in bounded decision evidence with their rejection reason, but cannot
 win regardless of score.
 
 Read errors, Modbus exceptions, incomplete word counts, invalid encodings,
-missing results, malformed firmware, and duplicate or contradictory identity
-sources fail closed without selecting a profile. Context cancellation stops the
-remaining plan.
+missing results, malformed firmware, duplicate evidence identities, and
+duplicate or contradictory identity declarations fail closed without selecting
+a profile. Context cancellation is checked before and after every caller read;
+it stops the remaining plan and returns a bounded no-match decision together
+with the context error.
 
 Decision evidence is immutable and includes exact profile ID/version, score,
 reason, matched gates, ordered probe evidence IDs, detector version, and
 qualification version. Accessors return independent copies. Strict JSON rejects
-unknown, missing, malformed, and oversized input.
+unknown, missing, duplicate, case-folded, malformed, non-canonical-key,
+unreachable, and oversized input. Marshal output is deterministic and bounded;
+unmarshal reconstructs an immutable decision and validates outcome, ranking,
+gate, and selected-profile consistency.
 
 ## Bounds
 
 `DetectionLimits` closes plan declarations, executed reads, words per read,
 aggregate words, decoded identity bytes, evidence-ID bytes, and serialized
-decision bytes. Every limit is finite and positive, and decision serialization
-cannot exceed `MaxSerializedContractBytes`.
+decision bytes. Every limit is finite and positive. Plan feasibility and a
+conservative worst-case decision size are checked before any read. Runtime
+results are checked before identity decoding, and decision serialization cannot
+exceed either its configured limit or `MaxSerializedContractBytes`.
 
-This document must not be read as implementation or qualification evidence.
-GREEN implementation, standard-family declarations, vendor overlays, and the
-M2-03 evidence corpus require their own scoped work.
+This implementation is not qualification evidence. Standard-family
+declarations, vendor overlays, and the M2-03 evidence corpus require separate
+scoped work backed by public evidence.

--- a/policy/registry-boundary.json
+++ b/policy/registry-boundary.json
@@ -1,7 +1,7 @@
 {
-  "schema": "helianthus-modbusreg-boundary/v4",
+  "schema": "helianthus-modbusreg-boundary/v5",
   "repository_mode": "single_multi_vendor",
-  "implementation_scope": "m2_01_contracts_only",
+  "implementation_scope": "public_registry_semantics",
   "module_path": "github.com/Project-Helianthus/helianthus-modbusreg",
   "required_public_dependencies": [
     "github.com/Project-Helianthus/helianthus-modbus"
@@ -23,22 +23,15 @@
     "serial",
     "socket"
   ],
-  "forbidden_m2_01_directory_names": [
+  "forbidden_ownership_directory_names": [
     "binding",
     "bindings",
     "canonical",
-    "detector",
-    "detectors",
     "framing",
     "gateway",
     "gateways",
     "network",
     "private",
-    "probe",
-    "probes",
-    "profiles",
-    "qualification",
-    "qualifications",
     "semantic",
     "semantics",
     "serial",
@@ -47,15 +40,12 @@
     "transport",
     "transports"
   ],
-  "forbidden_m2_01_product_file_stems": [
+  "forbidden_product_file_stems": [
     "binding",
     "canonical",
-    "detector",
     "framing",
     "gateway",
     "network",
-    "probe",
-    "qualification",
     "semantic",
     "semantics",
     "serial",

--- a/profile_detection.go
+++ b/profile_detection.go
@@ -1,0 +1,611 @@
+package modbusreg
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"unicode/utf8"
+)
+
+// IdentityStringGateSpec is one exact case-sensitive identity gate.
+type IdentityStringGateSpec struct {
+	Expected string
+}
+
+// FirmwareGateSpec is a half-open semantic firmware interval.
+type FirmwareGateSpec struct {
+	MinimumInclusive Version
+	MaximumExclusive Version
+}
+
+// DetectionCandidateSpec binds gates and ranking to one exact catalog profile.
+type DetectionCandidateSpec struct {
+	ProfileID      string
+	ProfileVersion Version
+	Score          uint32
+	Enabled        bool
+	FixtureOnly    bool
+	Manufacturer   IdentityStringGateSpec
+	Model          IdentityStringGateSpec
+	Firmware       FirmwareGateSpec
+}
+
+// DetectionCandidate is an immutable profile detection declaration.
+type DetectionCandidate struct {
+	spec DetectionCandidateSpec
+}
+
+func validExpectedIdentity(value string, maximum int) bool {
+	if value == "" || len(value) > maximum || !utf8.ValidString(value) {
+		return false
+	}
+	for _, character := range []byte(value) {
+		if character < 0x20 || character > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+// NewDetectionCandidate validates exact identity and semantic firmware gates.
+func NewDetectionCandidate(
+	spec DetectionCandidateSpec,
+	limits DetectionLimits,
+) (DetectionCandidate, error) {
+	if err := validateDetectionLimits(limits); err != nil {
+		return DetectionCandidate{}, err
+	}
+	if !validIdentity(spec.ProfileID) || !spec.ProfileVersion.valid() ||
+		spec.Score == 0 ||
+		!validExpectedIdentity(spec.Manufacturer.Expected, limits.MaxIdentityBytes) ||
+		!validExpectedIdentity(spec.Model.Expected, limits.MaxIdentityBytes) ||
+		!spec.Firmware.MinimumInclusive.valid() ||
+		!spec.Firmware.MaximumExclusive.valid() ||
+		compareVersion(
+			spec.Firmware.MinimumInclusive,
+			spec.Firmware.MaximumExclusive,
+		) >= 0 {
+		return DetectionCandidate{}, fmt.Errorf("detection candidate is invalid")
+	}
+	if err := preflightAggregate(spec); err != nil {
+		return DetectionCandidate{}, err
+	}
+	return DetectionCandidate{spec: spec}, nil
+}
+
+// Spec returns an independent complete candidate declaration.
+func (candidate DetectionCandidate) Spec() DetectionCandidateSpec {
+	return candidate.spec
+}
+
+// ProfileDetectorSpec binds one plan and candidate set to an immutable catalog.
+type ProfileDetectorSpec struct {
+	DetectorVersion Version
+	Plan            ProbePlan
+	Catalog         Catalog
+	Candidates      []DetectionCandidate
+	Limits          DetectionLimits
+}
+
+type boundDetectionCandidate struct {
+	candidate DetectionCandidate
+	profile   ProfileDescriptor
+}
+
+// ProfileDetector is an immutable concurrent-safe detector declaration.
+type ProfileDetector struct {
+	detectorVersion Version
+	plan            ProbePlan
+	candidates      []boundDetectionCandidate
+	limits          DetectionLimits
+}
+
+func detectionDecisionUpperBound(
+	candidates []boundDetectionCandidate,
+	plan ProbePlan,
+	limits DetectionLimits,
+) error {
+	bound := uint64(512)
+	perEvidenceID := uint64(limits.MaxEvidenceIDBytes)*6 + 128
+	planCount := uint64(len(plan.spec.Declarations))
+	if planCount != 0 && perEvidenceID > math.MaxUint64/planCount {
+		return fmt.Errorf("detection decision bound overflows")
+	}
+	for _, candidate := range candidates {
+		profileBytes := uint64(len(candidate.profile.ID())) * 6
+		versionBytes := uint64(len(candidate.profile.Version().String())+
+			len(candidate.profile.DetectorVersion().String())+
+			len(candidate.profile.QualificationVersion().String())) * 6
+		candidateBound := uint64(768) + profileBytes + versionBytes +
+			planCount*perEvidenceID
+		if candidateBound > math.MaxUint64-bound {
+			return fmt.Errorf("detection decision bound overflows")
+		}
+		bound += candidateBound
+	}
+	if bound > uint64(limits.MaxDecisionBytes) {
+		return fmt.Errorf("detection decision exceeds the configured byte bound")
+	}
+	return nil
+}
+
+// NewProfileDetector validates exact catalog/version bindings before any read.
+func NewProfileDetector(spec ProfileDetectorSpec) (*ProfileDetector, error) {
+	if err := validateDetectionLimits(spec.Limits); err != nil {
+		return nil, err
+	}
+	if !spec.DetectorVersion.valid() || len(spec.Candidates) == 0 ||
+		len(spec.Candidates) > MaxProfileDependencies {
+		return nil, fmt.Errorf("profile detector declaration is invalid")
+	}
+	plan, err := NewProbePlan(spec.Plan.Spec(), spec.Limits)
+	if err != nil {
+		return nil, err
+	}
+	if plan.Version() != spec.DetectorVersion {
+		return nil, fmt.Errorf("probe plan and detector versions disagree")
+	}
+	fields := make(map[ProbeIdentityField]struct{}, len(plan.spec.Declarations))
+	for _, declaration := range plan.spec.Declarations {
+		fields[declaration.IdentityField] = struct{}{}
+	}
+	for _, required := range []ProbeIdentityField{
+		ProbeIdentityManufacturer,
+		ProbeIdentityModel,
+		ProbeIdentityFirmware,
+	} {
+		if _, exists := fields[required]; !exists {
+			return nil, fmt.Errorf("probe plan lacks a required identity declaration")
+		}
+	}
+	profiles := spec.Catalog.Profiles()
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("profile detector catalog is empty")
+	}
+	byID := make(map[string]ProfileDescriptor, len(profiles))
+	for _, profile := range profiles {
+		byID[profile.ID()] = profile
+	}
+	bound := make([]boundDetectionCandidate, len(spec.Candidates))
+	seen := make(map[string]struct{}, len(spec.Candidates))
+	for index, declared := range spec.Candidates {
+		candidate, candidateErr := NewDetectionCandidate(declared.Spec(), spec.Limits)
+		if candidateErr != nil {
+			return nil, candidateErr
+		}
+		candidateSpec := candidate.spec
+		if _, duplicate := seen[candidateSpec.ProfileID]; duplicate {
+			return nil, fmt.Errorf("detection candidate profile binding is duplicated")
+		}
+		profile, exists := byID[candidateSpec.ProfileID]
+		if !exists || profile.Version() != candidateSpec.ProfileVersion {
+			return nil, fmt.Errorf("detection candidate profile binding is absent")
+		}
+		if profile.DetectorVersion() != spec.DetectorVersion ||
+			!profile.QualificationVersion().valid() {
+			return nil, fmt.Errorf("detection candidate contract versions disagree")
+		}
+		seen[candidateSpec.ProfileID] = struct{}{}
+		bound[index] = boundDetectionCandidate{
+			candidate: candidate,
+			profile:   profile,
+		}
+	}
+	sort.Slice(bound, func(first, second int) bool {
+		firstProfile := bound[first].profile
+		secondProfile := bound[second].profile
+		if firstProfile.ID() != secondProfile.ID() {
+			return firstProfile.ID() < secondProfile.ID()
+		}
+		return compareVersion(firstProfile.Version(), secondProfile.Version()) < 0
+	})
+	if err := detectionDecisionUpperBound(bound, plan, spec.Limits); err != nil {
+		return nil, err
+	}
+	return &ProfileDetector{
+		detectorVersion: spec.DetectorVersion,
+		plan:            plan,
+		candidates:      bound,
+		limits:          spec.Limits,
+	}, nil
+}
+
+// DetectionOutcome is the closed detector decision set.
+type DetectionOutcome string
+
+const (
+	DetectionMatched   DetectionOutcome = "matched"
+	DetectionNoMatch   DetectionOutcome = "no_match"
+	DetectionAmbiguous DetectionOutcome = "ambiguous"
+)
+
+// DetectionReason is the closed decision and candidate evidence reason set.
+type DetectionReason string
+
+const (
+	DetectionReasonSelected             DetectionReason = "selected"
+	DetectionReasonEqualBest            DetectionReason = "equal_best"
+	DetectionReasonLowerScore           DetectionReason = "lower_score"
+	DetectionReasonIdentityMismatch     DetectionReason = "identity_mismatch"
+	DetectionReasonFirmwareMismatch     DetectionReason = "firmware_mismatch"
+	DetectionReasonInvalidIdentity      DetectionReason = "invalid_identity"
+	DetectionReasonFixtureOptInRequired DetectionReason = "fixture_opt_in_required"
+	DetectionReasonCandidateDisabled    DetectionReason = "candidate_disabled"
+	DetectionReasonProfileDefaultOff    DetectionReason = "profile_default_off"
+	DetectionReasonProfileRevoked       DetectionReason = "profile_revoked"
+	DetectionReasonProfileSuperseded    DetectionReason = "profile_superseded"
+	DetectionReasonProfileUnqualified   DetectionReason = "profile_unqualified"
+	DetectionReasonReadError            DetectionReason = "read_error"
+	DetectionReasonProbeException       DetectionReason = "probe_exception"
+	DetectionReasonIncompleteProbe      DetectionReason = "incomplete_probe"
+	DetectionReasonInvalidProbeResult   DetectionReason = "invalid_probe_result"
+	DetectionReasonContextCancelled     DetectionReason = "context_cancelled"
+)
+
+// DetectionOptions contains per-call policy that cannot alter declarations.
+type DetectionOptions struct {
+	AllowFixtureOnly bool
+}
+
+// DetectionCandidateEvidence is one immutable-decision candidate projection.
+// DetectionDecision.Evidence returns deep copies of these values.
+type DetectionCandidateEvidence struct {
+	ProfileID            string
+	ProfileVersion       Version
+	Score                uint32
+	Reason               DetectionReason
+	MatchedGates         []ProbeIdentityField
+	ProbeEvidenceIDs     []string
+	DetectorVersion      Version
+	QualificationVersion Version
+}
+
+// DetectionDecision is one immutable bounded selection result.
+type DetectionDecision struct {
+	outcome                DetectionOutcome
+	reason                 DetectionReason
+	selectedProfileID      string
+	selectedProfileVersion Version
+	evidence               []DetectionCandidateEvidence
+	maxDecisionBytes       int
+}
+
+func cloneDetectionEvidence(
+	values []DetectionCandidateEvidence,
+) []DetectionCandidateEvidence {
+	result := make([]DetectionCandidateEvidence, len(values))
+	for index, value := range values {
+		result[index] = value
+		result[index].MatchedGates = append(
+			[]ProbeIdentityField(nil),
+			value.MatchedGates...,
+		)
+		result[index].ProbeEvidenceIDs = append(
+			[]string(nil),
+			value.ProbeEvidenceIDs...,
+		)
+	}
+	return result
+}
+
+// Outcome returns matched, no-match, or ambiguous.
+func (decision DetectionDecision) Outcome() DetectionOutcome { return decision.outcome }
+
+// Reason returns the closed overall decision reason.
+func (decision DetectionDecision) Reason() DetectionReason { return decision.reason }
+
+// SelectedProfileID is empty unless the outcome is matched.
+func (decision DetectionDecision) SelectedProfileID() string {
+	return decision.selectedProfileID
+}
+
+// SelectedProfileVersion is zero unless the outcome is matched.
+func (decision DetectionDecision) SelectedProfileVersion() Version {
+	return decision.selectedProfileVersion
+}
+
+// Evidence returns an independent deterministic candidate evidence copy.
+func (decision DetectionDecision) Evidence() []DetectionCandidateEvidence {
+	return cloneDetectionEvidence(decision.evidence)
+}
+
+type detectedIdentity struct {
+	value      string
+	evidenceID string
+}
+
+func (detector *ProfileDetector) baseEvidence(
+	reason DetectionReason,
+) []DetectionCandidateEvidence {
+	evidence := make([]DetectionCandidateEvidence, len(detector.candidates))
+	for index, candidate := range detector.candidates {
+		evidence[index] = DetectionCandidateEvidence{
+			ProfileID:            candidate.profile.ID(),
+			ProfileVersion:       candidate.profile.Version(),
+			Score:                candidate.candidate.spec.Score,
+			Reason:               reason,
+			DetectorVersion:      candidate.profile.DetectorVersion(),
+			QualificationVersion: candidate.profile.QualificationVersion(),
+		}
+	}
+	return evidence
+}
+
+func (detector *ProfileDetector) decision(
+	outcome DetectionOutcome,
+	reason DetectionReason,
+	selectedProfileID string,
+	selectedProfileVersion Version,
+	evidence []DetectionCandidateEvidence,
+) DetectionDecision {
+	return DetectionDecision{
+		outcome:                outcome,
+		reason:                 reason,
+		selectedProfileID:      selectedProfileID,
+		selectedProfileVersion: selectedProfileVersion,
+		evidence:               cloneDetectionEvidence(evidence),
+		maxDecisionBytes:       detector.limits.MaxDecisionBytes,
+	}
+}
+
+func (detector *ProfileDetector) failureDecision(
+	reason DetectionReason,
+) DetectionDecision {
+	return detector.decision(
+		DetectionNoMatch,
+		reason,
+		"",
+		Version{},
+		detector.baseEvidence(reason),
+	)
+}
+
+func readerIsNil(reader ProbeReader) bool {
+	if reader == nil {
+		return true
+	}
+	value := reflect.ValueOf(reader)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map,
+		reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
+func candidateEligibilityReason(
+	profile ProfileDescriptor,
+	candidate DetectionCandidateSpec,
+	options DetectionOptions,
+) DetectionReason {
+	switch profile.spec.State {
+	case ProfileRevoked:
+		return DetectionReasonProfileRevoked
+	case ProfileSuperseded:
+		return DetectionReasonProfileSuperseded
+	case ProfileActive:
+	default:
+		return DetectionReasonInvalidIdentity
+	}
+	if profile.spec.Maturity != MaturityQualified {
+		return DetectionReasonProfileUnqualified
+	}
+	if !profile.spec.DefaultEnabled {
+		return DetectionReasonProfileDefaultOff
+	}
+	if !candidate.Enabled {
+		return DetectionReasonCandidateDisabled
+	}
+	if candidate.FixtureOnly && !options.AllowFixtureOnly {
+		return DetectionReasonFixtureOptInRequired
+	}
+	return ""
+}
+
+func evaluateCandidate(
+	bound boundDetectionCandidate,
+	identities map[ProbeIdentityField]detectedIdentity,
+	options DetectionOptions,
+) DetectionCandidateEvidence {
+	spec := bound.candidate.spec
+	evidence := DetectionCandidateEvidence{
+		ProfileID:            bound.profile.ID(),
+		ProfileVersion:       bound.profile.Version(),
+		Score:                spec.Score,
+		DetectorVersion:      bound.profile.DetectorVersion(),
+		QualificationVersion: bound.profile.QualificationVersion(),
+	}
+	if reason := candidateEligibilityReason(bound.profile, spec, options); reason != "" {
+		evidence.Reason = reason
+		return evidence
+	}
+	manufacturer := identities[ProbeIdentityManufacturer]
+	if manufacturer.value != spec.Manufacturer.Expected {
+		evidence.Reason = DetectionReasonIdentityMismatch
+		return evidence
+	}
+	evidence.MatchedGates = append(evidence.MatchedGates, ProbeIdentityManufacturer)
+	evidence.ProbeEvidenceIDs = append(evidence.ProbeEvidenceIDs, manufacturer.evidenceID)
+	model := identities[ProbeIdentityModel]
+	if model.value != spec.Model.Expected {
+		evidence.Reason = DetectionReasonIdentityMismatch
+		return evidence
+	}
+	evidence.MatchedGates = append(evidence.MatchedGates, ProbeIdentityModel)
+	evidence.ProbeEvidenceIDs = append(evidence.ProbeEvidenceIDs, model.evidenceID)
+	firmware := identities[ProbeIdentityFirmware]
+	firmwareVersion, err := ParseVersion(firmware.value)
+	if err != nil {
+		evidence.Reason = DetectionReasonInvalidIdentity
+		return evidence
+	}
+	if compareVersion(firmwareVersion, spec.Firmware.MinimumInclusive) < 0 ||
+		compareVersion(firmwareVersion, spec.Firmware.MaximumExclusive) >= 0 {
+		evidence.Reason = DetectionReasonFirmwareMismatch
+		return evidence
+	}
+	evidence.MatchedGates = append(evidence.MatchedGates, ProbeIdentityFirmware)
+	evidence.ProbeEvidenceIDs = append(evidence.ProbeEvidenceIDs, firmware.evidenceID)
+	evidence.Reason = DetectionReasonSelected
+	return evidence
+}
+
+func noMatchReason(evidence []DetectionCandidateEvidence) DetectionReason {
+	priorities := []DetectionReason{
+		DetectionReasonInvalidIdentity,
+		DetectionReasonIdentityMismatch,
+		DetectionReasonFirmwareMismatch,
+		DetectionReasonFixtureOptInRequired,
+		DetectionReasonProfileRevoked,
+		DetectionReasonProfileSuperseded,
+		DetectionReasonProfileUnqualified,
+		DetectionReasonProfileDefaultOff,
+		DetectionReasonCandidateDisabled,
+	}
+	for _, priority := range priorities {
+		for _, candidate := range evidence {
+			if candidate.Reason == priority {
+				return priority
+			}
+		}
+	}
+	return DetectionReasonInvalidIdentity
+}
+
+func (detector *ProfileDetector) finalizeDecision(
+	decision DetectionDecision,
+) (DetectionDecision, error) {
+	if _, err := MarshalDetectionDecision(decision); err != nil {
+		return DetectionDecision{}, err
+	}
+	return decision, nil
+}
+
+// Detect executes each read serially in declaration order, then evaluates and
+// ranks immutable catalog candidates without mutating detector state.
+func (detector *ProfileDetector) Detect(
+	ctx context.Context,
+	reader ProbeReader,
+	options DetectionOptions,
+) (DetectionDecision, error) {
+	if detector == nil || ctx == nil || readerIsNil(reader) {
+		return DetectionDecision{}, fmt.Errorf("profile detection request is invalid")
+	}
+	identities := make(map[ProbeIdentityField]detectedIdentity, len(detector.plan.spec.Declarations))
+	evidenceIDs := make(map[string]struct{}, len(detector.plan.spec.Declarations))
+	totalWords := 0
+	for _, declaration := range detector.plan.spec.Declarations {
+		if err := ctx.Err(); err != nil {
+			decision := detector.failureDecision(DetectionReasonContextCancelled)
+			validated, decisionErr := detector.finalizeDecision(decision)
+			if decisionErr != nil {
+				return DetectionDecision{}, decisionErr
+			}
+			return validated, err
+		}
+		result, err := reader.ReadProbe(ctx, probeRequest(declaration))
+		if contextErr := ctx.Err(); contextErr != nil {
+			decision := detector.failureDecision(DetectionReasonContextCancelled)
+			validated, decisionErr := detector.finalizeDecision(decision)
+			if decisionErr != nil {
+				return DetectionDecision{}, decisionErr
+			}
+			return validated, contextErr
+		}
+		if err != nil {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonReadError))
+		}
+		if !result.validWithin(detector.limits) {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidProbeResult))
+		}
+		if result.status == ProbeReadException {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonProbeException))
+		}
+		if len(result.words) != int(declaration.WordCount) {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonIncompleteProbe))
+		}
+		if totalWords > detector.limits.MaxTotalWords-len(result.words) {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidProbeResult))
+		}
+		totalWords += len(result.words)
+		if _, duplicate := evidenceIDs[result.evidenceID]; duplicate {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidProbeResult))
+		}
+		evidenceIDs[result.evidenceID] = struct{}{}
+		identity, decodeErr := decodeProbeASCII(
+			result.words,
+			detector.limits.MaxIdentityBytes,
+		)
+		if decodeErr != nil {
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidIdentity))
+		}
+		if prior, duplicate := identities[declaration.IdentityField]; duplicate {
+			if prior.value != identity || prior.evidenceID != result.evidenceID {
+				return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidIdentity))
+			}
+			return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidProbeResult))
+		}
+		identities[declaration.IdentityField] = detectedIdentity{
+			value:      identity,
+			evidenceID: result.evidenceID,
+		}
+	}
+	firmware := identities[ProbeIdentityFirmware]
+	if _, err := ParseVersion(firmware.value); err != nil {
+		return detector.finalizeDecision(detector.failureDecision(DetectionReasonInvalidIdentity))
+	}
+	evidence := make([]DetectionCandidateEvidence, len(detector.candidates))
+	matched := make([]int, 0, len(detector.candidates))
+	for index, candidate := range detector.candidates {
+		evidence[index] = evaluateCandidate(candidate, identities, options)
+		if evidence[index].Reason == DetectionReasonSelected {
+			matched = append(matched, index)
+		}
+	}
+	if len(matched) == 0 {
+		return detector.finalizeDecision(detector.decision(
+			DetectionNoMatch,
+			noMatchReason(evidence),
+			"",
+			Version{},
+			evidence,
+		))
+	}
+	highest := uint32(0)
+	for _, index := range matched {
+		if evidence[index].Score > highest {
+			highest = evidence[index].Score
+		}
+	}
+	best := make([]int, 0, len(matched))
+	for _, index := range matched {
+		if evidence[index].Score == highest {
+			best = append(best, index)
+		} else {
+			evidence[index].Reason = DetectionReasonLowerScore
+		}
+	}
+	if len(best) != 1 {
+		for _, index := range best {
+			evidence[index].Reason = DetectionReasonEqualBest
+		}
+		return detector.finalizeDecision(detector.decision(
+			DetectionAmbiguous,
+			DetectionReasonEqualBest,
+			"",
+			Version{},
+			evidence,
+		))
+	}
+	selected := evidence[best[0]]
+	return detector.finalizeDecision(detector.decision(
+		DetectionMatched,
+		DetectionReasonSelected,
+		selected.ProfileID,
+		selected.ProfileVersion,
+		evidence,
+	))
+}

--- a/read_plan.go
+++ b/read_plan.go
@@ -1,0 +1,336 @@
+package modbusreg
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"unicode/utf8"
+)
+
+// ProbeFunction is the closed read-only Modbus function set used by detection.
+type ProbeFunction string
+
+const (
+	ProbeReadHoldingRegisters ProbeFunction = "fc03"
+	ProbeReadInputRegisters   ProbeFunction = "fc04"
+)
+
+// ProbeIdentityField identifies one authoritative device identity value.
+type ProbeIdentityField string
+
+const (
+	ProbeIdentityManufacturer ProbeIdentityField = "manufacturer"
+	ProbeIdentityModel        ProbeIdentityField = "model"
+	ProbeIdentityFirmware     ProbeIdentityField = "firmware"
+)
+
+// ProbeIdentityEncoding is the closed register-to-identity decoding set.
+type ProbeIdentityEncoding string
+
+const (
+	// ProbeIdentityASCII decodes big-endian word bytes and trims trailing NULs.
+	ProbeIdentityASCII ProbeIdentityEncoding = "ascii"
+)
+
+// DetectionLimits closes every detector-owned collection and byte dimension.
+type DetectionLimits struct {
+	MaxPlanDeclarations int
+	MaxReads            int
+	MaxWordsPerRead     int
+	MaxTotalWords       int
+	MaxIdentityBytes    int
+	MaxEvidenceIDBytes  int
+	MaxDecisionBytes    int
+}
+
+// DefaultDetectionLimits returns finite bounds for one manufacturer/model/
+// firmware detection plan.
+func DefaultDetectionLimits() DetectionLimits {
+	return DetectionLimits{
+		MaxPlanDeclarations: 3,
+		MaxReads:            3,
+		MaxWordsPerRead:     MaxRawWords,
+		MaxTotalWords:       3 * MaxRawWords,
+		MaxIdentityBytes:    256,
+		MaxEvidenceIDBytes:  256,
+		MaxDecisionBytes:    MaxSerializedContractBytes,
+	}
+}
+
+func validateDetectionLimits(limits DetectionLimits) error {
+	positive := []int{
+		limits.MaxPlanDeclarations,
+		limits.MaxReads,
+		limits.MaxWordsPerRead,
+		limits.MaxTotalWords,
+		limits.MaxIdentityBytes,
+		limits.MaxEvidenceIDBytes,
+		limits.MaxDecisionBytes,
+	}
+	for _, value := range positive {
+		if value <= 0 {
+			return fmt.Errorf("detection limits must be finite and positive")
+		}
+	}
+	if limits.MaxPlanDeclarations > MaxProfileDependencies ||
+		limits.MaxReads > MaxProfileDependencies ||
+		limits.MaxWordsPerRead > MaxRawWords ||
+		limits.MaxIdentityBytes > MaxContractStringBytes ||
+		limits.MaxEvidenceIDBytes > MaxContractStringBytes ||
+		limits.MaxDecisionBytes > MaxSerializedContractBytes {
+		return fmt.Errorf("detection limits exceed the contract maximum")
+	}
+	if limits.MaxPlanDeclarations > math.MaxInt/limits.MaxWordsPerRead ||
+		limits.MaxTotalWords > limits.MaxPlanDeclarations*limits.MaxWordsPerRead {
+		return fmt.Errorf("detection word limits are inconsistent")
+	}
+	return nil
+}
+
+// ProbeDeclarationSpec declares one bounded read and its identity projection.
+type ProbeDeclarationSpec struct {
+	ID            string
+	Function      ProbeFunction
+	Address       uint16
+	WordCount     uint16
+	IdentityField ProbeIdentityField
+	Encoding      ProbeIdentityEncoding
+}
+
+// ProbePlanSpec is the complete ordered detector read declaration.
+type ProbePlanSpec struct {
+	Version      Version
+	Declarations []ProbeDeclarationSpec
+}
+
+// ProbePlan is an immutable ordered read-only plan.
+type ProbePlan struct {
+	spec ProbePlanSpec
+}
+
+func cloneProbePlanSpec(spec ProbePlanSpec) ProbePlanSpec {
+	spec.Declarations = append([]ProbeDeclarationSpec(nil), spec.Declarations...)
+	return spec
+}
+
+func validProbeFunction(function ProbeFunction) bool {
+	return function == ProbeReadHoldingRegisters ||
+		function == ProbeReadInputRegisters
+}
+
+func validProbeIdentityField(field ProbeIdentityField) bool {
+	switch field {
+	case ProbeIdentityManufacturer, ProbeIdentityModel, ProbeIdentityFirmware:
+		return true
+	default:
+		return false
+	}
+}
+
+// NewProbePlan validates all declarations and preserves their exact order.
+func NewProbePlan(spec ProbePlanSpec, limits DetectionLimits) (ProbePlan, error) {
+	if err := validateDetectionLimits(limits); err != nil {
+		return ProbePlan{}, err
+	}
+	if !spec.Version.valid() || len(spec.Declarations) == 0 ||
+		len(spec.Declarations) > limits.MaxPlanDeclarations ||
+		len(spec.Declarations) > limits.MaxReads {
+		return ProbePlan{}, fmt.Errorf("probe plan cardinality is invalid")
+	}
+	if err := preflightAggregate(spec); err != nil {
+		return ProbePlan{}, err
+	}
+	seenIDs := make(map[string]struct{}, len(spec.Declarations))
+	seenFields := make(map[ProbeIdentityField]struct{}, len(spec.Declarations))
+	totalWords := 0
+	for _, declaration := range spec.Declarations {
+		if !validIdentity(declaration.ID) ||
+			!validProbeFunction(declaration.Function) ||
+			!validProbeIdentityField(declaration.IdentityField) ||
+			declaration.Encoding != ProbeIdentityASCII ||
+			declaration.WordCount == 0 ||
+			int(declaration.WordCount) > limits.MaxWordsPerRead {
+			return ProbePlan{}, fmt.Errorf("probe declaration is invalid")
+		}
+		last := uint32(declaration.Address) + uint32(declaration.WordCount) - 1
+		if last > math.MaxUint16 {
+			return ProbePlan{}, fmt.Errorf("probe declaration range overflows")
+		}
+		if _, duplicate := seenIDs[declaration.ID]; duplicate {
+			return ProbePlan{}, fmt.Errorf("probe declaration ID is duplicated")
+		}
+		if _, duplicate := seenFields[declaration.IdentityField]; duplicate {
+			return ProbePlan{}, fmt.Errorf("probe identity producer is duplicated")
+		}
+		seenIDs[declaration.ID] = struct{}{}
+		seenFields[declaration.IdentityField] = struct{}{}
+		if totalWords > limits.MaxTotalWords-int(declaration.WordCount) {
+			return ProbePlan{}, fmt.Errorf("probe plan exceeds the aggregate word bound")
+		}
+		totalWords += int(declaration.WordCount)
+	}
+	return ProbePlan{spec: cloneProbePlanSpec(spec)}, nil
+}
+
+// Spec returns an independent complete plan declaration.
+func (plan ProbePlan) Spec() ProbePlanSpec {
+	return cloneProbePlanSpec(plan.spec)
+}
+
+// Version returns the immutable plan contract version.
+func (plan ProbePlan) Version() Version {
+	return plan.spec.Version
+}
+
+// Declarations returns independent declarations in execution order.
+func (plan ProbePlan) Declarations() []ProbeDeclarationSpec {
+	return append([]ProbeDeclarationSpec(nil), plan.spec.Declarations...)
+}
+
+// ProbeReadRequest is the transport-neutral read request passed to a caller.
+// Its unexported representation cannot carry endpoint or write authority.
+type ProbeReadRequest struct {
+	declarationID string
+	function      ProbeFunction
+	address       uint16
+	wordCount     uint16
+}
+
+func probeRequest(declaration ProbeDeclarationSpec) ProbeReadRequest {
+	return ProbeReadRequest{
+		declarationID: declaration.ID,
+		function:      declaration.Function,
+		address:       declaration.Address,
+		wordCount:     declaration.WordCount,
+	}
+}
+
+// DeclarationID returns the immutable plan declaration identity.
+func (request ProbeReadRequest) DeclarationID() string { return request.declarationID }
+
+// Function returns FC03 or FC04.
+func (request ProbeReadRequest) Function() ProbeFunction { return request.function }
+
+// Address returns the zero-based Modbus register address.
+func (request ProbeReadRequest) Address() uint16 { return request.address }
+
+// WordCount returns the positive bounded read width.
+func (request ProbeReadRequest) WordCount() uint16 { return request.wordCount }
+
+// ProbeReader is implemented by the caller that owns transport and I/O.
+type ProbeReader interface {
+	ReadProbe(context.Context, ProbeReadRequest) (ProbeReadResult, error)
+}
+
+// ProbeReadStatus is the closed read disposition set.
+type ProbeReadStatus string
+
+const (
+	ProbeReadSucceeded ProbeReadStatus = "succeeded"
+	ProbeReadException ProbeReadStatus = "exception"
+)
+
+// ProbeReadResultSpec is one caller-returned bounded read result.
+type ProbeReadResultSpec struct {
+	Status        ProbeReadStatus
+	Words         []uint16
+	EvidenceID    string
+	ExceptionCode uint8
+}
+
+// ProbeReadResult is an immutable read result with no endpoint provenance.
+type ProbeReadResult struct {
+	status        ProbeReadStatus
+	words         []uint16
+	evidenceID    string
+	exceptionCode uint8
+}
+
+func validProbeEvidenceID(value string, maximum int) bool {
+	return value != "" && len(value) <= maximum && validIdentity(value)
+}
+
+// NewProbeReadResult validates against the absolute default result bounds.
+// A detector may impose lower limits before consuming the result.
+func NewProbeReadResult(spec ProbeReadResultSpec) (ProbeReadResult, error) {
+	limits := DefaultDetectionLimits()
+	if !validProbeEvidenceID(spec.EvidenceID, limits.MaxEvidenceIDBytes) {
+		return ProbeReadResult{}, fmt.Errorf("probe evidence identity is invalid")
+	}
+	switch spec.Status {
+	case ProbeReadSucceeded:
+		if len(spec.Words) == 0 || len(spec.Words) > limits.MaxWordsPerRead ||
+			spec.ExceptionCode != 0 {
+			return ProbeReadResult{}, fmt.Errorf("successful probe result is invalid")
+		}
+	case ProbeReadException:
+		if len(spec.Words) != 0 || spec.ExceptionCode == 0 {
+			return ProbeReadResult{}, fmt.Errorf("exception probe result is invalid")
+		}
+	default:
+		return ProbeReadResult{}, fmt.Errorf("probe result status is invalid")
+	}
+	if err := preflightAggregate(spec); err != nil {
+		return ProbeReadResult{}, err
+	}
+	return ProbeReadResult{
+		status:        spec.Status,
+		words:         append([]uint16(nil), spec.Words...),
+		evidenceID:    spec.EvidenceID,
+		exceptionCode: spec.ExceptionCode,
+	}, nil
+}
+
+// Status returns the immutable read disposition.
+func (result ProbeReadResult) Status() ProbeReadStatus { return result.status }
+
+// Words returns an independent register-word copy.
+func (result ProbeReadResult) Words() []uint16 {
+	return append([]uint16(nil), result.words...)
+}
+
+// EvidenceID returns the caller-supplied public probe evidence identity.
+func (result ProbeReadResult) EvidenceID() string { return result.evidenceID }
+
+// ExceptionCode returns zero for successful reads.
+func (result ProbeReadResult) ExceptionCode() uint8 { return result.exceptionCode }
+
+func (result ProbeReadResult) validWithin(limits DetectionLimits) bool {
+	if !validProbeEvidenceID(result.evidenceID, limits.MaxEvidenceIDBytes) {
+		return false
+	}
+	switch result.status {
+	case ProbeReadSucceeded:
+		return len(result.words) > 0 && len(result.words) <= limits.MaxWordsPerRead &&
+			result.exceptionCode == 0
+	case ProbeReadException:
+		return len(result.words) == 0 && result.exceptionCode != 0
+	default:
+		return false
+	}
+}
+
+func decodeProbeASCII(words []uint16, maximum int) (string, error) {
+	if len(words) == 0 || len(words) > math.MaxInt/2 || maximum <= 0 {
+		return "", fmt.Errorf("probe identity words are invalid")
+	}
+	encoded := make([]byte, len(words)*2)
+	for index, word := range words {
+		encoded[index*2] = byte(word >> 8)
+		encoded[index*2+1] = byte(word)
+	}
+	end := len(encoded)
+	for end > 0 && encoded[end-1] == 0 {
+		end--
+	}
+	encoded = encoded[:end]
+	if len(encoded) == 0 || len(encoded) > maximum || !utf8.Valid(encoded) {
+		return "", fmt.Errorf("probe identity exceeds its byte bound")
+	}
+	for _, character := range encoded {
+		if character < 0x20 || character > 0x7e {
+			return "", fmt.Errorf("probe identity is not canonical ASCII")
+		}
+	}
+	return string(encoded), nil
+}

--- a/scripts/validate_scope_policy.py
+++ b/scripts/validate_scope_policy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate the current registry tree against structural M2-01 boundaries."""
+"""Validate the public registry tree against stable ownership boundaries."""
 
 from __future__ import annotations
 
@@ -14,9 +14,9 @@ from typing import Iterable
 from urllib.parse import urlparse
 
 
-SCHEMA = "helianthus-modbusreg-boundary/v4"
+SCHEMA = "helianthus-modbusreg-boundary/v5"
 REPOSITORY_MODE = "single_multi_vendor"
-IMPLEMENTATION_SCOPE = "m2_01_contracts_only"
+IMPLEMENTATION_SCOPE = "public_registry_semantics"
 MODULE_PATH = "github.com/Project-Helianthus/helianthus-modbusreg"
 PUBLIC_MODBUS = "github.com/Project-Helianthus/helianthus-modbus"
 POLICY_KEYS = {
@@ -29,8 +29,8 @@ POLICY_KEYS = {
     "allowed_non_io_net_imports",
     "forbidden_product_import_prefixes",
     "forbidden_product_import_tokens",
-    "forbidden_m2_01_directory_names",
-    "forbidden_m2_01_product_file_stems",
+    "forbidden_ownership_directory_names",
+    "forbidden_product_file_stems",
     "standard_root",
     "vendor_root",
     "vendor_evidence_file",
@@ -43,13 +43,9 @@ REQUIRED_FORBIDDEN_IMPORT_TOKENS = {"framing", "serial", "socket"}
 REQUIRED_SCOPE_DIRECTORIES = {
     "bindings",
     "canonical",
-    "detectors",
     "framing",
     "gateway",
     "private",
-    "probes",
-    "profiles",
-    "qualification",
     "semantics",
     "serial",
     "sockets",
@@ -58,11 +54,8 @@ REQUIRED_SCOPE_DIRECTORIES = {
 REQUIRED_SCOPE_FILE_STEMS = {
     "binding",
     "canonical",
-    "detector",
     "framing",
     "gateway",
-    "probe",
-    "qualification",
     "semantic",
     "serial",
     "socket",
@@ -144,16 +137,19 @@ def load_policy(root: Path) -> dict[str, object]:
     ):
         raise PolicyError("product import boundary omits a required token")
     if not REQUIRED_SCOPE_DIRECTORIES.issubset(
-        {item.casefold() for item in string_list(policy, "forbidden_m2_01_directory_names")}
+        {
+            item.casefold()
+            for item in string_list(policy, "forbidden_ownership_directory_names")
+        }
     ):
-        raise PolicyError("M2-01 directory boundary is incomplete")
+        raise PolicyError("registry ownership directory boundary is incomplete")
     if not REQUIRED_SCOPE_FILE_STEMS.issubset(
         {
             item.casefold()
-            for item in string_list(policy, "forbidden_m2_01_product_file_stems")
+            for item in string_list(policy, "forbidden_product_file_stems")
         }
     ):
-        raise PolicyError("M2-01 product filename boundary is incomplete")
+        raise PolicyError("registry ownership filename boundary is incomplete")
     safe_relative_path(policy["standard_root"], "profiles/standard", "standard_root")
     safe_relative_path(policy["vendor_root"], "profiles/vendor", "vendor_root")
     safe_relative_path(
@@ -217,16 +213,16 @@ def current_files(root: Path) -> list[Path]:
     return sorted(files)
 
 
-def validate_m2_01_scope(root: Path, policy: dict[str, object]) -> None:
+def validate_registry_scope(root: Path, policy: dict[str, object]) -> None:
     if policy["implementation_scope"] != IMPLEMENTATION_SCOPE:
-        raise PolicyError("implementation scope must remain M2-01 contracts-only")
+        raise PolicyError("implementation scope must remain public registry semantics")
     forbidden_directories = {
         item.casefold()
-        for item in string_list(policy, "forbidden_m2_01_directory_names")
+        for item in string_list(policy, "forbidden_ownership_directory_names")
     }
     forbidden_stems = {
         item.casefold()
-        for item in string_list(policy, "forbidden_m2_01_product_file_stems")
+        for item in string_list(policy, "forbidden_product_file_stems")
     }
     for path in current_files(root):
         relative = path.relative_to(root)
@@ -234,7 +230,7 @@ def validate_m2_01_scope(root: Path, policy: dict[str, object]) -> None:
         leaked_directories = directory_names & forbidden_directories
         if leaked_directories:
             raise PolicyError(
-                f"M2-01 forbids ownership directory in {relative.as_posix()}: "
+                f"registry boundary forbids ownership directory in {relative.as_posix()}: "
                 f"{sorted(leaked_directories)}"
             )
         if path.suffix == ".go" and not path.name.endswith("_test.go"):
@@ -244,7 +240,7 @@ def validate_m2_01_scope(root: Path, policy: dict[str, object]) -> None:
             leaked_stems = stem_tokens & forbidden_stems
             if leaked_stems:
                 raise PolicyError(
-                    f"M2-01 forbids product ownership in {relative.as_posix()}: "
+                    f"registry boundary forbids product ownership in {relative.as_posix()}: "
                     f"{sorted(leaked_stems)}"
                 )
 
@@ -456,7 +452,7 @@ def go_imports(root: Path) -> list[str]:
 def validate(root: Path) -> None:
     policy = load_policy(root)
     validate_module(root, policy)
-    validate_m2_01_scope(root, policy)
+    validate_registry_scope(root, policy)
     validate_non_go_code(root)
     validate_imports(go_imports(root), policy)
     validate_standard_sources(root, policy)

--- a/tests/test_scope_policy.py
+++ b/tests/test_scope_policy.py
@@ -143,9 +143,9 @@ class ScopePolicyTests(unittest.TestCase):
                 "package modbusreg\n\ntype IdentityContract struct{}\n",
                 encoding="utf-8",
             )
-            validator.validate_m2_01_scope(root, self.policy())
+            validator.validate_registry_scope(root, self.policy())
 
-    def test_detector_probe_qualification_and_profile_scope_leakage_fails(self) -> None:
+    def test_detector_probe_qualification_and_profile_ownership_is_allowed(self) -> None:
         policy = self.policy()
         for relative in (
             "detectors/example/detector.go",
@@ -159,15 +159,13 @@ class ScopePolicyTests(unittest.TestCase):
                 target = root / relative
                 target.parent.mkdir(parents=True)
                 target.write_text("package example\n", encoding="utf-8")
-                with self.assertRaises(validator.PolicyError):
-                    validator.validate_m2_01_scope(root, policy)
+                validator.validate_registry_scope(root, policy)
 
         for name in ("detector.go", "probe.go", "qualification.go"):
             with self.subTest(name=name), tempfile.TemporaryDirectory() as temp:
                 root = Path(temp)
                 (root / name).write_text("package modbusreg\n", encoding="utf-8")
-                with self.assertRaises(validator.PolicyError):
-                    validator.validate_m2_01_scope(root, policy)
+                validator.validate_registry_scope(root, policy)
 
     def test_gateway_private_binding_and_canonical_semantic_ownership_fails(self) -> None:
         policy = self.policy()
@@ -184,7 +182,7 @@ class ScopePolicyTests(unittest.TestCase):
                 target.parent.mkdir(parents=True)
                 target.write_text("package forbidden\n", encoding="utf-8")
                 with self.assertRaises(validator.PolicyError):
-                    validator.validate_m2_01_scope(root, policy)
+                    validator.validate_registry_scope(root, policy)
 
     def test_standard_family_vendor_leak_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## What

Implement FMV3-M2-02 deterministic profile detection and bounded transport-neutral read-only probing.

Closes #5.

## RED Evidence

- Test-only HEAD: `dcd56508428eba8189d07c16a348b3fac80b3cee`
- Hosted RED run: `31399340042`
- Added 11 behavior tests and a RED-phase public contract skeleton.
- Hosted checks and lint failed as intended on absent detector symbols after terminology, scope, mutation, and formatting gates passed.

## GREEN Evidence

- Implementation and reviewed HEAD: `4697971ccfef158dc35f6b777ec966d4a051ba63`
- Added immutable FC03/FC04 probe plans/results, exact catalog candidate binding, qualification-aware eligibility, deterministic ranking, fail-closed execution, and strict bounded decision serialization.
- Generalized the stale M2-01-only scope metadata to the stable public registry semantic boundary while preserving transport, gateway, private binding, external dependency, and I/O exclusions.
- Local `./scripts/ci_local.sh`: PASS, including 14 Python scope mutation tests, race tests, vet, build, and golangci-lint.
- Detector concurrency/cancellation under race/shuffle `count=100`: PASS.
- Full suite under race/shuffle `count=20`: PASS.
- GitHub Actions run `31401629999`: `checks` PASS, `lint` PASS.
- Fresh exact-HEAD review: `NO_BLOCKING_FINDINGS`; P3/P4 none.

## Scope

Read-only FC03/FC04 probe declarations, deterministic selection, strict identity/firmware gates, fixture opt-in, qualification lifecycle, bounded evidence, and fail-closed decisions. No sockets, framing, writes, vendor profiles, fixture corpus, gateway, or live-device work.

## Gates

- [x] RED-only commit published
- [x] Hosted RED observed
- [x] GREEN implementation
- [x] Local CI green
- [x] Hosted CI green on exact HEAD
- [x] Fresh exact-HEAD `NO_BLOCKING_FINDINGS`