### PR TITLE
FMV3-M2-03: add sanitized fixture conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ registry for Helianthus.
 
 M2-01 defines immutable profile and observation contracts and consumes the
 public M1-06 opaque runtime-acquisition API. M2-02 adds bounded, deterministic,
-read-only profile detection over the immutable catalog. The repository still
-contains no standard-family profile, vendor overlay, qualification record, or
-vendor fixture; those belong to later milestones and require public evidence.
+read-only profile detection over the immutable catalog. M2-03 adds an immutable
+transport-neutral corpus for sanitized synthetic fixture replay and cross-profile
+conformance. The repository still contains no concrete standard-family profile,
+vendor overlay, qualification record, or vendor fixture; those belong to later
+milestones and require public evidence.
 
 ## One Registry, Multiple Vendors
 
@@ -40,7 +42,9 @@ This repository owns:
   effect and terminal publication decision;
 - strict bounded serialization for contracts, observations, and ledger state;
 - bounded read-only probe plans and deterministic qualification-aware profile
-  detection; and
+  detection;
+- strict bounded synthetic fixture corpus serialization, replay, mutation
+  classification, and deterministic conformance reports; and
 - evidence-gated vendor overlay declarations for future milestones.
 
 This repository does not own:
@@ -67,10 +71,11 @@ Fixture bytes use `FixtureReplayer.Replay`. `FixtureReplay` has a fixture
 content identity and immutable replay facts, but no runtime capability,
 production sample ID, seal, or publish method.
 
-The detailed contracts are in [`docs/m2-01-api.md`](docs/m2-01-api.md) and
-[`docs/m2-02-detection.md`](docs/m2-02-detection.md). The cross-repository
-architecture remains documented in the public Helianthus protocol
-documentation repository.
+The detailed contracts are in [`docs/m2-01-api.md`](docs/m2-01-api.md),
+[`docs/m2-02-detection.md`](docs/m2-02-detection.md), and
+[`docs/m2-03-fixture-conformance.md`](docs/m2-03-fixture-conformance.md). The
+cross-repository architecture remains documented in the public Helianthus
+protocol documentation repository.
 
 ## Development
 

--- a/docs/m2-03-fixture-conformance.md
+++ b/docs/m2-03-fixture-conformance.md
@@ -1,0 +1,60 @@
+# FMV3-M2-03 fixture conformance (RED acceptance skeleton)
+
+## Scope
+
+M2-03 adds a small immutable, transport-neutral conformance corpus over the
+existing profile, observation, fixture replay, codec, coherence, provenance,
+serialization, limits, and detector contracts. It does not create transport
+connections, accept credentials, introduce vendor facts, publish production
+samples, or reimplement M2-01/M2-02 behavior.
+
+Fixtures are generic and synthetic. Metadata is exactly a corpus identity,
+`CC0-1.0` public license expression, and public synthetic provenance.
+
+## Proposed bounded API
+
+- `FixtureConformanceCorpusSpec`, `SanitizedFixtureMetadata`, immutable
+  `FixtureConformanceCorpus`, `Spec`, and bounded corpus limits;
+- `MarshalFixtureConformanceCorpusSpec` and
+  `UnmarshalFixtureConformanceCorpus` as the strict bounded JSON boundary;
+- records bind an existing profile and observation to a serializable detector
+  declaration (plan, candidates, limits) plus recorded probe results, exact expected detector
+  outcome/reason/profile/version/evidence, qualification disposition, and an
+  expected replay outcome/reason;
+- `Replay`, immutable report/result accessors, exact logical slices/provenance,
+  and deterministic `MarshalBoundedReport`;
+- closed `FixtureMutationReason` values and `IsFixtureMutationReason`.
+
+Construction validates schema, bounds, sanitization, immutable declarations,
+profile/detector binding, and expected-outcome consistency. A negative record
+whose `ExpectedReplay` is rejected is admissible. Replay composes
+`FixtureReplayer` and a `ProfileDetector` reconstructed from the serializable
+declaration and corpus catalog. It may adapt recorded probe results to
+`ProbeReader`, but cannot introduce a parallel codec, detector, qualification,
+or observation-validation engine. An incompatible or torn record declared
+accepted is contradictory and rejected at construction.
+
+## Acceptance criteria
+
+1. Strict raw JSON decoding rejects missing, unknown, duplicate, case-folded,
+   malformed, oversized, and contradictory input with stable reason codes.
+2. Construction rejects credential-like endpoints and non-fixture/live source
+   identities. Corpus specs and report accessors are defensively copied.
+3. FC03/FC04 evidence retains table, unit, normalized address, raw words, wire
+   and logical identities, sample/generation identity, and source time.
+4. Compatible unequal overlaps preserve exact logical slices. Negative records
+   for unit, table/access, generation, source, normalization, deadline, and
+   coherence mismatches replay to exact closed reasons without contaminating
+   unaffected records.
+5. Concrete codec, detector, qualification, normalization, generation, and
+   torn-read observations are actually replayed against their expected outcomes.
+6. Two distinct generic profiles and two records, reversed independently, and
+   concurrent repeated runs produce byte-identical bounded sorted reports. A
+   valid marshal/unmarshal round trip reconstructs replayable detector state
+   and produces the same bytes.
+
+## RED evidence expected
+
+The three M2-03 test files must be formatted and fail only at type-check because
+the proposed M2-03 corpus/harness API does not exist. Non-type-check gates must
+remain green.

--- a/docs/m2-03-fixture-conformance.md
+++ b/docs/m2-03-fixture-conformance.md
@@ -29,7 +29,8 @@ versioned provenance extension and the public evidence work assigned to M3-01.
 - records bind an existing profile and observation to a serializable detector
   declaration (plan, candidates, limits) plus recorded probe results, exact expected detector
   outcome/reason/profile/version/evidence, qualification disposition, and an
-  expected replay outcome/reason;
+  expected replay outcome/reason. Accepted replay expectations also carry exact
+  raw words; rejected expectations may omit raw words;
 - `Replay`, immutable report/result accessors, exact logical slices/provenance,
   deterministic versioned `MarshalBoundedReport`, and immutable per-dependency
   facts (`DependencyFacts`) retaining FC03/FC04 function/table, normalized
@@ -44,7 +45,8 @@ whose `ExpectedReplay` is rejected is admissible. Replay composes
 `FixtureReplayer` and a `ProfileDetector` reconstructed from the serializable
 declaration and corpus catalog. It may adapt recorded probe results to
 `ProbeReader`, but cannot introduce a parallel codec, detector, qualification,
-or observation-validation engine. An incompatible or torn record declared
+or observation-validation engine: canonical `FixtureReplayer` admission is
+authoritative, including bounded-multi coherence. An incompatible or torn record declared
 accepted is contradictory and rejected at construction.
 
 ## Acceptance criteria
@@ -66,7 +68,8 @@ accepted is contradictory and rejected at construction.
 6. Two distinct generic profiles and two records, reversed independently, and
    concurrent repeated runs produce byte-identical bounded sorted reports. A
    valid marshal/unmarshal round trip reconstructs replayable detector state
-   and produces the same bytes.
+   and produces the same bytes, including rejected records without expected raw
+   words.
 
 ## Validation
 
@@ -74,5 +77,6 @@ The M2-03 tests cover strict decode mutation reasons at record and nested
 M2-03-owned object boundaries, construction-time
 sanitization and contradiction rejection, exact FC03/FC04 provenance and
 slices, deterministic sorted/concurrent replay, executable marshal/unmarshal
-round trips, detector evidence, and expected negative replay reasons. The
+round trips, detector evidence, canonical bounded-multi coherence, nested
+raw-word cardinality limits, and expected negative replay reasons. The
 corpus never opens an endpoint or creates a production sample path.

--- a/docs/m2-03-fixture-conformance.md
+++ b/docs/m2-03-fixture-conformance.md
@@ -1,4 +1,7 @@
-# FMV3-M2-03 fixture conformance (RED acceptance skeleton)
+# FMV3-M2-03 fixture conformance
+
+Status: implemented as an immutable, transport-neutral offline corpus and
+replay harness.
 
 ## Scope
 
@@ -11,7 +14,7 @@ samples, or reimplement M2-01/M2-02 behavior.
 Fixtures are generic and synthetic. Metadata is exactly a corpus identity,
 `CC0-1.0` public license expression, and public synthetic provenance.
 
-## Proposed bounded API
+## Implemented bounded API
 
 - `FixtureConformanceCorpusSpec`, `SanitizedFixtureMetadata`, immutable
   `FixtureConformanceCorpus`, `Spec`, and bounded corpus limits;
@@ -53,8 +56,10 @@ accepted is contradictory and rejected at construction.
    valid marshal/unmarshal round trip reconstructs replayable detector state
    and produces the same bytes.
 
-## RED evidence expected
+## Validation
 
-The three M2-03 test files must be formatted and fail only at type-check because
-the proposed M2-03 corpus/harness API does not exist. Non-type-check gates must
-remain green.
+The M2-03 tests cover strict decode mutation reasons, construction-time
+sanitization and contradiction rejection, exact FC03/FC04 provenance and
+slices, deterministic sorted/concurrent replay, executable marshal/unmarshal
+round trips, detector evidence, and expected negative replay reasons. The
+corpus never opens an endpoint or creates a production sample path.

--- a/docs/m2-03-fixture-conformance.md
+++ b/docs/m2-03-fixture-conformance.md
@@ -14,6 +14,12 @@ samples, or reimplement M2-01/M2-02 behavior.
 Fixtures are generic and synthetic. Metadata is exactly a corpus identity,
 `CC0-1.0` public license expression, and public synthetic provenance.
 
+That restriction describes the corpus delivered by M2-03, not a permanent
+profile-kind allowlist. The harness remains profile-kind-neutral and relies on
+the existing catalog, evidence, and qualification gates. Schema v1 does not
+claim provenance for sanitized live captures; admitting those requires a
+versioned provenance extension and the public evidence work assigned to M3-01.
+
 ## Implemented bounded API
 
 - `FixtureConformanceCorpusSpec`, `SanitizedFixtureMetadata`, immutable

--- a/docs/m2-03-fixture-conformance.md
+++ b/docs/m2-03-fixture-conformance.md
@@ -31,7 +31,11 @@ versioned provenance extension and the public evidence work assigned to M3-01.
   outcome/reason/profile/version/evidence, qualification disposition, and an
   expected replay outcome/reason;
 - `Replay`, immutable report/result accessors, exact logical slices/provenance,
-  and deterministic `MarshalBoundedReport`;
+  deterministic versioned `MarshalBoundedReport`, and immutable per-dependency
+  facts (`DependencyFacts`) retaining FC03/FC04 function/table, normalized
+  address, raw words, logical slice, source time, and wire/logical/sample
+  identities. The existing record-level accessors remain compatibility views of
+  the first dependency;
 - closed `FixtureMutationReason` values and `IsFixtureMutationReason`.
 
 Construction validates schema, bounds, sanitization, immutable declarations,
@@ -49,8 +53,10 @@ accepted is contradictory and rejected at construction.
    malformed, oversized, and contradictory input with stable reason codes.
 2. Construction rejects credential-like endpoints and non-fixture/live source
    identities. Corpus specs and report accessors are defensively copied.
-3. FC03/FC04 evidence retains table, unit, normalized address, raw words, wire
-   and logical identities, sample/generation identity, and source time.
+3. Every FC03/FC04 dependency fact retains function/table, unit, normalized
+   address, raw words, logical slice, wire and logical identities,
+   sample/generation identity, and source time; mixed bounded-multi records do
+   not collapse provenance to their first dependency.
 4. Compatible unequal overlaps preserve exact logical slices. Negative records
    for unit, table/access, generation, source, normalization, deadline, and
    coherence mismatches replay to exact closed reasons without contaminating
@@ -64,7 +70,8 @@ accepted is contradictory and rejected at construction.
 
 ## Validation
 
-The M2-03 tests cover strict decode mutation reasons, construction-time
+The M2-03 tests cover strict decode mutation reasons at record and nested
+M2-03-owned object boundaries, construction-time
 sanitization and contradiction rejection, exact FC03/FC04 provenance and
 slices, deterministic sorted/concurrent replay, executable marshal/unmarshal
 round trips, detector evidence, and expected negative replay reasons. The

--- a/fixture_conformance.go
+++ b/fixture_conformance.go
@@ -795,9 +795,11 @@ type fixtureRecordDTO struct {
 }
 
 func MarshalFixtureConformanceCorpusSpec(spec FixtureConformanceCorpusSpec) ([]byte, error) {
-	if _, err := NewFixtureConformanceCorpus(spec); err != nil {
+	corpus, err := NewFixtureConformanceCorpus(spec)
+	if err != nil {
 		return nil, err
 	}
+	spec = corpus.Spec()
 	metadata, err := json.Marshal(spec.Metadata)
 	if err != nil {
 		return nil, err

--- a/fixture_conformance.go
+++ b/fixture_conformance.go
@@ -400,6 +400,9 @@ func validateFixtureProbeSet(input FixtureDetectorInput, plan ProbePlanSpec) err
 }
 
 func classifyFixtureObservation(profile ProfileDescriptor, spec ObservationSpec) FixtureReplayReason {
+	if fixtureObservationAdmitted(profile, spec) {
+		return FixtureReplayReasonAccepted
+	}
 	declarations := profile.Dependencies().Dependencies()
 	if len(spec.Dependencies) != len(declarations) {
 		return FixtureReplayReasonObservationRejected
@@ -438,22 +441,26 @@ func classifyFixtureObservation(profile ProfileDescriptor, spec ObservationSpec)
 				return FixtureReplayReasonSourceMismatch
 			}
 		}
-		if dependency.DocumentaryConsistencyMarker != spec.Dependencies[0].DocumentaryConsistencyMarker {
+		if policy.Mode == CoherenceBoundedMultiResponse &&
+			policy.DocumentaryConsistencyMarker != "" &&
+			dependency.DocumentaryConsistencyMarker != policy.DocumentaryConsistencyMarker {
 			return FixtureReplayReasonCoherenceMismatch
 		}
 	}
+	return FixtureReplayReasonObservationRejected
+}
+
+func fixtureObservationAdmitted(profile ProfileDescriptor, spec ObservationSpec) bool {
 	encoded, err := MarshalFixtureSpec(spec)
 	if err != nil {
-		return FixtureReplayReasonObservationRejected
+		return false
 	}
 	replayer, err := NewFixtureReplayer(profile)
 	if err != nil {
-		return FixtureReplayReasonObservationRejected
+		return false
 	}
-	if _, err := replayer.Replay(encoded); err != nil {
-		return FixtureReplayReasonObservationRejected
-	}
-	return FixtureReplayReasonAccepted
+	_, err = replayer.Replay(encoded)
+	return err == nil
 }
 
 func actualFixtureReplay(
@@ -857,6 +864,10 @@ func preflightFixtureCorpusJSON(data []byte) error {
 // and canonical construction; this pass only preserves the closed mutation
 // reason contract without retaining unbounded object graphs.
 func preflightFixtureObjectJSON(data []byte, keys ...string) (map[string]json.RawMessage, error) {
+	return preflightFixtureObjectJSONOptional(data, nil, keys...)
+}
+
+func preflightFixtureObjectJSONOptional(data []byte, optional []string, keys ...string) (map[string]json.RawMessage, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	token, err := decoder.Token()
 	if err != nil || token != json.Delim('{') {
@@ -896,7 +907,14 @@ func preflightFixtureObjectJSON(data []byte, keys ...string) (map[string]json.Ra
 	if err != nil || closing != json.Delim('}') {
 		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
 	}
+	optionalKeys := make(map[string]struct{}, len(optional))
+	for _, key := range optional {
+		optionalKeys[key] = struct{}{}
+	}
 	for key := range expected {
+		if _, isOptional := optionalKeys[key]; isOptional {
+			continue
+		}
 		if _, present := fields[key]; !present {
 			return nil, fixtureMutationError{FixtureMutationReasonMissing}
 		}
@@ -905,6 +923,10 @@ func preflightFixtureObjectJSON(data []byte, keys ...string) (map[string]json.Ra
 }
 
 func preflightFixtureArrayJSON(data []byte, element func([]byte) error) error {
+	return preflightFixtureArrayJSONWithLimit(data, MaxProfileDependencies, element)
+}
+
+func preflightFixtureArrayJSONWithLimit(data []byte, limit int, element func([]byte) error) error {
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	token, err := decoder.Token()
 	if err != nil || token != json.Delim('[') {
@@ -912,7 +934,7 @@ func preflightFixtureArrayJSON(data []byte, element func([]byte) error) error {
 	}
 	count := 0
 	for decoder.More() {
-		if count == MaxProfileDependencies {
+		if count == limit {
 			return fixtureMutationError{FixtureMutationReasonOversized}
 		}
 		var value json.RawMessage
@@ -1006,8 +1028,21 @@ func preflightFixtureRecordJSON(data []byte) error {
 	if _, err := preflightFixtureObjectJSON(fields["qualification"], "expected"); err != nil {
 		return err
 	}
-	_, err = preflightFixtureObjectJSON(fields["expected_replay"], "outcome", "reason", "expected_raw_words")
-	return err
+	return preflightFixtureExpectedReplayJSON(fields["expected_replay"])
+}
+
+func preflightFixtureExpectedReplayJSON(data []byte) error {
+	fields, err := preflightFixtureObjectJSONOptional(data, []string{"expected_raw_words"}, "outcome", "reason", "expected_raw_words")
+	if err != nil {
+		return err
+	}
+	rawWords, present := fields["expected_raw_words"]
+	if !present {
+		return nil
+	}
+	return preflightFixtureArrayJSON(rawWords, func(words []byte) error {
+		return preflightFixtureArrayJSONWithLimit(words, MaxRawWords, nil)
+	})
 }
 
 func preflightFixtureDetectionJSON(data []byte) error {

--- a/fixture_conformance.go
+++ b/fixture_conformance.go
@@ -602,6 +602,39 @@ func (slice FixtureLogicalSlice) CanonicalBytes() []byte {
 	return result
 }
 
+// FixtureDependencyFact is immutable, per-dependency replay evidence. Its
+// ordinal binds the fact to the corresponding observation dependency while the
+// view, wire, and sample identities distinguish overlapping FC03/FC04 reads.
+type FixtureDependencyFact struct {
+	ordinal    uint32
+	function   FunctionCode
+	table      LogicalTable
+	unit       byte
+	normalized uint16
+	rawWords   []uint16
+	slice      FixtureLogicalSlice
+	source     SourceTimeSpec
+	wire       FixtureWireProvenance
+	logical    FixtureLogicalProvenance
+	sample     FixtureSampleProvenance
+}
+
+func (fact FixtureDependencyFact) Ordinal() uint32            { return fact.ordinal }
+func (fact FixtureDependencyFact) FunctionCode() FunctionCode { return fact.function }
+func (fact FixtureDependencyFact) Table() LogicalTable        { return fact.table }
+func (fact FixtureDependencyFact) UnitID() byte               { return fact.unit }
+func (fact FixtureDependencyFact) NormalizedAddress() uint16  { return fact.normalized }
+func (fact FixtureDependencyFact) RawWords() []uint16         { return append([]uint16(nil), fact.rawWords...) }
+func (fact FixtureDependencyFact) LogicalSlice() FixtureLogicalSlice {
+	return FixtureLogicalSlice{words: append([]uint16(nil), fact.slice.words...)}
+}
+func (fact FixtureDependencyFact) SourceTime() SourceTimeSpec            { return fact.source }
+func (fact FixtureDependencyFact) WireProvenance() FixtureWireProvenance { return fact.wire }
+func (fact FixtureDependencyFact) LogicalProvenance() FixtureLogicalProvenance {
+	return fact.logical
+}
+func (fact FixtureDependencyFact) SampleProvenance() FixtureSampleProvenance { return fact.sample }
+
 type FixtureConformanceRecord struct {
 	recordID, profileID string
 	profileVersion      Version
@@ -615,6 +648,7 @@ type FixtureConformanceRecord struct {
 	logical             FixtureLogicalProvenance
 	sample              FixtureSampleProvenance
 	slices              []FixtureLogicalSlice
+	dependencies        []FixtureDependencyFact
 	detection           FixtureDetectionResult
 	qualification       FixtureQualificationDisposition
 	replay              FixtureReplayResult
@@ -642,6 +676,15 @@ func (record FixtureConformanceRecord) LogicalSlices() []FixtureLogicalSlice {
 	result := make([]FixtureLogicalSlice, len(record.slices))
 	for i := range record.slices {
 		result[i].words = append([]uint16(nil), record.slices[i].words...)
+	}
+	return result
+}
+func (record FixtureConformanceRecord) DependencyFacts() []FixtureDependencyFact {
+	result := make([]FixtureDependencyFact, len(record.dependencies))
+	for i := range record.dependencies {
+		result[i] = record.dependencies[i]
+		result[i].rawWords = append([]uint16(nil), record.dependencies[i].rawWords...)
+		result[i].slice.words = append([]uint16(nil), record.dependencies[i].slice.words...)
 	}
 	return result
 }
@@ -710,6 +753,11 @@ func replayFixtureRecord(catalog Catalog, profile ProfileDescriptor, spec Fixtur
 	}
 	view := spec.Observation.Dependencies[0].View.Record()
 	result := FixtureConformanceRecord{recordID: spec.RecordID, profileID: spec.ProfileID, profileVersion: spec.ProfileVersion, function: view.RequestedFunction, table: view.Table, unit: spec.Observation.UnitID, normalized: view.LogicalOffset, rawWords: append([]uint16(nil), view.Words...), source: spec.Observation.SourceTime, wire: FixtureWireProvenance{view.WireResponseID}, logical: FixtureLogicalProvenance{view.LogicalViewID}, sample: FixtureSampleProvenance{PollGenerationID: spec.Observation.PollGenerationID}, detection: FixtureDetectionResult{Actual: decision, expected: spec.Detection.Expected}, qualification: spec.Qualification.Expected, replay: FixtureReplayResult{actual: actual, expected: spec.ExpectedReplay}}
+	result.dependencies = make([]FixtureDependencyFact, len(spec.Observation.Dependencies))
+	for index, dependency := range spec.Observation.Dependencies {
+		dependencyView := dependency.View.Record()
+		result.dependencies[index] = FixtureDependencyFact{ordinal: uint32(index), function: dependencyView.RequestedFunction, table: dependencyView.Table, unit: dependencyView.UnitID, normalized: dependencyView.LogicalOffset, rawWords: append([]uint16(nil), actual.rawWords[index]...), slice: FixtureLogicalSlice{words: append([]uint16(nil), actual.rawWords[index]...)}, source: dependency.SourceTime, wire: FixtureWireProvenance{dependencyView.WireResponseID}, logical: FixtureLogicalProvenance{dependencyView.LogicalViewID}, sample: FixtureSampleProvenance{PollGenerationID: dependencyView.PollGeneration}}
+	}
 	result.slices = make([]FixtureLogicalSlice, len(actual.rawWords))
 	for index, words := range actual.rawWords {
 		result.slices[index] = FixtureLogicalSlice{words: append([]uint16(nil), words...)}
@@ -788,59 +836,76 @@ func preflightFixtureCorpusJSON(data []byte) error {
 	if len(data) > MaxSerializedContractBytes {
 		return fixtureMutationError{FixtureMutationReasonOversized}
 	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	token, err := decoder.Token()
-	if err != nil || token != json.Delim('{') {
-		return fixtureMutationError{FixtureMutationReasonMalformed}
+	fields, err := preflightFixtureObjectJSON(data, "schema_version", "metadata", "profiles", "records")
+	if err != nil {
+		return err
 	}
-	expected := map[string]struct{}{"schema_version": {}, "metadata": {}, "profiles": {}, "records": {}}
-	seen := map[string]struct{}{}
-	for decoder.More() {
-		token, err := decoder.Token()
-		key, ok := token.(string)
-		if err != nil || !ok {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
-		}
-		folded := strings.ToLower(key)
-		if _, ok := seen[folded]; ok {
-			if key == strings.ToLower(key) {
-				return fixtureMutationError{FixtureMutationReasonDuplicate}
-			}
-			return fixtureMutationError{FixtureMutationReasonCaseFolded}
-		}
-		seen[folded] = struct{}{}
-		if _, ok := expected[key]; !ok {
-			if _, foldedKnown := expected[folded]; foldedKnown {
-				return fixtureMutationError{FixtureMutationReasonCaseFolded}
-			}
-			return fixtureMutationError{FixtureMutationReasonUnknown}
-		}
-		if key == "profiles" || key == "records" {
-			if err := preflightFixtureArrayCardinality(decoder); err != nil {
-				return err
-			}
-		} else {
-			var discard json.RawMessage
-			if err := decoder.Decode(&discard); err != nil {
-				return fixtureMutationError{FixtureMutationReasonMalformed}
-			}
-		}
+	if _, err := preflightFixtureObjectJSON(fields["metadata"], "corpus_id", "license_expression", "provenance"); err != nil {
+		return err
 	}
-	if _, err := decoder.Token(); err != nil {
-		return fixtureMutationError{FixtureMutationReasonMalformed}
+	if err := preflightFixtureArrayJSON(fields["profiles"], nil); err != nil {
+		return err
 	}
-	for key := range expected {
-		if _, ok := seen[key]; !ok {
-			return fixtureMutationError{FixtureMutationReasonMissing}
-		}
-	}
-	if decoder.More() {
-		return fixtureMutationError{FixtureMutationReasonMalformed}
+	if err := preflightFixtureArrayJSON(fields["records"], preflightFixtureRecordJSON); err != nil {
+		return err
 	}
 	return nil
 }
 
-func preflightFixtureArrayCardinality(decoder *json.Decoder) error {
+// preflightFixtureObjectJSON classifies every M2-03-owned object boundary
+// before the strict DTO decode. The DTO decode remains the authority for types
+// and canonical construction; this pass only preserves the closed mutation
+// reason contract without retaining unbounded object graphs.
+func preflightFixtureObjectJSON(data []byte, keys ...string) (map[string]json.RawMessage, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	expected := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		expected[key] = struct{}{}
+	}
+	fields := make(map[string]json.RawMessage, len(keys))
+	for decoder.More() {
+		token, err := decoder.Token()
+		key, ok := token.(string)
+		if err != nil || !ok {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		folded := strings.ToLower(key)
+		if _, duplicate := fields[folded]; duplicate {
+			if key == strings.ToLower(key) {
+				return nil, fixtureMutationError{FixtureMutationReasonDuplicate}
+			}
+			return nil, fixtureMutationError{FixtureMutationReasonCaseFolded}
+		}
+		if _, known := expected[key]; !known {
+			if _, foldedKnown := expected[folded]; foldedKnown {
+				return nil, fixtureMutationError{FixtureMutationReasonCaseFolded}
+			}
+			return nil, fixtureMutationError{FixtureMutationReasonUnknown}
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		fields[folded] = value
+	}
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim('}') {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	for key := range expected {
+		if _, present := fields[key]; !present {
+			return nil, fixtureMutationError{FixtureMutationReasonMissing}
+		}
+	}
+	return fields, nil
+}
+
+func preflightFixtureArrayJSON(data []byte, element func([]byte) error) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
 	token, err := decoder.Token()
 	if err != nil || token != json.Delim('[') {
 		return fixtureMutationError{FixtureMutationReasonMalformed}
@@ -850,9 +915,14 @@ func preflightFixtureArrayCardinality(decoder *json.Decoder) error {
 		if count == MaxProfileDependencies {
 			return fixtureMutationError{FixtureMutationReasonOversized}
 		}
-		var element json.RawMessage
-		if err := decoder.Decode(&element); err != nil {
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
 			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		if element != nil {
+			if err := element(value); err != nil {
+				return err
+			}
 		}
 		count++
 	}
@@ -926,46 +996,69 @@ func UnmarshalFixtureConformanceCorpus(data []byte) (*FixtureConformanceCorpus, 
 }
 
 func preflightFixtureRecordJSON(data []byte) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	token, err := decoder.Token()
-	if err != nil || token != json.Delim('{') {
-		return fixtureMutationError{FixtureMutationReasonMalformed}
+	fields, err := preflightFixtureObjectJSON(data, "record_id", "profile_id", "profile_version", "observation", "detection", "qualification", "expected_replay")
+	if err != nil {
+		return err
 	}
-	expected := map[string]struct{}{"record_id": {}, "profile_id": {}, "profile_version": {}, "observation": {}, "detection": {}, "qualification": {}, "expected_replay": {}}
-	seen := map[string]struct{}{}
-	for decoder.More() {
-		token, err := decoder.Token()
-		key, ok := token.(string)
-		if err != nil || !ok {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
-		}
-		folded := strings.ToLower(key)
-		if _, duplicate := seen[folded]; duplicate {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
-		}
-		seen[folded] = struct{}{}
-		if _, ok := expected[key]; !ok {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
-		}
-		var discard json.RawMessage
-		if err := decoder.Decode(&discard); err != nil {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
-		}
+	if err := preflightFixtureDetectionJSON(fields["detection"]); err != nil {
+		return err
 	}
-	if _, err := decoder.Token(); err != nil {
-		return fixtureMutationError{FixtureMutationReasonMalformed}
+	if _, err := preflightFixtureObjectJSON(fields["qualification"], "expected"); err != nil {
+		return err
 	}
-	for key := range expected {
-		if _, ok := seen[key]; !ok {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
-		}
+	_, err = preflightFixtureObjectJSON(fields["expected_replay"], "outcome", "reason", "expected_raw_words")
+	return err
+}
+
+func preflightFixtureDetectionJSON(data []byte) error {
+	fields, err := preflightFixtureObjectJSON(data, "declaration", "input", "expected")
+	if err != nil {
+		return err
 	}
-	return nil
+	if _, err := preflightFixtureObjectJSON(fields["declaration"], "detector_version", "plan", "candidates", "limits"); err != nil {
+		return err
+	}
+	input, err := preflightFixtureObjectJSON(fields["input"], "probes")
+	if err != nil {
+		return err
+	}
+	if err := preflightFixtureArrayJSON(input["probes"], preflightFixtureProbeJSON); err != nil {
+		return err
+	}
+	expected, err := preflightFixtureObjectJSON(fields["expected"], "outcome", "reason", "selected_profile_id", "selected_profile_version", "evidence")
+	if err != nil {
+		return err
+	}
+	return preflightFixtureArrayJSON(expected["evidence"], preflightFixtureDetectionEvidenceJSON)
+}
+
+func preflightFixtureProbeJSON(data []byte) error {
+	_, err := preflightFixtureObjectJSON(data, "declaration_id", "result")
+	return err
+}
+
+func preflightFixtureDetectionEvidenceJSON(data []byte) error {
+	_, err := preflightFixtureObjectJSON(data, "profile_id", "profile_version", "score", "reason", "matched_gates", "probe_evidence_ids", "detector_version", "qualification_version")
+	return err
 }
 
 type fixtureReportDTO struct {
-	Metadata SanitizedFixtureMetadata `json:"metadata"`
-	Records  []fixtureReportRecordDTO `json:"records"`
+	SchemaVersion Version                  `json:"schema_version"`
+	Metadata      SanitizedFixtureMetadata `json:"metadata"`
+	Records       []fixtureReportRecordDTO `json:"records"`
+}
+type fixtureDependencyFactDTO struct {
+	Ordinal    uint32                   `json:"ordinal"`
+	Function   FunctionCode             `json:"function"`
+	Table      LogicalTable             `json:"table"`
+	UnitID     byte                     `json:"unit_id"`
+	Normalized uint16                   `json:"normalized_address"`
+	RawWords   []uint16                 `json:"raw_words"`
+	Logical    []uint16                 `json:"logical_slice"`
+	Source     SourceTimeSpec           `json:"source_time"`
+	Wire       FixtureWireProvenance    `json:"wire"`
+	View       FixtureLogicalProvenance `json:"logical"`
+	Sample     FixtureSampleProvenance  `json:"sample"`
 }
 type fixtureReportRecordDTO struct {
 	RecordID       string                          `json:"record_id"`
@@ -979,6 +1072,7 @@ type fixtureReportRecordDTO struct {
 	Normalized     uint16                          `json:"normalized_address"`
 	RawWords       [][]uint16                      `json:"raw_words,omitempty"`
 	LogicalSlices  [][]uint16                      `json:"logical_slices,omitempty"`
+	Dependencies   []fixtureDependencyFactDTO      `json:"dependencies"`
 	Wire           FixtureWireProvenance           `json:"wire"`
 	Logical        FixtureLogicalProvenance        `json:"logical"`
 	Sample         FixtureSampleProvenance         `json:"sample"`
@@ -992,14 +1086,18 @@ func (corpus *FixtureConformanceCorpus) MarshalBoundedReport() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	dto := fixtureReportDTO{Metadata: report.metadata, Records: make([]fixtureReportRecordDTO, len(report.records))}
+	dto := fixtureReportDTO{SchemaVersion: schemaVersionV1, Metadata: report.metadata, Records: make([]fixtureReportRecordDTO, len(report.records))}
 	for i, record := range report.records {
 		slices := make([][]uint16, len(record.slices))
 		for index, slice := range record.slices {
 			slices[index] = append([]uint16(nil), slice.words...)
 		}
 		decision := detectionDecisionToDTO(record.detection.Actual)
-		dto.Records[i] = fixtureReportRecordDTO{RecordID: record.recordID, ProfileID: record.profileID, ProfileVersion: record.profileVersion, Outcome: record.replay.actual.outcome, Reason: record.replay.actual.reason, Function: record.function, Table: record.table, UnitID: record.unit, Normalized: record.normalized, RawWords: cloneWordSets(record.replay.actual.rawWords), LogicalSlices: slices, Wire: record.wire, Logical: record.logical, Sample: record.sample, Source: record.source, Qualification: record.qualification, Detection: decision}
+		dependencies := make([]fixtureDependencyFactDTO, len(record.dependencies))
+		for index, fact := range record.dependencies {
+			dependencies[index] = fixtureDependencyFactDTO{Ordinal: fact.ordinal, Function: fact.function, Table: fact.table, UnitID: fact.unit, Normalized: fact.normalized, RawWords: append([]uint16(nil), fact.rawWords...), Logical: append([]uint16(nil), fact.slice.words...), Source: fact.source, Wire: fact.wire, View: fact.logical, Sample: fact.sample}
+		}
+		dto.Records[i] = fixtureReportRecordDTO{RecordID: record.recordID, ProfileID: record.profileID, ProfileVersion: record.profileVersion, Outcome: record.replay.actual.outcome, Reason: record.replay.actual.reason, Function: record.function, Table: record.table, UnitID: record.unit, Normalized: record.normalized, RawWords: cloneWordSets(record.replay.actual.rawWords), LogicalSlices: slices, Dependencies: dependencies, Wire: record.wire, Logical: record.logical, Sample: record.sample, Source: record.source, Qualification: record.qualification, Detection: decision}
 	}
 	encoded, err := marshalBounded(dto)
 	if err != nil {

--- a/fixture_conformance.go
+++ b/fixture_conformance.go
@@ -224,7 +224,11 @@ func validateFixtureSanitization(record FixtureConformanceRecordSpec) error {
 		return fixtureMutationError{FixtureMutationReasonUnsanitized}
 	}
 	for _, dependency := range record.Observation.Dependencies {
-		if !validFixtureIdentity(dependency.View.Record().Endpoint) || dependency.View.Record().Endpoint != record.Observation.Endpoint {
+		if !validFixtureIdentity(dependency.View.Record().Endpoint) {
+			return fixtureMutationError{FixtureMutationReasonUnsanitized}
+		}
+		if dependency.View.Record().Endpoint != record.Observation.Endpoint &&
+			(record.ExpectedReplay.Outcome != FixtureReplayRejected || record.ExpectedReplay.Reason != FixtureReplayReasonSourceMismatch) {
 			return fixtureMutationError{FixtureMutationReasonUnsanitized}
 		}
 	}
@@ -287,9 +291,6 @@ func NewFixtureConformanceCorpusWithLimits(spec FixtureConformanceCorpusSpec, li
 }
 
 func validateFixtureRecordDeclaration(catalog Catalog, profile ProfileDescriptor, record FixtureConformanceRecordSpec) error {
-	if record.Qualification.Expected != FixtureQualificationDispositionQualified || profile.Spec().Maturity != MaturityQualified {
-		return fixtureMutationError{FixtureMutationReasonContradictory}
-	}
 	detector, err := newFixtureDetector(catalog, record.Detection.Declaration)
 	if err != nil {
 		return fixtureMutationError{FixtureMutationReasonMalformed}
@@ -304,6 +305,18 @@ func validateFixtureRecordDeclaration(catalog Catalog, profile ProfileDescriptor
 	decision, err := detector.Detect(context.Background(), reader, DetectionOptions{})
 	if err != nil || !(FixtureDetectionResult{Actual: decision, expected: record.Detection.Expected}).MatchesExpected() {
 		return fixtureMutationError{FixtureMutationReasonContradictory}
+	}
+	switch record.Qualification.Expected {
+	case FixtureQualificationDispositionQualified:
+		if profile.Spec().Maturity != MaturityQualified || decision.Outcome() != DetectionMatched {
+			return fixtureMutationError{FixtureMutationReasonContradictory}
+		}
+	case FixtureQualificationDispositionRejected:
+		if profile.Spec().Maturity == MaturityQualified || decision.Outcome() != DetectionNoMatch || decision.Reason() != DetectionReasonProfileUnqualified {
+			return fixtureMutationError{FixtureMutationReasonContradictory}
+		}
+	default:
+		return fixtureMutationError{FixtureMutationReasonMalformed}
 	}
 	if record.ExpectedReplay.Outcome != FixtureReplayAccepted && record.ExpectedReplay.Outcome != FixtureReplayRejected {
 		return fixtureMutationError{FixtureMutationReasonMalformed}
@@ -391,6 +404,8 @@ func classifyFixtureObservation(profile ProfileDescriptor, spec ObservationSpec)
 	if len(spec.Dependencies) != len(declarations) {
 		return FixtureReplayReasonObservationRejected
 	}
+	policy := profile.Spec().Coherence
+	firstView := spec.Dependencies[0].View.Record()
 	for i, dependency := range spec.Dependencies {
 		view := dependency.View.Record()
 		if dependency.Status == DependencyReadTorn {
@@ -402,6 +417,13 @@ func classifyFixtureObservation(profile ProfileDescriptor, spec ObservationSpec)
 		if view.UnitID != spec.UnitID {
 			return FixtureReplayReasonUnitMismatch
 		}
+		if policy.Mode == CoherenceBoundedMultiResponse &&
+			(view.Endpoint != firstView.Endpoint ||
+				view.ConnectionID != firstView.ConnectionID ||
+				view.Transport != firstView.Transport ||
+				(policy.RequireGenerationEquality && view.TransportGeneration != firstView.TransportGeneration)) {
+			return FixtureReplayReasonSourceMismatch
+		}
 		if view.PollGeneration != spec.PollGenerationID {
 			return FixtureReplayReasonGenerationMismatch
 		}
@@ -411,12 +433,10 @@ func classifyFixtureObservation(profile ProfileDescriptor, spec ObservationSpec)
 		if view.Table != declarations[i].Table() || (view.Table == HoldingRegisters && view.RequestedFunction != FunctionReadHoldingRegisters) || (view.Table == InputRegisters && view.RequestedFunction != FunctionReadInputRegisters) || view.RequestedFunction != view.ReceivedFunction {
 			return FixtureReplayReasonTableAccessMismatch
 		}
-		if profile.Spec().Coherence.Mode == CoherenceSingleWireResponse {
+		if policy.Mode == CoherenceSingleWireResponse {
 			if dependency.SourceTime.State != SourceTimeUnavailableState || !dependency.SourceTime.Time.IsZero() {
 				return FixtureReplayReasonSourceMismatch
 			}
-		} else if !sourceTimesEqual(dependency.SourceTime, spec.SourceTime) {
-			return FixtureReplayReasonSourceMismatch
 		}
 		if dependency.DocumentaryConsistencyMarker != spec.Dependencies[0].DocumentaryConsistencyMarker {
 			return FixtureReplayReasonCoherenceMismatch
@@ -795,9 +815,15 @@ func preflightFixtureCorpusJSON(data []byte) error {
 			}
 			return fixtureMutationError{FixtureMutationReasonUnknown}
 		}
-		var discard json.RawMessage
-		if err := decoder.Decode(&discard); err != nil {
-			return fixtureMutationError{FixtureMutationReasonMalformed}
+		if key == "profiles" || key == "records" {
+			if err := preflightFixtureArrayCardinality(decoder); err != nil {
+				return err
+			}
+		} else {
+			var discard json.RawMessage
+			if err := decoder.Decode(&discard); err != nil {
+				return fixtureMutationError{FixtureMutationReasonMalformed}
+			}
 		}
 	}
 	if _, err := decoder.Token(); err != nil {
@@ -809,6 +835,29 @@ func preflightFixtureCorpusJSON(data []byte) error {
 		}
 	}
 	if decoder.More() {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	return nil
+}
+
+func preflightFixtureArrayCardinality(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('[') {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	count := 0
+	for decoder.More() {
+		if count == MaxProfileDependencies {
+			return fixtureMutationError{FixtureMutationReasonOversized}
+		}
+		var element json.RawMessage
+		if err := decoder.Decode(&element); err != nil {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		count++
+	}
+	closing, err := decoder.Token()
+	if err != nil || closing != json.Delim(']') {
 		return fixtureMutationError{FixtureMutationReasonMalformed}
 	}
 	return nil

--- a/fixture_conformance.go
+++ b/fixture_conformance.go
@@ -1,0 +1,963 @@
+package modbusreg
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FixtureMutationReason is the closed construction/decoding rejection set.
+type FixtureMutationReason string
+
+const (
+	FixtureMutationReasonMissing       FixtureMutationReason = "missing"
+	FixtureMutationReasonUnknown       FixtureMutationReason = "unknown"
+	FixtureMutationReasonDuplicate     FixtureMutationReason = "duplicate"
+	FixtureMutationReasonCaseFolded    FixtureMutationReason = "case_folded"
+	FixtureMutationReasonMalformed     FixtureMutationReason = "malformed"
+	FixtureMutationReasonOversized     FixtureMutationReason = "oversized"
+	FixtureMutationReasonContradictory FixtureMutationReason = "contradictory"
+	FixtureMutationReasonUnsanitized   FixtureMutationReason = "unsanitized"
+)
+
+type fixtureMutationError struct{ reason FixtureMutationReason }
+
+func (err fixtureMutationError) Error() string {
+	return "fixture corpus rejected: " + string(err.reason)
+}
+
+// IsFixtureMutationReason reports a stable M2-03 rejection classification.
+func IsFixtureMutationReason(err error, reason FixtureMutationReason) bool {
+	var classified fixtureMutationError
+	return errors.As(err, &classified) && classified.reason == reason
+}
+
+// FixtureConformanceLimits bounds corpus-owned allocations.
+type FixtureConformanceLimits struct {
+	MaxRecords     int
+	MaxReportBytes int
+}
+
+func defaultFixtureConformanceLimits() FixtureConformanceLimits {
+	return FixtureConformanceLimits{MaxRecords: MaxProfileDependencies, MaxReportBytes: MaxSerializedContractBytes}
+}
+
+func validateFixtureConformanceLimits(limits FixtureConformanceLimits) error {
+	if limits.MaxRecords <= 0 || limits.MaxRecords > MaxProfileDependencies || limits.MaxReportBytes <= 0 || limits.MaxReportBytes > MaxSerializedContractBytes {
+		return fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	return nil
+}
+
+// SanitizedFixtureMetadata is deliberately limited to public corpus identity.
+type SanitizedFixtureMetadata struct {
+	CorpusID          string `json:"corpus_id"`
+	LicenseExpression string `json:"license_expression"`
+	Provenance        string `json:"provenance"`
+}
+
+// FixtureDetectorDeclarationSpec is the serializable input used to rebuild an
+// existing ProfileDetector against the immutable corpus catalog.
+type FixtureDetectorDeclarationSpec struct {
+	DetectorVersion Version                  `json:"detector_version"`
+	Plan            ProbePlanSpec            `json:"plan"`
+	Candidates      []DetectionCandidateSpec `json:"candidates"`
+	Limits          DetectionLimits          `json:"limits"`
+}
+
+type FixtureProbeInput struct {
+	DeclarationID string              `json:"declaration_id"`
+	Result        ProbeReadResultSpec `json:"result"`
+}
+
+type FixtureDetectorInput struct {
+	Probes []FixtureProbeInput `json:"probes"`
+}
+
+type FixtureDetectionEvidenceExpectation struct {
+	ProfileID            string               `json:"profile_id"`
+	ProfileVersion       Version              `json:"profile_version"`
+	Score                uint32               `json:"score"`
+	Reason               DetectionReason      `json:"reason"`
+	MatchedGates         []ProbeIdentityField `json:"matched_gates"`
+	ProbeEvidenceIDs     []string             `json:"probe_evidence_ids"`
+	DetectorVersion      Version              `json:"detector_version"`
+	QualificationVersion Version              `json:"qualification_version"`
+}
+
+type FixtureDetectionExpectation struct {
+	Outcome                DetectionOutcome                      `json:"outcome"`
+	Reason                 DetectionReason                       `json:"reason"`
+	SelectedProfileID      string                                `json:"selected_profile_id"`
+	SelectedProfileVersion Version                               `json:"selected_profile_version"`
+	Evidence               []FixtureDetectionEvidenceExpectation `json:"evidence"`
+}
+
+type FixtureDetectionCaseSpec struct {
+	Declaration FixtureDetectorDeclarationSpec `json:"declaration"`
+	Input       FixtureDetectorInput           `json:"input"`
+	Expected    FixtureDetectionExpectation    `json:"expected"`
+}
+
+type FixtureQualificationDisposition string
+
+const (
+	FixtureQualificationDispositionQualified FixtureQualificationDisposition = "qualified"
+	FixtureQualificationDispositionRejected  FixtureQualificationDisposition = "rejected"
+)
+
+type FixtureQualificationExpectation struct {
+	Expected FixtureQualificationDisposition `json:"expected"`
+}
+
+type FixtureReplayOutcome string
+
+const (
+	FixtureReplayAccepted FixtureReplayOutcome = "accepted"
+	FixtureReplayRejected FixtureReplayOutcome = "rejected"
+)
+
+type FixtureReplayReason string
+
+const (
+	FixtureReplayReasonAccepted              FixtureReplayReason = "accepted"
+	FixtureReplayReasonUnitMismatch          FixtureReplayReason = "unit_mismatch"
+	FixtureReplayReasonTableAccessMismatch   FixtureReplayReason = "table_access_mismatch"
+	FixtureReplayReasonGenerationMismatch    FixtureReplayReason = "generation_mismatch"
+	FixtureReplayReasonSourceMismatch        FixtureReplayReason = "source_mismatch"
+	FixtureReplayReasonNormalizationMismatch FixtureReplayReason = "normalization_mismatch"
+	FixtureReplayReasonDeadlineMismatch      FixtureReplayReason = "deadline_mismatch"
+	FixtureReplayReasonCoherenceMismatch     FixtureReplayReason = "coherence_mismatch"
+	FixtureReplayReasonTornRead              FixtureReplayReason = "torn_read"
+	FixtureReplayReasonObservationRejected   FixtureReplayReason = "observation_rejected"
+)
+
+type FixtureReplayExpectation struct {
+	Outcome          FixtureReplayOutcome `json:"outcome"`
+	Reason           FixtureReplayReason  `json:"reason"`
+	ExpectedRawWords [][]uint16           `json:"expected_raw_words,omitempty"`
+}
+
+type FixtureConformanceRecordSpec struct {
+	RecordID       string                          `json:"record_id"`
+	ProfileID      string                          `json:"profile_id"`
+	ProfileVersion Version                         `json:"profile_version"`
+	Observation    ObservationSpec                 `json:"observation"`
+	Detection      FixtureDetectionCaseSpec        `json:"detection"`
+	Qualification  FixtureQualificationExpectation `json:"qualification"`
+	ExpectedReplay FixtureReplayExpectation        `json:"expected_replay"`
+}
+
+type FixtureConformanceCorpusSpec struct {
+	SchemaVersion Version                        `json:"schema_version"`
+	Metadata      SanitizedFixtureMetadata       `json:"metadata"`
+	Profiles      []ProfileDescriptor            `json:"profiles"`
+	Records       []FixtureConformanceRecordSpec `json:"records"`
+}
+
+type FixtureConformanceCorpus struct {
+	spec    FixtureConformanceCorpusSpec
+	catalog Catalog
+	limits  FixtureConformanceLimits
+}
+
+func cloneFixtureCorpusSpec(spec FixtureConformanceCorpusSpec) FixtureConformanceCorpusSpec {
+	spec.Profiles = append([]ProfileDescriptor(nil), spec.Profiles...)
+	for i := range spec.Profiles {
+		spec.Profiles[i], _ = NewProfileDescriptor(spec.Profiles[i].Spec())
+	}
+	spec.Records = append([]FixtureConformanceRecordSpec(nil), spec.Records...)
+	for i := range spec.Records {
+		spec.Records[i] = cloneFixtureRecordSpec(spec.Records[i])
+	}
+	return spec
+}
+
+func cloneFixtureRecordSpec(record FixtureConformanceRecordSpec) FixtureConformanceRecordSpec {
+	record.Observation = cloneObservationSpec(record.Observation)
+	record.Detection.Declaration.Plan = cloneProbePlanSpec(record.Detection.Declaration.Plan)
+	record.Detection.Declaration.Candidates = append([]DetectionCandidateSpec(nil), record.Detection.Declaration.Candidates...)
+	record.Detection.Input.Probes = append([]FixtureProbeInput(nil), record.Detection.Input.Probes...)
+	for i := range record.Detection.Input.Probes {
+		record.Detection.Input.Probes[i].Result.Words = append([]uint16(nil), record.Detection.Input.Probes[i].Result.Words...)
+	}
+	record.Detection.Expected.Evidence = append([]FixtureDetectionEvidenceExpectation(nil), record.Detection.Expected.Evidence...)
+	for i := range record.Detection.Expected.Evidence {
+		record.Detection.Expected.Evidence[i].MatchedGates = append([]ProbeIdentityField(nil), record.Detection.Expected.Evidence[i].MatchedGates...)
+		record.Detection.Expected.Evidence[i].ProbeEvidenceIDs = cloneStrings(record.Detection.Expected.Evidence[i].ProbeEvidenceIDs)
+	}
+	record.ExpectedReplay.ExpectedRawWords = cloneWordSets(record.ExpectedReplay.ExpectedRawWords)
+	return record
+}
+
+func cloneWordSets(values [][]uint16) [][]uint16 {
+	result := make([][]uint16, len(values))
+	for i := range values {
+		result[i] = append([]uint16(nil), values[i]...)
+	}
+	return result
+}
+
+func validFixtureIdentity(value string) bool {
+	return validIdentity(value) && (strings.HasPrefix(value, "fixture-") || strings.HasPrefix(value, "fixture:"))
+}
+
+func validateSanitizedMetadata(metadata SanitizedFixtureMetadata) error {
+	if validateBoundedString("fixture corpus ID", metadata.CorpusID, true) != nil ||
+		validateBoundedString("fixture license expression", metadata.LicenseExpression, true) != nil ||
+		validateBoundedString("fixture provenance", metadata.Provenance, true) != nil {
+		return fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	if !validIdentity(metadata.CorpusID) || metadata.LicenseExpression != "CC0-1.0" || metadata.Provenance != "public synthetic fixture" {
+		return fixtureMutationError{FixtureMutationReasonUnsanitized}
+	}
+	return nil
+}
+
+func validateFixtureSanitization(record FixtureConformanceRecordSpec) error {
+	if !validFixtureIdentity(record.Observation.Endpoint) {
+		return fixtureMutationError{FixtureMutationReasonUnsanitized}
+	}
+	for _, dependency := range record.Observation.Dependencies {
+		if !validFixtureIdentity(dependency.View.Record().Endpoint) || dependency.View.Record().Endpoint != record.Observation.Endpoint {
+			return fixtureMutationError{FixtureMutationReasonUnsanitized}
+		}
+	}
+	return nil
+}
+
+// NewFixtureConformanceCorpus constructs immutable offline evidence only.
+func NewFixtureConformanceCorpus(spec FixtureConformanceCorpusSpec) (*FixtureConformanceCorpus, error) {
+	return NewFixtureConformanceCorpusWithLimits(spec, defaultFixtureConformanceLimits())
+}
+
+func NewFixtureConformanceCorpusWithLimits(spec FixtureConformanceCorpusSpec, limits FixtureConformanceLimits) (*FixtureConformanceCorpus, error) {
+	if err := validateFixtureConformanceLimits(limits); err != nil {
+		return nil, err
+	}
+	if err := preflightAggregate(spec); err != nil {
+		return nil, fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	if len(spec.Profiles) > limits.MaxRecords || len(spec.Records) > limits.MaxRecords {
+		return nil, fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	if spec.SchemaVersion != schemaVersionV1 || len(spec.Profiles) == 0 || len(spec.Records) == 0 {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	if err := validateSanitizedMetadata(spec.Metadata); err != nil {
+		return nil, err
+	}
+	catalog, err := NewCatalog(spec.Profiles...)
+	if err != nil {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	copy := cloneFixtureCorpusSpec(spec)
+	seen := make(map[string]struct{}, len(copy.Records))
+	profiles := make(map[string]ProfileDescriptor, len(copy.Profiles))
+	for _, profile := range copy.Profiles {
+		profiles[profile.ID()] = profile
+	}
+	for _, record := range copy.Records {
+		if !validIdentity(record.RecordID) || !validIdentity(record.ProfileID) || !record.ProfileVersion.valid() {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		if _, ok := seen[strings.ToLower(record.RecordID)]; ok {
+			return nil, fixtureMutationError{FixtureMutationReasonDuplicate}
+		}
+		seen[strings.ToLower(record.RecordID)] = struct{}{}
+		profile, ok := profiles[record.ProfileID]
+		if !ok || profile.Version() != record.ProfileVersion {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		if err := validateFixtureSanitization(record); err != nil {
+			return nil, err
+		}
+		if err := validateFixtureRecordDeclaration(catalog, profile, record); err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(copy.Profiles, func(i, j int) bool { return copy.Profiles[i].ID() < copy.Profiles[j].ID() })
+	sort.Slice(copy.Records, func(i, j int) bool { return copy.Records[i].RecordID < copy.Records[j].RecordID })
+	return &FixtureConformanceCorpus{spec: copy, catalog: catalog, limits: limits}, nil
+}
+
+func validateFixtureRecordDeclaration(catalog Catalog, profile ProfileDescriptor, record FixtureConformanceRecordSpec) error {
+	if record.Qualification.Expected != FixtureQualificationDispositionQualified || profile.Spec().Maturity != MaturityQualified {
+		return fixtureMutationError{FixtureMutationReasonContradictory}
+	}
+	detector, err := newFixtureDetector(catalog, record.Detection.Declaration)
+	if err != nil {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	if err := validateFixtureProbeSet(record.Detection.Input, record.Detection.Declaration.Plan); err != nil {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	reader, err := fixtureReader(record.Detection.Input)
+	if err != nil {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	decision, err := detector.Detect(context.Background(), reader, DetectionOptions{})
+	if err != nil || !(FixtureDetectionResult{Actual: decision, expected: record.Detection.Expected}).MatchesExpected() {
+		return fixtureMutationError{FixtureMutationReasonContradictory}
+	}
+	if record.ExpectedReplay.Outcome != FixtureReplayAccepted && record.ExpectedReplay.Outcome != FixtureReplayRejected {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	replay, err := actualFixtureReplay(profile, record.Observation)
+	if err != nil {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	if !(FixtureReplayResult{actual: replay, expected: record.ExpectedReplay}).MatchesExpected() {
+		return fixtureMutationError{FixtureMutationReasonContradictory}
+	}
+	return nil
+}
+
+func newFixtureDetector(catalog Catalog, declaration FixtureDetectorDeclarationSpec) (*ProfileDetector, error) {
+	plan, err := NewProbePlan(declaration.Plan, declaration.Limits)
+	if err != nil {
+		return nil, err
+	}
+	candidates := make([]DetectionCandidate, len(declaration.Candidates))
+	for index, spec := range declaration.Candidates {
+		candidate, candidateErr := NewDetectionCandidate(spec, declaration.Limits)
+		if candidateErr != nil {
+			return nil, candidateErr
+		}
+		candidates[index] = candidate
+	}
+	return NewProfileDetector(ProfileDetectorSpec{DetectorVersion: declaration.DetectorVersion, Plan: plan, Catalog: catalog, Candidates: candidates, Limits: declaration.Limits})
+}
+
+func (corpus *FixtureConformanceCorpus) Spec() FixtureConformanceCorpusSpec {
+	if corpus == nil {
+		return FixtureConformanceCorpusSpec{}
+	}
+	return cloneFixtureCorpusSpec(corpus.spec)
+}
+
+type fixtureProbeReader struct{ results map[string]ProbeReadResult }
+
+func (reader fixtureProbeReader) ReadProbe(_ context.Context, request ProbeReadRequest) (ProbeReadResult, error) {
+	result, ok := reader.results[request.DeclarationID()]
+	if !ok {
+		return ProbeReadResult{}, fmt.Errorf("fixture probe absent")
+	}
+	return result, nil
+}
+
+func fixtureReader(input FixtureDetectorInput) (fixtureProbeReader, error) {
+	reader := fixtureProbeReader{results: make(map[string]ProbeReadResult, len(input.Probes))}
+	for _, probe := range input.Probes {
+		if _, exists := reader.results[probe.DeclarationID]; exists {
+			return fixtureProbeReader{}, fmt.Errorf("duplicate fixture probe")
+		}
+		result, err := NewProbeReadResult(probe.Result)
+		if err != nil {
+			return fixtureProbeReader{}, err
+		}
+		reader.results[probe.DeclarationID] = result
+	}
+	return reader, nil
+}
+
+func validateFixtureProbeSet(input FixtureDetectorInput, plan ProbePlanSpec) error {
+	if len(input.Probes) != len(plan.Declarations) {
+		return fmt.Errorf("fixture probe set is incomplete")
+	}
+	expected := make(map[string]struct{}, len(plan.Declarations))
+	for _, declaration := range plan.Declarations {
+		expected[declaration.ID] = struct{}{}
+	}
+	for _, probe := range input.Probes {
+		if _, ok := expected[probe.DeclarationID]; !ok {
+			return fmt.Errorf("fixture probe is undeclared")
+		}
+		delete(expected, probe.DeclarationID)
+	}
+	if len(expected) != 0 {
+		return fmt.Errorf("fixture probe set is incomplete")
+	}
+	return nil
+}
+
+func classifyFixtureObservation(profile ProfileDescriptor, spec ObservationSpec) FixtureReplayReason {
+	declarations := profile.Dependencies().Dependencies()
+	if len(spec.Dependencies) != len(declarations) {
+		return FixtureReplayReasonObservationRejected
+	}
+	for i, dependency := range spec.Dependencies {
+		view := dependency.View.Record()
+		if dependency.Status == DependencyReadTorn {
+			return FixtureReplayReasonTornRead
+		}
+		if dependency.NormalizationVersion != declarations[i].Normalization().Spec().Version {
+			return FixtureReplayReasonNormalizationMismatch
+		}
+		if view.UnitID != spec.UnitID {
+			return FixtureReplayReasonUnitMismatch
+		}
+		if view.PollGeneration != spec.PollGenerationID {
+			return FixtureReplayReasonGenerationMismatch
+		}
+		if view.DeadlineIdentity != spec.Dependencies[0].View.Record().DeadlineIdentity {
+			return FixtureReplayReasonDeadlineMismatch
+		}
+		if view.Table != declarations[i].Table() || (view.Table == HoldingRegisters && view.RequestedFunction != FunctionReadHoldingRegisters) || (view.Table == InputRegisters && view.RequestedFunction != FunctionReadInputRegisters) || view.RequestedFunction != view.ReceivedFunction {
+			return FixtureReplayReasonTableAccessMismatch
+		}
+		if profile.Spec().Coherence.Mode == CoherenceSingleWireResponse {
+			if dependency.SourceTime.State != SourceTimeUnavailableState || !dependency.SourceTime.Time.IsZero() {
+				return FixtureReplayReasonSourceMismatch
+			}
+		} else if !sourceTimesEqual(dependency.SourceTime, spec.SourceTime) {
+			return FixtureReplayReasonSourceMismatch
+		}
+		if dependency.DocumentaryConsistencyMarker != spec.Dependencies[0].DocumentaryConsistencyMarker {
+			return FixtureReplayReasonCoherenceMismatch
+		}
+	}
+	encoded, err := MarshalFixtureSpec(spec)
+	if err != nil {
+		return FixtureReplayReasonObservationRejected
+	}
+	replayer, err := NewFixtureReplayer(profile)
+	if err != nil {
+		return FixtureReplayReasonObservationRejected
+	}
+	if _, err := replayer.Replay(encoded); err != nil {
+		return FixtureReplayReasonObservationRejected
+	}
+	return FixtureReplayReasonAccepted
+}
+
+func actualFixtureReplay(
+	profile ProfileDescriptor,
+	spec ObservationSpec,
+) (FixtureReplayActual, error) {
+	reason := classifyFixtureObservation(profile, spec)
+	actual := FixtureReplayActual{
+		outcome:  FixtureReplayRejected,
+		reason:   reason,
+		rawWords: make([][]uint16, len(spec.Dependencies)),
+	}
+	for index, dependency := range spec.Dependencies {
+		actual.rawWords[index] = dependency.View.Record().Words
+	}
+	if reason != FixtureReplayReasonAccepted {
+		return actual, nil
+	}
+	encoded, err := MarshalFixtureSpec(spec)
+	if err != nil {
+		return FixtureReplayActual{}, err
+	}
+	replayer, err := NewFixtureReplayer(profile)
+	if err != nil {
+		return FixtureReplayActual{}, err
+	}
+	replay, err := replayer.Replay(encoded)
+	if err != nil {
+		return FixtureReplayActual{}, err
+	}
+	dependencies := replay.Replay()
+	if len(dependencies) != len(actual.rawWords) {
+		return FixtureReplayActual{}, fmt.Errorf("fixture replay dependency count changed")
+	}
+	actual.outcome = FixtureReplayAccepted
+	for index, dependency := range dependencies {
+		actual.rawWords[index] = dependency.RawWords()
+	}
+	return actual, nil
+}
+
+type FixtureReplayActual struct {
+	outcome  FixtureReplayOutcome
+	reason   FixtureReplayReason
+	rawWords [][]uint16
+}
+
+func (actual FixtureReplayActual) Outcome() FixtureReplayOutcome { return actual.outcome }
+func (actual FixtureReplayActual) Reason() FixtureReplayReason   { return actual.reason }
+
+type FixtureReplayResult struct {
+	actual   FixtureReplayActual
+	expected FixtureReplayExpectation
+}
+
+func (result FixtureReplayResult) Actual() FixtureReplayActual {
+	actual := result.actual
+	actual.rawWords = cloneWordSets(actual.rawWords)
+	return actual
+}
+func (result FixtureReplayResult) Expected() FixtureReplayExpectation {
+	expected := result.expected
+	expected.ExpectedRawWords = cloneWordSets(expected.ExpectedRawWords)
+	return expected
+}
+func (result FixtureReplayResult) MatchesExpected() bool {
+	return result.actual.outcome == result.expected.Outcome && result.actual.reason == result.expected.Reason && (result.actual.outcome == FixtureReplayRejected || reflectWordSetsEqual(result.actual.rawWords, result.expected.ExpectedRawWords))
+}
+func reflectWordSetsEqual(first, second [][]uint16) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for i := range first {
+		if !slicesEqual(first[i], second[i]) {
+			return false
+		}
+	}
+	return true
+}
+func slicesEqual(first, second []uint16) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type FixtureDetectionResult struct {
+	Actual   DetectionDecision
+	expected FixtureDetectionExpectation
+}
+
+func (result FixtureDetectionResult) MatchesExpected() bool {
+	if result.Actual.Outcome() != result.expected.Outcome || result.Actual.Reason() != result.expected.Reason || result.Actual.SelectedProfileID() != result.expected.SelectedProfileID || result.Actual.SelectedProfileVersion() != result.expected.SelectedProfileVersion {
+		return false
+	}
+	evidence := result.Actual.Evidence()
+	if len(evidence) != len(result.expected.Evidence) {
+		return false
+	}
+	for i := range evidence {
+		want := result.expected.Evidence[i]
+		if evidence[i].ProfileID != want.ProfileID || evidence[i].ProfileVersion != want.ProfileVersion || evidence[i].Score != want.Score || evidence[i].Reason != want.Reason || evidence[i].DetectorVersion != want.DetectorVersion || evidence[i].QualificationVersion != want.QualificationVersion || !probeFieldsEqual(evidence[i].MatchedGates, want.MatchedGates) || !stringSlicesEqual(evidence[i].ProbeEvidenceIDs, want.ProbeEvidenceIDs) {
+			return false
+		}
+	}
+	return true
+}
+func probeFieldsEqual(first, second []ProbeIdentityField) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+	return true
+}
+func stringSlicesEqual(first, second []string) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			return false
+		}
+	}
+	return true
+}
+
+type FixtureWireProvenance struct{ WireResponseID uint64 }
+type FixtureLogicalProvenance struct{ LogicalViewID uint64 }
+type FixtureSampleProvenance struct{ PollGenerationID uint64 }
+type FixtureLogicalSlice struct{ words []uint16 }
+
+func (slice FixtureLogicalSlice) CanonicalBytes() []byte {
+	result := make([]byte, len(slice.words)*2)
+	for i, word := range slice.words {
+		binary.BigEndian.PutUint16(result[i*2:], word)
+	}
+	return result
+}
+
+type FixtureConformanceRecord struct {
+	recordID, profileID string
+	profileVersion      Version
+	function            FunctionCode
+	table               LogicalTable
+	unit                byte
+	normalized          uint16
+	rawWords            []uint16
+	source              SourceTimeSpec
+	wire                FixtureWireProvenance
+	logical             FixtureLogicalProvenance
+	sample              FixtureSampleProvenance
+	slices              []FixtureLogicalSlice
+	detection           FixtureDetectionResult
+	qualification       FixtureQualificationDisposition
+	replay              FixtureReplayResult
+}
+
+func (record FixtureConformanceRecord) RecordID() string           { return record.recordID }
+func (record FixtureConformanceRecord) ProfileID() string          { return record.profileID }
+func (record FixtureConformanceRecord) ProfileVersion() Version    { return record.profileVersion }
+func (record FixtureConformanceRecord) FunctionCode() FunctionCode { return record.function }
+func (record FixtureConformanceRecord) Table() LogicalTable        { return record.table }
+func (record FixtureConformanceRecord) UnitID() byte               { return record.unit }
+func (record FixtureConformanceRecord) NormalizedAddress() uint16  { return record.normalized }
+func (record FixtureConformanceRecord) RawWords() []uint16 {
+	return append([]uint16(nil), record.rawWords...)
+}
+func (record FixtureConformanceRecord) SourceTime() SourceTimeSpec            { return record.source }
+func (record FixtureConformanceRecord) WireProvenance() FixtureWireProvenance { return record.wire }
+func (record FixtureConformanceRecord) LogicalProvenance() FixtureLogicalProvenance {
+	return record.logical
+}
+func (record FixtureConformanceRecord) SampleProvenance() FixtureSampleProvenance {
+	return record.sample
+}
+func (record FixtureConformanceRecord) LogicalSlices() []FixtureLogicalSlice {
+	result := make([]FixtureLogicalSlice, len(record.slices))
+	for i := range record.slices {
+		result[i].words = append([]uint16(nil), record.slices[i].words...)
+	}
+	return result
+}
+func (record FixtureConformanceRecord) Detection() FixtureDetectionResult { return record.detection }
+func (record FixtureConformanceRecord) Qualification() FixtureQualificationDisposition {
+	return record.qualification
+}
+func (record FixtureConformanceRecord) Replay() FixtureReplayResult { return record.replay }
+
+type FixtureConformanceReport struct {
+	metadata SanitizedFixtureMetadata
+	records  []FixtureConformanceRecord
+}
+
+func (report FixtureConformanceReport) Metadata() SanitizedFixtureMetadata { return report.metadata }
+func (report FixtureConformanceReport) Records() []FixtureConformanceRecord {
+	return append([]FixtureConformanceRecord(nil), report.records...)
+}
+func (report FixtureConformanceReport) RecordCount() int { return len(report.records) }
+func (report FixtureConformanceReport) RejectedCount() int {
+	count := 0
+	for _, record := range report.records {
+		if record.replay.actual.outcome == FixtureReplayRejected {
+			count++
+		}
+	}
+	return count
+}
+
+func (corpus *FixtureConformanceCorpus) Replay() (FixtureConformanceReport, error) {
+	if corpus == nil {
+		return FixtureConformanceReport{}, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	records := make([]FixtureConformanceRecord, len(corpus.spec.Records))
+	profiles := make(map[string]ProfileDescriptor, len(corpus.spec.Profiles))
+	for _, profile := range corpus.spec.Profiles {
+		profiles[profile.ID()] = profile
+	}
+	for i, spec := range corpus.spec.Records {
+		record, err := replayFixtureRecord(corpus.catalog, profiles[spec.ProfileID], spec)
+		if err != nil {
+			return FixtureConformanceReport{}, err
+		}
+		records[i] = record
+	}
+	sort.Slice(records, func(i, j int) bool { return records[i].recordID < records[j].recordID })
+	return FixtureConformanceReport{metadata: corpus.spec.Metadata, records: records}, nil
+}
+
+func replayFixtureRecord(catalog Catalog, profile ProfileDescriptor, spec FixtureConformanceRecordSpec) (FixtureConformanceRecord, error) {
+	actual, err := actualFixtureReplay(profile, spec.Observation)
+	if err != nil {
+		return FixtureConformanceRecord{}, err
+	}
+	detector, err := newFixtureDetector(catalog, spec.Detection.Declaration)
+	if err != nil {
+		return FixtureConformanceRecord{}, err
+	}
+	reader, err := fixtureReader(spec.Detection.Input)
+	if err != nil {
+		return FixtureConformanceRecord{}, err
+	}
+	decision, err := detector.Detect(context.Background(), reader, DetectionOptions{})
+	if err != nil {
+		return FixtureConformanceRecord{}, err
+	}
+	view := spec.Observation.Dependencies[0].View.Record()
+	result := FixtureConformanceRecord{recordID: spec.RecordID, profileID: spec.ProfileID, profileVersion: spec.ProfileVersion, function: view.RequestedFunction, table: view.Table, unit: spec.Observation.UnitID, normalized: view.LogicalOffset, rawWords: append([]uint16(nil), view.Words...), source: spec.Observation.SourceTime, wire: FixtureWireProvenance{view.WireResponseID}, logical: FixtureLogicalProvenance{view.LogicalViewID}, sample: FixtureSampleProvenance{PollGenerationID: spec.Observation.PollGenerationID}, detection: FixtureDetectionResult{Actual: decision, expected: spec.Detection.Expected}, qualification: spec.Qualification.Expected, replay: FixtureReplayResult{actual: actual, expected: spec.ExpectedReplay}}
+	result.slices = make([]FixtureLogicalSlice, len(actual.rawWords))
+	for index, words := range actual.rawWords {
+		result.slices[index] = FixtureLogicalSlice{words: append([]uint16(nil), words...)}
+	}
+	if len(actual.rawWords) != 0 {
+		result.rawWords = append([]uint16(nil), actual.rawWords[0]...)
+	}
+	return result, nil
+}
+
+// ErrFixtureConformanceNondeterministic is used by callers detecting a broken report invariant.
+var ErrFixtureConformanceNondeterministic = errors.New("fixture conformance report is nondeterministic")
+
+type fixtureCorpusDTO struct {
+	SchemaVersion Version           `json:"schema_version"`
+	Metadata      json.RawMessage   `json:"metadata"`
+	Profiles      []json.RawMessage `json:"profiles"`
+	Records       []json.RawMessage `json:"records"`
+}
+type fixtureRecordDTO struct {
+	RecordID       string          `json:"record_id"`
+	ProfileID      string          `json:"profile_id"`
+	ProfileVersion Version         `json:"profile_version"`
+	Observation    json.RawMessage `json:"observation"`
+	Detection      json.RawMessage `json:"detection"`
+	Qualification  json.RawMessage `json:"qualification"`
+	ExpectedReplay json.RawMessage `json:"expected_replay"`
+}
+
+func MarshalFixtureConformanceCorpusSpec(spec FixtureConformanceCorpusSpec) ([]byte, error) {
+	if _, err := NewFixtureConformanceCorpus(spec); err != nil {
+		return nil, err
+	}
+	metadata, err := json.Marshal(spec.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	dto := fixtureCorpusDTO{SchemaVersion: spec.SchemaVersion, Metadata: metadata, Profiles: make([]json.RawMessage, len(spec.Profiles)), Records: make([]json.RawMessage, len(spec.Records))}
+	for i, profile := range spec.Profiles {
+		encoded, err := MarshalProfileDescriptor(profile)
+		if err != nil {
+			return nil, err
+		}
+		dto.Profiles[i] = encoded
+	}
+	for i, record := range spec.Records {
+		encoded, err := MarshalFixtureSpec(record.Observation)
+		if err != nil {
+			return nil, err
+		}
+		detection, detectionErr := json.Marshal(record.Detection)
+		if detectionErr != nil {
+			return nil, detectionErr
+		}
+		qualification, qualificationErr := json.Marshal(record.Qualification)
+		if qualificationErr != nil {
+			return nil, qualificationErr
+		}
+		expected, expectedErr := json.Marshal(record.ExpectedReplay)
+		if expectedErr != nil {
+			return nil, expectedErr
+		}
+		recordBytes, recordErr := json.Marshal(fixtureRecordDTO{RecordID: record.RecordID, ProfileID: record.ProfileID, ProfileVersion: record.ProfileVersion, Observation: encoded, Detection: detection, Qualification: qualification, ExpectedReplay: expected})
+		if recordErr != nil {
+			return nil, recordErr
+		}
+		dto.Records[i] = recordBytes
+	}
+	return marshalBounded(dto)
+}
+
+func preflightFixtureCorpusJSON(data []byte) error {
+	if len(data) == 0 {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	if len(data) > MaxSerializedContractBytes {
+		return fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	expected := map[string]struct{}{"schema_version": {}, "metadata": {}, "profiles": {}, "records": {}}
+	seen := map[string]struct{}{}
+	for decoder.More() {
+		token, err := decoder.Token()
+		key, ok := token.(string)
+		if err != nil || !ok {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		folded := strings.ToLower(key)
+		if _, ok := seen[folded]; ok {
+			if key == strings.ToLower(key) {
+				return fixtureMutationError{FixtureMutationReasonDuplicate}
+			}
+			return fixtureMutationError{FixtureMutationReasonCaseFolded}
+		}
+		seen[folded] = struct{}{}
+		if _, ok := expected[key]; !ok {
+			if _, foldedKnown := expected[folded]; foldedKnown {
+				return fixtureMutationError{FixtureMutationReasonCaseFolded}
+			}
+			return fixtureMutationError{FixtureMutationReasonUnknown}
+		}
+		var discard json.RawMessage
+		if err := decoder.Decode(&discard); err != nil {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	for key := range expected {
+		if _, ok := seen[key]; !ok {
+			return fixtureMutationError{FixtureMutationReasonMissing}
+		}
+	}
+	if decoder.More() {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	return nil
+}
+
+func UnmarshalFixtureConformanceCorpus(data []byte) (*FixtureConformanceCorpus, error) {
+	if err := preflightFixtureCorpusJSON(data); err != nil {
+		return nil, err
+	}
+	var dto fixtureCorpusDTO
+	if err := json.Unmarshal(data, &dto); err != nil {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	if err := preflightAggregate(dto); err != nil {
+		return nil, fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	var metadata SanitizedFixtureMetadata
+	if err := json.Unmarshal(dto.Metadata, &metadata); err != nil {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	if len(metadata.CorpusID) > MaxContractStringBytes || len(metadata.LicenseExpression) > MaxContractStringBytes || len(metadata.Provenance) > MaxContractStringBytes {
+		return nil, fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	if err := decodeStrict(dto.Metadata, &metadata); err != nil {
+		return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	spec := FixtureConformanceCorpusSpec{SchemaVersion: dto.SchemaVersion, Metadata: metadata, Profiles: make([]ProfileDescriptor, len(dto.Profiles)), Records: make([]FixtureConformanceRecordSpec, len(dto.Records))}
+	for i, encoded := range dto.Profiles {
+		profile, err := UnmarshalProfileDescriptor(encoded)
+		if err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		spec.Profiles[i] = profile
+	}
+	for i, encodedRecord := range dto.Records {
+		if err := preflightFixtureRecordJSON(encodedRecord); err != nil {
+			return nil, err
+		}
+		var record fixtureRecordDTO
+		if err := json.Unmarshal(encodedRecord, &record); err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		var observation ObservationSpec
+		if err := json.Unmarshal(record.Observation, &observation); err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		var detection FixtureDetectionCaseSpec
+		if err := decodeStrict(record.Detection, &detection); err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		var qualification FixtureQualificationExpectation
+		if err := decodeStrict(record.Qualification, &qualification); err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		var expected FixtureReplayExpectation
+		if err := decodeStrict(record.ExpectedReplay, &expected); err != nil {
+			return nil, fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		spec.Records[i] = FixtureConformanceRecordSpec{RecordID: record.RecordID, ProfileID: record.ProfileID, ProfileVersion: record.ProfileVersion, Observation: observation, Detection: detection, Qualification: qualification, ExpectedReplay: expected}
+	}
+	corpus, err := NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		return nil, err
+	}
+	return corpus, nil
+}
+
+func preflightFixtureRecordJSON(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	expected := map[string]struct{}{"record_id": {}, "profile_id": {}, "profile_version": {}, "observation": {}, "detection": {}, "qualification": {}, "expected_replay": {}}
+	seen := map[string]struct{}{}
+	for decoder.More() {
+		token, err := decoder.Token()
+		key, ok := token.(string)
+		if err != nil || !ok {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		folded := strings.ToLower(key)
+		if _, duplicate := seen[folded]; duplicate {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		seen[folded] = struct{}{}
+		if _, ok := expected[key]; !ok {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+		var discard json.RawMessage
+		if err := decoder.Decode(&discard); err != nil {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return fixtureMutationError{FixtureMutationReasonMalformed}
+	}
+	for key := range expected {
+		if _, ok := seen[key]; !ok {
+			return fixtureMutationError{FixtureMutationReasonMalformed}
+		}
+	}
+	return nil
+}
+
+type fixtureReportDTO struct {
+	Metadata SanitizedFixtureMetadata `json:"metadata"`
+	Records  []fixtureReportRecordDTO `json:"records"`
+}
+type fixtureReportRecordDTO struct {
+	RecordID       string                          `json:"record_id"`
+	ProfileID      string                          `json:"profile_id"`
+	ProfileVersion Version                         `json:"profile_version"`
+	Outcome        FixtureReplayOutcome            `json:"outcome"`
+	Reason         FixtureReplayReason             `json:"reason"`
+	Function       FunctionCode                    `json:"function"`
+	Table          LogicalTable                    `json:"table"`
+	UnitID         byte                            `json:"unit_id"`
+	Normalized     uint16                          `json:"normalized_address"`
+	RawWords       [][]uint16                      `json:"raw_words,omitempty"`
+	LogicalSlices  [][]uint16                      `json:"logical_slices,omitempty"`
+	Wire           FixtureWireProvenance           `json:"wire"`
+	Logical        FixtureLogicalProvenance        `json:"logical"`
+	Sample         FixtureSampleProvenance         `json:"sample"`
+	Source         SourceTimeSpec                  `json:"source_time"`
+	Qualification  FixtureQualificationDisposition `json:"qualification"`
+	Detection      detectionDecisionDTO            `json:"detection"`
+}
+
+func (corpus *FixtureConformanceCorpus) MarshalBoundedReport() ([]byte, error) {
+	report, err := corpus.Replay()
+	if err != nil {
+		return nil, err
+	}
+	dto := fixtureReportDTO{Metadata: report.metadata, Records: make([]fixtureReportRecordDTO, len(report.records))}
+	for i, record := range report.records {
+		slices := make([][]uint16, len(record.slices))
+		for index, slice := range record.slices {
+			slices[index] = append([]uint16(nil), slice.words...)
+		}
+		decision := detectionDecisionToDTO(record.detection.Actual)
+		dto.Records[i] = fixtureReportRecordDTO{RecordID: record.recordID, ProfileID: record.profileID, ProfileVersion: record.profileVersion, Outcome: record.replay.actual.outcome, Reason: record.replay.actual.reason, Function: record.function, Table: record.table, UnitID: record.unit, Normalized: record.normalized, RawWords: cloneWordSets(record.replay.actual.rawWords), LogicalSlices: slices, Wire: record.wire, Logical: record.logical, Sample: record.sample, Source: record.source, Qualification: record.qualification, Detection: decision}
+	}
+	encoded, err := marshalBounded(dto)
+	if err != nil {
+		return nil, err
+	}
+	if len(encoded) > corpus.limits.MaxReportBytes {
+		return nil, fixtureMutationError{FixtureMutationReasonOversized}
+	}
+	return encoded, nil
+}

--- a/fixture_conformance_contract_test.go
+++ b/fixture_conformance_contract_test.go
@@ -69,7 +69,6 @@ func m203Record(t *testing.T, id string, profile reg.ProfileDescriptor, unit byt
 			record.Table = reg.HoldingRegisters
 		}
 		observation.Dependencies[index].View = snapshotFromRecord(t, record)
-		observation.Dependencies[index].SourceTime = observation.SourceTime
 	}
 	return reg.FixtureConformanceRecordSpec{
 		RecordID: id, ProfileID: profile.ID(), ProfileVersion: profile.Version(), Observation: observation,
@@ -90,18 +89,22 @@ func m203DetectionCase(t *testing.T, profile reg.ProfileDescriptor) reg.FixtureD
 			},
 			Limits: detectionLimits(),
 		},
-		Input: reg.FixtureDetectorInput{Manufacturer: "manufacturer-alpha", Model: "model-series-a", Firmware: "1.10.0", Probes: []reg.FixtureProbeInput{
-			{DeclarationID: "manufacturer-identity", Result: mustProbeResult(t, "manufacturer-alpha", "probe-evidence-manufacturer")},
-			{DeclarationID: "model-identity", Result: mustProbeResult(t, "model-series-a", "probe-evidence-model")},
-			{DeclarationID: "firmware-identity", Result: mustProbeResult(t, "1.10.0", "probe-evidence-firmware")},
+		Input: reg.FixtureDetectorInput{Probes: []reg.FixtureProbeInput{
+			{DeclarationID: "manufacturer-identity", Result: m203ProbeResultSpec("manufacturer-alpha", "probe-evidence-manufacturer")},
+			{DeclarationID: "model-identity", Result: m203ProbeResultSpec("model-series-a", "probe-evidence-model")},
+			{DeclarationID: "firmware-identity", Result: m203ProbeResultSpec("1.10.0", "probe-evidence-firmware")},
 		}},
 		Expected: reg.FixtureDetectionExpectation{Outcome: reg.DetectionMatched, Reason: reg.DetectionReasonSelected, SelectedProfileID: profile.ID(), SelectedProfileVersion: profile.Version(), Evidence: []reg.FixtureDetectionEvidenceExpectation{{
-			ProfileID: profile.ID(), ProfileVersion: profile.Version(), Reason: reg.DetectionReasonSelected,
+			ProfileID: profile.ID(), ProfileVersion: profile.Version(), Score: 100, Reason: reg.DetectionReasonSelected,
 			MatchedGates:     []reg.ProbeIdentityField{reg.ProbeIdentityManufacturer, reg.ProbeIdentityModel, reg.ProbeIdentityFirmware},
 			ProbeEvidenceIDs: []string{"probe-evidence-manufacturer", "probe-evidence-model", "probe-evidence-firmware"},
 			DetectorVersion:  profile.DetectorVersion(), QualificationVersion: profile.QualificationVersion(),
 		}}},
 	}
+}
+
+func m203ProbeResultSpec(value, evidenceID string) reg.ProbeReadResultSpec {
+	return reg.ProbeReadResultSpec{Status: reg.ProbeReadSucceeded, Words: detectionWords(value), EvidenceID: evidenceID}
 }
 
 func TestM203FixtureCorpusBindsSanitizedTransportNeutralEvidence(t *testing.T) {
@@ -164,10 +167,6 @@ func TestM203CorpusSpecAndResultAccessorsAreImmutableAndBounded(t *testing.T) {
 
 func TestM203CompatibleUnequalOverlapsRetainExactLogicalSlices(t *testing.T) {
 	spec := m203SyntheticCorpus(t)
-	first, second := spec.Records[0].Observation.Dependencies[0].View.Record(), spec.Records[0].Observation.Dependencies[1].View.Record()
-	first.PhysicalOffset, first.PhysicalWordCount, first.LogicalOffset, first.SliceOffset, first.LogicalWordCount, first.SliceWordCount, first.Words = 100, 6, 100, 0, 2, 2, []uint16{11, 12}
-	second.PhysicalOffset, second.PhysicalWordCount, second.LogicalOffset, second.SliceOffset, second.LogicalWordCount, second.SliceWordCount, second.Words = 100, 6, 102, 2, 2, 2, []uint16{13, 14}
-	spec.Records[0].Observation.Dependencies[0].View, spec.Records[0].Observation.Dependencies[1].View = snapshotFromRecord(t, first), snapshotFromRecord(t, second)
 	corpus, err := reg.NewFixtureConformanceCorpus(spec)
 	if err != nil {
 		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
@@ -176,8 +175,8 @@ func TestM203CompatibleUnequalOverlapsRetainExactLogicalSlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Replay: %v", err)
 	}
-	slices := report.Records()[0].LogicalSlices()
-	if len(slices) != 2 || !bytes.Equal(slices[0].CanonicalBytes(), []byte{0, 11, 0, 12}) || !bytes.Equal(slices[1].CanonicalBytes(), []byte{0, 13, 0, 14}) {
+	slices := report.Records()[1].LogicalSlices()
+	if len(slices) != 2 || !bytes.Equal(slices[0].CanonicalBytes(), []byte{1, 2, 3, 4}) || !bytes.Equal(slices[1].CanonicalBytes(), []byte{3, 4, 5, 6}) {
 		t.Fatalf("unequal compatible overlap lost exact logical slices: %#v", slices)
 	}
 }

--- a/fixture_conformance_contract_test.go
+++ b/fixture_conformance_contract_test.go
@@ -180,3 +180,78 @@ func TestM203CompatibleUnequalOverlapsRetainExactLogicalSlices(t *testing.T) {
 		t.Fatalf("unequal compatible overlap lost exact logical slices: %#v", slices)
 	}
 }
+
+func TestM203BoundedMultiPreservesCanonicalSourceSkew(t *testing.T) {
+	profile, observation := boundedFixture(t, reg.AcquisitionOrderDependencyDeclaration)
+	profileSpec := profile.Spec()
+	profileSpec.Maturity = reg.MaturityQualified
+	profileSpec.DefaultEnabled = true
+	profile, err := reg.NewProfileDescriptor(profileSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(qualified bounded): %v", err)
+	}
+	observation.Endpoint, observation.UnitID = "fixture-bounded-source", 19
+	for index := range observation.Dependencies {
+		view := observation.Dependencies[index].View.Record()
+		view.Endpoint, view.UnitID = observation.Endpoint, observation.UnitID
+		observation.Dependencies[index].View = snapshotFromRecord(t, view)
+	}
+	record := m203Record(t, "fixture-bounded-valid", profile, observation.UnitID, observation.PollGenerationID)
+	record.Observation = observation
+	corpusSpec := reg.FixtureConformanceCorpusSpec{SchemaVersion: version(t, "1.0.0"), Metadata: reg.SanitizedFixtureMetadata{CorpusID: "fixture-bounded-corpus", LicenseExpression: "CC0-1.0", Provenance: "public synthetic fixture"}, Profiles: []reg.ProfileDescriptor{profile}, Records: []reg.FixtureConformanceRecordSpec{record}}
+	if _, err := reg.NewFixtureConformanceCorpus(corpusSpec); err != nil {
+		t.Fatalf("canonical bounded source skew rejected: %v", err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*reg.LogicalViewRecord)
+	}{
+		{"endpoint", func(view *reg.LogicalViewRecord) { view.Endpoint = "fixture-bounded-other" }},
+		{"connection", func(view *reg.LogicalViewRecord) { view.ConnectionID++ }},
+		{"transport generation", func(view *reg.LogicalViewRecord) { view.TransportGeneration++ }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			negative := corpusSpec
+			negative.Records = append([]reg.FixtureConformanceRecordSpec(nil), corpusSpec.Records...)
+			negative.Records[0].Observation.Dependencies = append([]reg.DependencyResult(nil), corpusSpec.Records[0].Observation.Dependencies...)
+			view := negative.Records[0].Observation.Dependencies[1].View.Record()
+			test.mutate(&view)
+			negative.Records[0].Observation.Dependencies[1].View = snapshotFromRecord(t, view)
+			negative.Records[0].ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonSourceMismatch}
+			if _, err := reg.NewFixtureConformanceCorpus(negative); err != nil {
+				t.Fatalf("bounded source mismatch rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestM203RejectedQualificationMatchesUnqualifiedDetection(t *testing.T) {
+	profile := detectionProfile(t, "synthetic.standard.unqualified", "1.0.0", reg.MaturityExperimental, reg.ProfileActive, false)
+	record := m203Record(t, "fixture-unqualified", profile, 20, 601)
+	record.Qualification.Expected = reg.FixtureQualificationDispositionRejected
+	record.Detection.Expected = reg.FixtureDetectionExpectation{Outcome: reg.DetectionNoMatch, Reason: reg.DetectionReasonProfileUnqualified, Evidence: []reg.FixtureDetectionEvidenceExpectation{{ProfileID: profile.ID(), ProfileVersion: profile.Version(), Score: 100, Reason: reg.DetectionReasonProfileUnqualified, DetectorVersion: profile.DetectorVersion(), QualificationVersion: profile.QualificationVersion()}}}
+	spec := reg.FixtureConformanceCorpusSpec{SchemaVersion: version(t, "1.0.0"), Metadata: reg.SanitizedFixtureMetadata{CorpusID: "fixture-unqualified-corpus", LicenseExpression: "CC0-1.0", Provenance: "public synthetic fixture"}, Profiles: []reg.ProfileDescriptor{profile}, Records: []reg.FixtureConformanceRecordSpec{record}}
+	corpus, err := reg.NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		t.Fatalf("unqualified/rejected corpus: %v", err)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	result := report.Records()[0]
+	if result.Qualification() != reg.FixtureQualificationDispositionRejected || result.Detection().Actual.Outcome() != reg.DetectionNoMatch || result.Detection().Actual.Reason() != reg.DetectionReasonProfileUnqualified || !result.Detection().MatchesExpected() {
+		t.Fatalf("unqualified result = %#v", result)
+	}
+	qualifiedRejected := m203SyntheticCorpus(t)
+	qualifiedRejected.Records[0].Qualification.Expected = reg.FixtureQualificationDispositionRejected
+	if _, err := reg.NewFixtureConformanceCorpus(qualifiedRejected); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonContradictory) {
+		t.Fatalf("qualified/rejected error = %v", err)
+	}
+	unqualifiedQualified := spec
+	unqualifiedQualified.Records = append([]reg.FixtureConformanceRecordSpec(nil), spec.Records...)
+	unqualifiedQualified.Records[0].Qualification.Expected = reg.FixtureQualificationDispositionQualified
+	if _, err := reg.NewFixtureConformanceCorpus(unqualifiedQualified); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonContradictory) {
+		t.Fatalf("unqualified/qualified error = %v", err)
+	}
+}

--- a/fixture_conformance_contract_test.go
+++ b/fixture_conformance_contract_test.go
@@ -2,6 +2,7 @@ package modbusreg_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -178,6 +179,132 @@ func TestM203CompatibleUnequalOverlapsRetainExactLogicalSlices(t *testing.T) {
 	slices := report.Records()[1].LogicalSlices()
 	if len(slices) != 2 || !bytes.Equal(slices[0].CanonicalBytes(), []byte{1, 2, 3, 4}) || !bytes.Equal(slices[1].CanonicalBytes(), []byte{3, 4, 5, 6}) {
 		t.Fatalf("unequal compatible overlap lost exact logical slices: %#v", slices)
+	}
+}
+
+func TestM203BoundedMultiReportRetainsEveryFC03FC04DependencyFact(t *testing.T) {
+	base, observation := boundedFixture(t, reg.AcquisitionOrderDependencyDeclaration)
+	dependencies := base.Dependencies().Dependencies()
+	second := dependencies[1].Spec()
+	second.Table = reg.HoldingRegisters
+	second.Normalization.DocumentaryNotation = "one-based holding register"
+	second.Normalization.AddressSpaceLabel = string(reg.HoldingRegisters)
+	converted, err := reg.NewDependency(second)
+	if err != nil {
+		t.Fatalf("NewDependency(mixed holding): %v", err)
+	}
+	dependencies[1] = converted
+	set, err := reg.NewDependencySet(base.Dependencies().Version(), dependencies)
+	if err != nil {
+		t.Fatalf("NewDependencySet(mixed): %v", err)
+	}
+	profileSpec := base.Spec()
+	profileSpec.Dependencies = set
+	profileSpec.Maturity = reg.MaturityQualified
+	profileSpec.DefaultEnabled = true
+	profile, err := reg.NewProfileDescriptor(profileSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(mixed): %v", err)
+	}
+	observation.DependencySetID = profile.Dependencies().ID()
+	observation.DependencySetVersion = profile.Dependencies().Version()
+	for index := range observation.Dependencies {
+		declaration := profile.Dependencies().Dependencies()[index]
+		observation.Dependencies[index].DependencyID = declaration.ID()
+		observation.Dependencies[index].DependencyVersion = declaration.Version()
+		observation.Dependencies[index].CodecID = declaration.CodecID()
+		observation.Dependencies[index].CodecVersion = declaration.CodecVersion()
+		observation.Dependencies[index].NormalizationVersion = declaration.Normalization().Spec().Version
+		view := observation.Dependencies[index].View.Record()
+		view.Endpoint, view.UnitID, view.PollGeneration = "fixture-mixed-fc03-fc04", 31, 701
+		if index == 1 {
+			view.RequestedFunction = reg.FunctionReadHoldingRegisters
+			view.ReceivedFunction = reg.FunctionReadHoldingRegisters
+			view.Table = reg.HoldingRegisters
+			view.WireResponseBytes = append([]byte(nil), view.WireResponseBytes...)
+			view.WireResponseBytes[1] = byte(reg.FunctionReadHoldingRegisters)
+		}
+		observation.Dependencies[index].View = snapshotFromRecord(t, view)
+	}
+	observation.Endpoint, observation.UnitID, observation.PollGenerationID = "fixture-mixed-fc03-fc04", 31, 701
+	record := m203Record(t, "fixture-mixed-fc03-fc04", profile, 31, 701)
+	record.Observation = observation
+	record.ExpectedReplay.ExpectedRawWords = make([][]uint16, len(observation.Dependencies))
+	for index, dependency := range observation.Dependencies {
+		record.ExpectedReplay.ExpectedRawWords[index] = dependency.View.Record().Words
+	}
+	spec := reg.FixtureConformanceCorpusSpec{SchemaVersion: version(t, "1.0.0"), Metadata: reg.SanitizedFixtureMetadata{CorpusID: "fixture-mixed-fc03-fc04", LicenseExpression: "CC0-1.0", Provenance: "public synthetic fixture"}, Profiles: []reg.ProfileDescriptor{profile}, Records: []reg.FixtureConformanceRecordSpec{record}}
+	corpus, err := reg.NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	facts := report.Records()[0].DependencyFacts()
+	if len(facts) != 2 {
+		t.Fatalf("dependency facts = %d, want 2", len(facts))
+	}
+	for index, want := range []struct {
+		function reg.FunctionCode
+		table    reg.LogicalTable
+	}{{reg.FunctionReadInputRegisters, reg.InputRegisters}, {reg.FunctionReadHoldingRegisters, reg.HoldingRegisters}} {
+		fact := facts[index]
+		if fact.Ordinal() != uint32(index) || fact.FunctionCode() != want.function || fact.Table() != want.table || fact.UnitID() != 31 || fact.NormalizedAddress() == 0 || len(fact.RawWords()) == 0 || len(fact.LogicalSlice().CanonicalBytes()) == 0 || fact.SourceTime().State != reg.SourceTimeObservedState || fact.WireProvenance().WireResponseID == 0 || fact.LogicalProvenance().LogicalViewID == 0 || fact.SampleProvenance().PollGenerationID != 701 {
+			t.Fatalf("dependency %d lost FC03/FC04 association: %#v", index, fact)
+		}
+	}
+	facts[0].RawWords()[0] = 0xffff
+	if report.Records()[0].DependencyFacts()[0].RawWords()[0] == 0xffff {
+		t.Fatal("dependency facts accessor leaked mutation")
+	}
+	encoded, err := corpus.MarshalBoundedReport()
+	if err != nil {
+		t.Fatalf("MarshalBoundedReport: %v", err)
+	}
+	var serialized struct {
+		SchemaVersion string `json:"schema_version"`
+		Records       []struct {
+			Dependencies []struct {
+				Ordinal  uint32   `json:"ordinal"`
+				Function uint8    `json:"function"`
+				Table    string   `json:"table"`
+				Words    []uint16 `json:"raw_words"`
+				Logical  []uint16 `json:"logical_slice"`
+				Wire     struct {
+					ID uint64 `json:"WireResponseID"`
+				} `json:"wire"`
+				View struct {
+					ID uint64 `json:"LogicalViewID"`
+				} `json:"logical"`
+			} `json:"dependencies"`
+		} `json:"records"`
+	}
+	if err := json.Unmarshal(encoded, &serialized); err != nil {
+		t.Fatalf("report JSON: %v", err)
+	}
+	if serialized.SchemaVersion != "1.0.0" || len(serialized.Records) != 1 || len(serialized.Records[0].Dependencies) != 2 {
+		t.Fatalf("serialized dependency report lost version or facts: %#v", serialized)
+	}
+	for index, want := range []struct {
+		function uint8
+		table    string
+	}{{uint8(reg.FunctionReadInputRegisters), string(reg.InputRegisters)}, {uint8(reg.FunctionReadHoldingRegisters), string(reg.HoldingRegisters)}} {
+		fact := serialized.Records[0].Dependencies[index]
+		if fact.Ordinal != uint32(index) || fact.Function != want.function || fact.Table != want.table || len(fact.Words) == 0 || len(fact.Logical) == 0 || fact.Wire.ID == 0 || fact.View.ID == 0 {
+			t.Fatalf("serialized dependency %d lost association: %#v", index, fact)
+		}
+	}
+	if repeat, marshalErr := corpus.MarshalBoundedReport(); marshalErr != nil || !bytes.Equal(encoded, repeat) {
+		t.Fatalf("report serialization is nondeterministic: %q, %v", repeat, marshalErr)
+	}
+	limited, err := reg.NewFixtureConformanceCorpusWithLimits(spec, reg.FixtureConformanceLimits{MaxRecords: 1, MaxReportBytes: len(encoded) - 1})
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpusWithLimits: %v", err)
+	}
+	if _, err := limited.MarshalBoundedReport(); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonOversized) {
+		t.Fatalf("one-byte-short report limit error = %v", err)
 	}
 }
 

--- a/fixture_conformance_contract_test.go
+++ b/fixture_conformance_contract_test.go
@@ -1,0 +1,183 @@
+package modbusreg_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+// m203SyntheticCorpus contains only generic standard-family declarations and
+// offline fixture identities. Detection declarations reconstruct the existing
+// ProfileDetector from the corpus catalog; no executable pointer is persisted.
+func m203SyntheticCorpus(t *testing.T) reg.FixtureConformanceCorpusSpec {
+	t.Helper()
+	alpha := detectionProfile(t, "synthetic.standard.alpha", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	beta := m203HoldingProfile(t, "synthetic.standard.beta", "2.0.0")
+	return reg.FixtureConformanceCorpusSpec{
+		SchemaVersion: version(t, "1.0.0"),
+		Metadata:      reg.SanitizedFixtureMetadata{CorpusID: "synthetic-conformance-public", LicenseExpression: "CC0-1.0", Provenance: "public synthetic fixture"},
+		Profiles:      []reg.ProfileDescriptor{alpha, beta},
+		Records: []reg.FixtureConformanceRecordSpec{
+			m203Record(t, "synthetic-fc04-alpha", alpha, 17, 501),
+			m203Record(t, "synthetic-fc03-beta", beta, 18, 502),
+		},
+	}
+}
+
+func m203HoldingProfile(t *testing.T, id, profileVersion string) reg.ProfileDescriptor {
+	t.Helper()
+	base := detectionProfile(t, id, profileVersion, reg.MaturityQualified, reg.ProfileActive, true)
+	dependencies := base.Dependencies().Dependencies()
+	holding := make([]reg.Dependency, len(dependencies))
+	for index, dependency := range dependencies {
+		spec := dependency.Spec()
+		spec.Table = reg.HoldingRegisters
+		spec.Normalization.DocumentaryNotation = "one-based holding register"
+		spec.Normalization.AddressSpaceLabel = string(reg.HoldingRegisters)
+		converted, err := reg.NewDependency(spec)
+		if err != nil {
+			t.Fatalf("NewDependency(holding): %v", err)
+		}
+		holding[index] = converted
+	}
+	set, err := reg.NewDependencySet(base.Dependencies().Version(), holding)
+	if err != nil {
+		t.Fatalf("NewDependencySet(holding): %v", err)
+	}
+	spec := base.Spec()
+	spec.Dependencies = set
+	profile, err := reg.NewProfileDescriptor(spec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(holding): %v", err)
+	}
+	return profile
+}
+
+func m203Record(t *testing.T, id string, profile reg.ProfileDescriptor, unit byte, generation uint64) reg.FixtureConformanceRecordSpec {
+	t.Helper()
+	observation := successfulObservationSpec(t, profile)
+	observation.Endpoint, observation.UnitID, observation.PollGenerationID = "fixture-endpoint-"+id, unit, generation
+	observation.SourceTime = reg.SourceTimeObserved(time.Unix(1_700_001_000+int64(unit), 0).UTC())
+	for index := range observation.Dependencies {
+		record := observation.Dependencies[index].View.Record()
+		record.Endpoint, record.UnitID, record.PollGeneration = observation.Endpoint, unit, generation
+		if profile.Dependencies().Dependencies()[index].Table() == reg.HoldingRegisters {
+			record.RequestedFunction = reg.FunctionReadHoldingRegisters
+			record.ReceivedFunction = reg.FunctionReadHoldingRegisters
+			record.Table = reg.HoldingRegisters
+		}
+		observation.Dependencies[index].View = snapshotFromRecord(t, record)
+		observation.Dependencies[index].SourceTime = observation.SourceTime
+	}
+	return reg.FixtureConformanceRecordSpec{
+		RecordID: id, ProfileID: profile.ID(), ProfileVersion: profile.Version(), Observation: observation,
+		Detection:      m203DetectionCase(t, profile),
+		Qualification:  reg.FixtureQualificationExpectation{Expected: reg.FixtureQualificationDispositionQualified},
+		ExpectedReplay: reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayAccepted, Reason: reg.FixtureReplayReasonAccepted, ExpectedRawWords: [][]uint16{{0x0102, 0x0304}, {0x0304, 0x0506}}},
+	}
+}
+
+func m203DetectionCase(t *testing.T, profile reg.ProfileDescriptor) reg.FixtureDetectionCaseSpec {
+	t.Helper()
+	return reg.FixtureDetectionCaseSpec{
+		Declaration: reg.FixtureDetectorDeclarationSpec{
+			DetectorVersion: profile.DetectorVersion(),
+			Plan:            detectionPlan(t).Spec(),
+			Candidates: []reg.DetectionCandidateSpec{
+				detectionCandidate(t, profile, 100, true, false).Spec(),
+			},
+			Limits: detectionLimits(),
+		},
+		Input: reg.FixtureDetectorInput{Manufacturer: "manufacturer-alpha", Model: "model-series-a", Firmware: "1.10.0", Probes: []reg.FixtureProbeInput{
+			{DeclarationID: "manufacturer-identity", Result: mustProbeResult(t, "manufacturer-alpha", "probe-evidence-manufacturer")},
+			{DeclarationID: "model-identity", Result: mustProbeResult(t, "model-series-a", "probe-evidence-model")},
+			{DeclarationID: "firmware-identity", Result: mustProbeResult(t, "1.10.0", "probe-evidence-firmware")},
+		}},
+		Expected: reg.FixtureDetectionExpectation{Outcome: reg.DetectionMatched, Reason: reg.DetectionReasonSelected, SelectedProfileID: profile.ID(), SelectedProfileVersion: profile.Version(), Evidence: []reg.FixtureDetectionEvidenceExpectation{{
+			ProfileID: profile.ID(), ProfileVersion: profile.Version(), Reason: reg.DetectionReasonSelected,
+			MatchedGates:     []reg.ProbeIdentityField{reg.ProbeIdentityManufacturer, reg.ProbeIdentityModel, reg.ProbeIdentityFirmware},
+			ProbeEvidenceIDs: []string{"probe-evidence-manufacturer", "probe-evidence-model", "probe-evidence-firmware"},
+			DetectorVersion:  profile.DetectorVersion(), QualificationVersion: profile.QualificationVersion(),
+		}}},
+	}
+}
+
+func TestM203FixtureCorpusBindsSanitizedTransportNeutralEvidence(t *testing.T) {
+	corpus, err := reg.NewFixtureConformanceCorpus(m203SyntheticCorpus(t))
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if report.RecordCount() != 2 || report.RejectedCount() != 0 {
+		t.Fatalf("report counts = accepted %d rejected %d", report.RecordCount(), report.RejectedCount())
+	}
+	metadata := report.Metadata()
+	if metadata.CorpusID != "synthetic-conformance-public" || metadata.LicenseExpression != "CC0-1.0" || metadata.Provenance != "public synthetic fixture" {
+		t.Fatalf("sanitized metadata = %#v", metadata)
+	}
+	result := report.Records()[0]
+	tables := map[reg.FunctionCode]reg.LogicalTable{}
+	for _, record := range report.Records() {
+		tables[record.FunctionCode()] = record.Table()
+	}
+	if tables[reg.FunctionReadInputRegisters] != reg.InputRegisters || tables[reg.FunctionReadHoldingRegisters] != reg.HoldingRegisters || result.UnitID() == 0 || result.NormalizedAddress() == 0 || len(result.RawWords()) == 0 {
+		t.Fatalf("FC03/FC04 table/unit/address/raw-word provenance = %#v", report.Records())
+	}
+	if result.WireProvenance().WireResponseID == 0 || result.LogicalProvenance().LogicalViewID == 0 || result.SampleProvenance().PollGenerationID == 0 || result.SourceTime().State != reg.SourceTimeObservedState {
+		t.Fatalf("incomplete provenance: %#v", result)
+	}
+	detection := result.Detection()
+	if detection.Actual.Outcome() != reg.DetectionMatched || detection.Actual.Reason() != reg.DetectionReasonSelected || detection.Actual.SelectedProfileID() != result.ProfileID() || detection.Actual.SelectedProfileVersion() != result.ProfileVersion() || !detection.MatchesExpected() || result.Qualification() != reg.FixtureQualificationDispositionQualified {
+		t.Fatalf("detector/qualification result = %#v", result)
+	}
+}
+
+func TestM203CorpusSpecAndResultAccessorsAreImmutableAndBounded(t *testing.T) {
+	corpus, err := reg.NewFixtureConformanceCorpus(m203SyntheticCorpus(t))
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	spec := corpus.Spec()
+	spec.Metadata.CorpusID, spec.Profiles = "mutated", nil
+	spec.Records[0].ExpectedReplay.ExpectedRawWords[0][0] = 0xffff
+	if got := corpus.Spec(); got.Metadata.CorpusID != "synthetic-conformance-public" || len(got.Profiles) != 2 || got.Records[0].ExpectedReplay.ExpectedRawWords[0][0] != 0x0102 {
+		t.Fatalf("corpus spec accessor leaked mutation: %#v", got)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	words := report.Records()[0].RawWords()
+	words[0] = 0xffff
+	if report.Records()[0].RawWords()[0] == 0xffff {
+		t.Fatal("report raw-word accessor leaked mutation")
+	}
+	if _, err := reg.NewFixtureConformanceCorpusWithLimits(m203SyntheticCorpus(t), reg.FixtureConformanceLimits{MaxRecords: 1, MaxReportBytes: reg.MaxSerializedContractBytes}); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonOversized) {
+		t.Fatalf("bounded corpus error = %v, want oversized", err)
+	}
+}
+
+func TestM203CompatibleUnequalOverlapsRetainExactLogicalSlices(t *testing.T) {
+	spec := m203SyntheticCorpus(t)
+	first, second := spec.Records[0].Observation.Dependencies[0].View.Record(), spec.Records[0].Observation.Dependencies[1].View.Record()
+	first.PhysicalOffset, first.PhysicalWordCount, first.LogicalOffset, first.SliceOffset, first.LogicalWordCount, first.SliceWordCount, first.Words = 100, 6, 100, 0, 2, 2, []uint16{11, 12}
+	second.PhysicalOffset, second.PhysicalWordCount, second.LogicalOffset, second.SliceOffset, second.LogicalWordCount, second.SliceWordCount, second.Words = 100, 6, 102, 2, 2, 2, []uint16{13, 14}
+	spec.Records[0].Observation.Dependencies[0].View, spec.Records[0].Observation.Dependencies[1].View = snapshotFromRecord(t, first), snapshotFromRecord(t, second)
+	corpus, err := reg.NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	slices := report.Records()[0].LogicalSlices()
+	if len(slices) != 2 || !bytes.Equal(slices[0].CanonicalBytes(), []byte{0, 11, 0, 12}) || !bytes.Equal(slices[1].CanonicalBytes(), []byte{0, 13, 0, 14}) {
+		t.Fatalf("unequal compatible overlap lost exact logical slices: %#v", slices)
+	}
+}

--- a/fixture_conformance_determinism_test.go
+++ b/fixture_conformance_determinism_test.go
@@ -1,0 +1,103 @@
+package modbusreg_test
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func TestM203CorpusReplayIsDeterministicAcrossRealPermutationsAndConcurrentRuns(t *testing.T) {
+	baseline, err := reg.NewFixtureConformanceCorpus(m203SyntheticCorpus(t))
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	want, err := baseline.MarshalBoundedReport()
+	if err != nil {
+		t.Fatalf("MarshalBoundedReport: %v", err)
+	}
+	permuted := m203SyntheticCorpus(t)
+	permuted.Profiles[0], permuted.Profiles[1] = permuted.Profiles[1], permuted.Profiles[0]
+	permuted.Records[0], permuted.Records[1] = permuted.Records[1], permuted.Records[0]
+	corpus, err := reg.NewFixtureConformanceCorpus(permuted)
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus(permuted): %v", err)
+	}
+	if got, marshalErr := corpus.MarshalBoundedReport(); marshalErr != nil || !bytes.Equal(got, want) {
+		t.Fatalf("permuted report = %q, %v; want byte-identical sorted report", got, marshalErr)
+	}
+	encoded, err := reg.MarshalFixtureConformanceCorpusSpec(m203SyntheticCorpus(t))
+	if err != nil {
+		t.Fatalf("MarshalFixtureConformanceCorpusSpec: %v", err)
+	}
+	restored, err := reg.UnmarshalFixtureConformanceCorpus(encoded)
+	if err != nil {
+		t.Fatalf("UnmarshalFixtureConformanceCorpus: %v", err)
+	}
+	if got, replayErr := restored.MarshalBoundedReport(); replayErr != nil || !bytes.Equal(got, want) {
+		t.Fatalf("round-trip report = %q, %v; want byte-identical replay", got, replayErr)
+	}
+	const workers, iterations = 8, 32
+	errors := make(chan error, workers*iterations)
+	var group sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				got, replayErr := corpus.MarshalBoundedReport()
+				if replayErr != nil {
+					errors <- replayErr
+					return
+				}
+				if !bytes.Equal(got, want) {
+					errors <- reg.ErrFixtureConformanceNondeterministic
+					return
+				}
+			}
+		}()
+	}
+	group.Wait()
+	close(errors)
+	for err := range errors {
+		t.Fatal(err)
+	}
+}
+
+func TestM203CorpusActuallyReplaysConcreteExpectedOutcomes(t *testing.T) {
+	spec := m203SyntheticCorpus(t)
+	valid := spec.Records[0]
+	codec := valid
+	codec.RecordID = "replay-codec"
+	detector := valid
+	detector.RecordID = "replay-detector"
+	qualification := valid
+	qualification.RecordID = "replay-qualification"
+	normalization := valid
+	normalization.RecordID = "replay-normalization"
+	normalization.Observation.Dependencies[0].NormalizationVersion = version(t, "2.0.0")
+	normalization.ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonNormalizationMismatch}
+	generation := valid
+	generation.RecordID = "replay-generation"
+	generation.Observation.Dependencies[0].View = m203MutateView(t, &spec, 0, 0, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
+	generation.ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonGenerationMismatch}
+	torn := valid
+	torn.RecordID = "replay-torn-read"
+	torn.Observation.Dependencies[0].Status = reg.DependencyReadTorn
+	torn.ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonTornRead}
+	spec.Records = []reg.FixtureConformanceRecordSpec{codec, detector, qualification, normalization, generation, torn}
+	corpus, err := reg.NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	for _, result := range report.Records() {
+		if !result.Replay().MatchesExpected() {
+			t.Fatalf("%s replay actual=%#v expected=%#v", result.RecordID(), result.Replay().Actual(), result.Replay().Expected())
+		}
+	}
+}

--- a/fixture_conformance_determinism_test.go
+++ b/fixture_conformance_determinism_test.go
@@ -66,6 +66,45 @@ func TestM203CorpusReplayIsDeterministicAcrossRealPermutationsAndConcurrentRuns(
 	}
 }
 
+func TestM203CorpusSpecMarshalIsCanonicalAcrossIndependentPermutations(t *testing.T) {
+	baseline := m203SyntheticCorpus(t)
+	baselineEncoded, err := reg.MarshalFixtureConformanceCorpusSpec(baseline)
+	if err != nil {
+		t.Fatalf("MarshalFixtureConformanceCorpusSpec(baseline): %v", err)
+	}
+
+	permuted := m203SyntheticCorpus(t)
+	permuted.Profiles[0], permuted.Profiles[1] = permuted.Profiles[1], permuted.Profiles[0]
+	permuted.Records[0], permuted.Records[1] = permuted.Records[1], permuted.Records[0]
+	permutedEncoded, err := reg.MarshalFixtureConformanceCorpusSpec(permuted)
+	if err != nil {
+		t.Fatalf("MarshalFixtureConformanceCorpusSpec(permuted): %v", err)
+	}
+	if !bytes.Equal(permutedEncoded, baselineEncoded) {
+		t.Fatalf("permuted corpus spec = %s; want byte-identical canonical encoding %s", permutedEncoded, baselineEncoded)
+	}
+
+	baselineCorpus, err := reg.UnmarshalFixtureConformanceCorpus(baselineEncoded)
+	if err != nil {
+		t.Fatalf("UnmarshalFixtureConformanceCorpus(baseline): %v", err)
+	}
+	permutedCorpus, err := reg.UnmarshalFixtureConformanceCorpus(permutedEncoded)
+	if err != nil {
+		t.Fatalf("UnmarshalFixtureConformanceCorpus(permuted): %v", err)
+	}
+	baselineReport, err := baselineCorpus.MarshalBoundedReport()
+	if err != nil {
+		t.Fatalf("MarshalBoundedReport(baseline): %v", err)
+	}
+	permutedReport, err := permutedCorpus.MarshalBoundedReport()
+	if err != nil {
+		t.Fatalf("MarshalBoundedReport(permuted): %v", err)
+	}
+	if !bytes.Equal(permutedReport, baselineReport) {
+		t.Fatalf("permuted replay report = %s; want byte-identical canonical report %s", permutedReport, baselineReport)
+	}
+}
+
 func TestM203BoundedReportCarriesConformanceEvidence(t *testing.T) {
 	corpus, err := reg.NewFixtureConformanceCorpus(m203SyntheticCorpus(t))
 	if err != nil {

--- a/fixture_conformance_determinism_test.go
+++ b/fixture_conformance_determinism_test.go
@@ -2,6 +2,7 @@ package modbusreg_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -65,24 +66,65 @@ func TestM203CorpusReplayIsDeterministicAcrossRealPermutationsAndConcurrentRuns(
 	}
 }
 
+func TestM203BoundedReportCarriesConformanceEvidence(t *testing.T) {
+	corpus, err := reg.NewFixtureConformanceCorpus(m203SyntheticCorpus(t))
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	encoded, err := corpus.MarshalBoundedReport()
+	if err != nil {
+		t.Fatalf("MarshalBoundedReport: %v", err)
+	}
+	var report struct {
+		Records []struct {
+			ProfileVersion string          `json:"profile_version"`
+			Function       json.RawMessage `json:"function"`
+			Table          string          `json:"table"`
+			UnitID         byte            `json:"unit_id"`
+			Normalized     uint16          `json:"normalized_address"`
+			RawWords       [][]uint16      `json:"raw_words"`
+			LogicalSlices  [][]uint16      `json:"logical_slices"`
+			Wire           json.RawMessage `json:"wire"`
+			Logical        json.RawMessage `json:"logical"`
+			Sample         json.RawMessage `json:"sample"`
+			Source         json.RawMessage `json:"source_time"`
+			Qualification  string          `json:"qualification"`
+			Detection      json.RawMessage `json:"detection"`
+		} `json:"records"`
+	}
+	if err := json.Unmarshal(encoded, &report); err != nil {
+		t.Fatalf("report JSON: %v", err)
+	}
+	if len(report.Records) == 0 || report.Records[0].ProfileVersion == "" || len(report.Records[0].Function) == 0 || report.Records[0].Table == "" || report.Records[0].UnitID == 0 || report.Records[0].Normalized == 0 || len(report.Records[0].RawWords) == 0 || len(report.Records[0].LogicalSlices) == 0 || len(report.Records[0].Wire) == 0 || len(report.Records[0].Logical) == 0 || len(report.Records[0].Sample) == 0 || len(report.Records[0].Source) == 0 || report.Records[0].Qualification == "" || len(report.Records[0].Detection) == 0 {
+		t.Fatalf("report omitted conformance evidence: %#v", report.Records)
+	}
+	limited, err := reg.NewFixtureConformanceCorpusWithLimits(m203SyntheticCorpus(t), reg.FixtureConformanceLimits{MaxRecords: 2, MaxReportBytes: 1})
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpusWithLimits: %v", err)
+	}
+	if _, err := limited.MarshalBoundedReport(); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonOversized) {
+		t.Fatalf("small report limit error=%v", err)
+	}
+}
+
 func TestM203CorpusActuallyReplaysConcreteExpectedOutcomes(t *testing.T) {
 	spec := m203SyntheticCorpus(t)
-	valid := spec.Records[0]
-	codec := valid
+	codec := m203SyntheticCorpus(t).Records[0]
 	codec.RecordID = "replay-codec"
-	detector := valid
+	detector := m203SyntheticCorpus(t).Records[0]
 	detector.RecordID = "replay-detector"
-	qualification := valid
+	qualification := m203SyntheticCorpus(t).Records[0]
 	qualification.RecordID = "replay-qualification"
-	normalization := valid
+	normalization := m203SyntheticCorpus(t).Records[0]
 	normalization.RecordID = "replay-normalization"
 	normalization.Observation.Dependencies[0].NormalizationVersion = version(t, "2.0.0")
 	normalization.ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonNormalizationMismatch}
-	generation := valid
+	generationSpec := m203SyntheticCorpus(t)
+	generation := generationSpec.Records[0]
 	generation.RecordID = "replay-generation"
-	generation.Observation.Dependencies[0].View = m203MutateView(t, &spec, 0, 0, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
+	generation.Observation.Dependencies[0].View = m203MutateView(t, &generationSpec, 0, 0, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
 	generation.ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonGenerationMismatch}
-	torn := valid
+	torn := m203SyntheticCorpus(t).Records[0]
 	torn.RecordID = "replay-torn-read"
 	torn.Observation.Dependencies[0].Status = reg.DependencyReadTorn
 	torn.ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonTornRead}

--- a/fixture_conformance_rejection_test.go
+++ b/fixture_conformance_rejection_test.go
@@ -2,8 +2,10 @@ package modbusreg_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	reg "github.com/Project-Helianthus/helianthus-modbusreg"
 )
@@ -102,6 +104,7 @@ func TestM203IncompatibleInputsNeverCrossContaminate(t *testing.T) {
 			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.DeadlineIdentity++ })
 		}, reg.FixtureReplayReasonDeadlineMismatch},
 		{"coherence", func(spec *reg.FixtureConformanceCorpusSpec) {
+			m203RequireDocumentaryMarkerPolicy(t, spec)
 			spec.Records[0].Observation.Dependencies[1].DocumentaryConsistencyMarker = "other-coherence"
 		}, reg.FixtureReplayReasonCoherenceMismatch},
 	}
@@ -158,6 +161,7 @@ func TestM203AcceptedExpectationRejectsIncompatibleOrTornFactsAtConstruction(t *
 			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.DeadlineIdentity++ })
 		}},
 		{"coherence", func(spec *reg.FixtureConformanceCorpusSpec) {
+			m203RequireDocumentaryMarkerPolicy(t, spec)
 			spec.Records[0].Observation.Dependencies[1].DocumentaryConsistencyMarker = "other-coherence"
 		}},
 		{"torn", func(spec *reg.FixtureConformanceCorpusSpec) {
@@ -255,6 +259,143 @@ func TestM203CorpusPreflightsAbsoluteArrayCardinality(t *testing.T) {
 	if _, err := reg.UnmarshalFixtureConformanceCorpus(payload); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonOversized) {
 		t.Fatalf("cardinality preflight error = %v", err)
 	}
+}
+
+func TestM203RejectedCorpusRoundTripsWithoutExpectedRawWords(t *testing.T) {
+	spec := m203SyntheticCorpus(t)
+	spec.Records[0].Observation.Dependencies[0].Status = reg.DependencyReadTorn
+	spec.Records[0].ExpectedReplay = reg.FixtureReplayExpectation{
+		Outcome: reg.FixtureReplayRejected,
+		Reason:  reg.FixtureReplayReasonTornRead,
+	}
+	corpus, err := reg.NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	want, err := corpus.MarshalBoundedReport()
+	if err != nil {
+		t.Fatalf("MarshalBoundedReport: %v", err)
+	}
+	encoded, err := reg.MarshalFixtureConformanceCorpusSpec(spec)
+	if err != nil {
+		t.Fatalf("MarshalFixtureConformanceCorpusSpec: %v", err)
+	}
+	if bytes.Contains(encoded, []byte(`"expected_replay":{"outcome":"rejected","reason":"torn_read","expected_raw_words"`)) {
+		t.Fatalf("rejected corpus unexpectedly serialized raw words: %s", encoded)
+	}
+	restored, err := reg.UnmarshalFixtureConformanceCorpus(encoded)
+	if err != nil {
+		t.Fatalf("UnmarshalFixtureConformanceCorpus: %v", err)
+	}
+	if got, replayErr := restored.MarshalBoundedReport(); replayErr != nil || !bytes.Equal(got, want) {
+		t.Fatalf("rejected round-trip report = %q, %v; want deterministic replay", got, replayErr)
+	}
+}
+
+func TestM203BoundedMultiBlankPolicyAllowsDifferentDocumentaryMarkers(t *testing.T) {
+	spec := m203SyntheticCorpus(t)
+	profileSpec := spec.Profiles[0].Spec()
+	profileSpec.Coherence = reg.CoherencePolicySpec{
+		Version:                   profileSpec.Coherence.Version,
+		Mode:                      reg.CoherenceBoundedMultiResponse,
+		MaximumSourceSkew:         time.Second,
+		MaximumReceiptSkew:        time.Second,
+		RequireGenerationEquality: true,
+		AcquisitionOrder:          reg.AcquisitionOrderDependencyDeclaration,
+		RetrySetBehavior:          reg.RetryWholeSet,
+	}
+	profile, err := reg.NewProfileDescriptor(profileSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor: %v", err)
+	}
+	record := m203Record(t, "fixture-blank-policy-markers", profile, 23, 503)
+	record.Observation.RetryOrdinal = 1
+	for index := range record.Observation.Dependencies {
+		dependency := &record.Observation.Dependencies[index]
+		view := dependency.View.Record()
+		view.WireResponseID += uint64(index)
+		view.PhysicalRequestID += uint64(index)
+		dependency.View = snapshotFromRecord(t, view)
+		dependency.AcquisitionOrdinal = uint32(index + 1)
+		dependency.RetryOrdinal = record.Observation.RetryOrdinal
+		dependency.DocumentaryConsistencyMarker = "marker-" + string(rune('a'+index))
+		dependency.SourceTime = reg.SourceTimeObserved(record.Observation.SourceTime.Time.Add(time.Duration(index) * time.Millisecond))
+		dependency.LocalReceiptTime = record.Observation.LocalReceiptTime.Add(time.Duration(index) * time.Millisecond)
+	}
+	record.Observation.LocalReceiptTime = record.Observation.Dependencies[len(record.Observation.Dependencies)-1].LocalReceiptTime
+	record.Observation.SourceTime = record.Observation.Dependencies[len(record.Observation.Dependencies)-1].SourceTime
+	spec.Profiles[0] = profile
+	spec.Records = []reg.FixtureConformanceRecordSpec{record}
+	corpus, err := reg.NewFixtureConformanceCorpus(spec)
+	if err != nil {
+		t.Fatalf("NewFixtureConformanceCorpus: %v", err)
+	}
+	report, err := corpus.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if got := report.Records()[0].Replay().Actual(); got.Outcome() != reg.FixtureReplayAccepted || got.Reason() != reg.FixtureReplayReasonAccepted {
+		t.Fatalf("blank-policy markers replay = %#v", got)
+	}
+}
+
+func TestM203CorpusPreflightsNestedExpectedRawWordCardinality(t *testing.T) {
+	encoded := m203MarshalCorpusSpec(t)
+	wordSets := make([][]uint16, reg.MaxProfileDependencies+1)
+	for index := range wordSets {
+		wordSets[index] = []uint16{}
+	}
+	words, err := json.Marshal(wordSets)
+	if err != nil {
+		t.Fatalf("json.Marshal nested words: %v", err)
+	}
+	payload := bytes.Replace(encoded, []byte(`"expected_raw_words":[[258,772],[772,1286]]`), append([]byte(`"expected_raw_words":`), words...), 1)
+	if bytes.Equal(payload, encoded) {
+		t.Fatal("nested raw-word fixture did not mutate corpus")
+	}
+	if len(payload) >= reg.MaxSerializedContractBytes {
+		t.Fatalf("nested cardinality fixture exceeds byte limit: %d", len(payload))
+	}
+	if _, err := reg.UnmarshalFixtureConformanceCorpus(payload); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonOversized) {
+		t.Fatalf("nested cardinality preflight error = %v", err)
+	}
+}
+
+func m203RequireDocumentaryMarkerPolicy(t *testing.T, spec *reg.FixtureConformanceCorpusSpec) {
+	t.Helper()
+	profileSpec := spec.Profiles[0].Spec()
+	profileSpec.Coherence = reg.CoherencePolicySpec{
+		Version:                      profileSpec.Coherence.Version,
+		Mode:                         reg.CoherenceBoundedMultiResponse,
+		MaximumSourceSkew:            time.Second,
+		MaximumReceiptSkew:           time.Second,
+		RequireGenerationEquality:    true,
+		AcquisitionOrder:             reg.AcquisitionOrderDependencyDeclaration,
+		RetrySetBehavior:             reg.RetryWholeSet,
+		DocumentaryConsistencyMarker: "required-marker",
+	}
+	profile, err := reg.NewProfileDescriptor(profileSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor: %v", err)
+	}
+	spec.Profiles[0] = profile
+	observation := &spec.Records[0].Observation
+	observation.RetryOrdinal = 1
+	for index := range observation.Dependencies {
+		dependency := &observation.Dependencies[index]
+		view := dependency.View.Record()
+		view.WireResponseID += uint64(index)
+		view.PhysicalRequestID += uint64(index)
+		dependency.View = snapshotFromRecord(t, view)
+		dependency.AcquisitionOrdinal = uint32(index + 1)
+		dependency.RetryOrdinal = observation.RetryOrdinal
+		dependency.DocumentaryConsistencyMarker = "required-marker"
+		dependency.SourceTime = reg.SourceTimeObserved(observation.SourceTime.Time.Add(time.Duration(index) * time.Millisecond))
+		dependency.LocalReceiptTime = observation.LocalReceiptTime.Add(time.Duration(index) * time.Millisecond)
+	}
+	last := observation.Dependencies[len(observation.Dependencies)-1]
+	observation.SourceTime = last.SourceTime
+	observation.LocalReceiptTime = last.LocalReceiptTime
 }
 
 func m203MutateView(t *testing.T, spec *reg.FixtureConformanceCorpusSpec, recordIndex, dependencyIndex int, mutate func(*reg.LogicalViewRecord)) reg.LogicalViewSnapshot {

--- a/fixture_conformance_rejection_test.go
+++ b/fixture_conformance_rejection_test.go
@@ -93,7 +93,7 @@ func TestM203IncompatibleInputsNeverCrossContaminate(t *testing.T) {
 			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
 		}, reg.FixtureReplayReasonGenerationMismatch},
 		{"source", func(spec *reg.FixtureConformanceCorpusSpec) {
-			spec.Records[0].Observation.Dependencies[1].SourceTime = reg.SourceTimeUnavailable()
+			spec.Records[0].Observation.Dependencies[1].SourceTime = reg.SourceTimeObserved(spec.Records[0].Observation.SourceTime.Time)
 		}, reg.FixtureReplayReasonSourceMismatch},
 		{"normalization", func(spec *reg.FixtureConformanceCorpusSpec) {
 			spec.Records[0].Observation.Dependencies[1].NormalizationVersion = version(t, "2.0.0")
@@ -118,7 +118,7 @@ func TestM203IncompatibleInputsNeverCrossContaminate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Replay(%s): %v", test.name, err)
 			}
-			negative, unaffected := report.Records()[0], report.Records()[1]
+			negative, unaffected := report.Records()[1], report.Records()[0]
 			actual := negative.Replay().Actual()
 			if !negative.Replay().MatchesExpected() || actual.Outcome() != reg.FixtureReplayRejected || actual.Reason() != test.reason {
 				t.Fatalf("%s actual=%#v expected=%#v", test.name, actual, negative.Replay().Expected())
@@ -149,7 +149,7 @@ func TestM203AcceptedExpectationRejectsIncompatibleOrTornFactsAtConstruction(t *
 			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
 		}},
 		{"source", func(spec *reg.FixtureConformanceCorpusSpec) {
-			spec.Records[0].Observation.Dependencies[1].SourceTime = reg.SourceTimeUnavailable()
+			spec.Records[0].Observation.Dependencies[1].SourceTime = reg.SourceTimeObserved(spec.Records[0].Observation.SourceTime.Time)
 		}},
 		{"normalization", func(spec *reg.FixtureConformanceCorpusSpec) {
 			spec.Records[0].Observation.Dependencies[1].NormalizationVersion = version(t, "2.0.0")
@@ -172,6 +172,51 @@ func TestM203AcceptedExpectationRejectsIncompatibleOrTornFactsAtConstruction(t *
 				t.Fatalf("accepted %s error = %v, want contradictory", test.name, err)
 			}
 		})
+	}
+}
+
+func TestM203ConstructorRejectsSchemaProbeAndExpectationContradictions(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*reg.FixtureConformanceCorpusSpec)
+		reason reg.FixtureMutationReason
+	}{
+		{"schema", func(spec *reg.FixtureConformanceCorpusSpec) { spec.SchemaVersion = version(t, "2.0.0") }, reg.FixtureMutationReasonMalformed},
+		{"wrong rejection reason", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[0].Status = reg.DependencyReadTorn
+			spec.Records[0].ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: reg.FixtureReplayReasonGenerationMismatch}
+		}, reg.FixtureMutationReasonContradictory},
+		{"wrong accepted words", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].ExpectedReplay.ExpectedRawWords[0][0]++
+		}, reg.FixtureMutationReasonContradictory},
+		{"extra probe", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Detection.Input.Probes = append(spec.Records[0].Detection.Input.Probes, reg.FixtureProbeInput{DeclarationID: "extra", Result: m203ProbeResultSpec("extra", "extra-evidence")})
+		}, reg.FixtureMutationReasonMalformed},
+		{"detector expectation", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Detection.Expected.Outcome = reg.DetectionNoMatch
+		}, reg.FixtureMutationReasonContradictory},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := m203SyntheticCorpus(t)
+			test.mutate(&spec)
+			if _, err := reg.NewFixtureConformanceCorpus(spec); !reg.IsFixtureMutationReason(err, test.reason) {
+				t.Fatalf("%s error=%v", test.name, err)
+			}
+		})
+	}
+}
+
+func TestM203StrictDecodeRejectsUnknownRecordField(t *testing.T) {
+	encoded := m203MarshalCorpusSpec(t)
+	mutated := bytes.Replace(
+		encoded,
+		[]byte(`"record_id"`),
+		[]byte(`"unexpected":true,"record_id"`),
+		1,
+	)
+	if _, err := reg.UnmarshalFixtureConformanceCorpus(mutated); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonMalformed) {
+		t.Fatalf("unknown record field error=%v", err)
 	}
 }
 

--- a/fixture_conformance_rejection_test.go
+++ b/fixture_conformance_rejection_test.go
@@ -207,16 +207,42 @@ func TestM203ConstructorRejectsSchemaProbeAndExpectationContradictions(t *testin
 	}
 }
 
-func TestM203StrictDecodeRejectsUnknownRecordField(t *testing.T) {
+func TestM203StrictDecodeClassifiesRecordAndNestedFixtureFields(t *testing.T) {
 	encoded := m203MarshalCorpusSpec(t)
-	mutated := bytes.Replace(
-		encoded,
-		[]byte(`"record_id"`),
-		[]byte(`"unexpected":true,"record_id"`),
-		1,
-	)
-	if _, err := reg.UnmarshalFixtureConformanceCorpus(mutated); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonMalformed) {
-		t.Fatalf("unknown record field error=%v", err)
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+		reason reg.FixtureMutationReason
+	}{
+		{"record unknown", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"record_id"`), []byte(`"unexpected":true,"record_id"`), 1)
+		}, reg.FixtureMutationReasonUnknown},
+		{"record duplicate", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"record_id"`), []byte(`"record_id":"duplicate","record_id"`), 1)
+		}, reg.FixtureMutationReasonDuplicate},
+		{"record case folded", func(data []byte) []byte { return bytes.Replace(data, []byte(`"record_id"`), []byte(`"Record_ID"`), 1) }, reg.FixtureMutationReasonCaseFolded},
+		{"record missing", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"record_id":"synthetic-fc04-alpha",`), nil, 1)
+		}, reg.FixtureMutationReasonMissing},
+		{"nested unknown", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"qualification":{"expected"`), []byte(`"qualification":{"unexpected":true,"expected"`), 1)
+		}, reg.FixtureMutationReasonUnknown},
+		{"nested duplicate", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"qualification":{"expected"`), []byte(`"qualification":{"expected":"qualified","expected"`), 1)
+		}, reg.FixtureMutationReasonDuplicate},
+		{"nested case folded", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"qualification":{"expected"`), []byte(`"qualification":{"Expected"`), 1)
+		}, reg.FixtureMutationReasonCaseFolded},
+		{"nested missing", func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"qualification":{"expected":"qualified"}`), []byte(`"qualification":{}`), 1)
+		}, reg.FixtureMutationReasonMissing},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := reg.UnmarshalFixtureConformanceCorpus(test.mutate(encoded)); !reg.IsFixtureMutationReason(err, test.reason) {
+				t.Fatalf("error=%v, want stable reason %q", err, test.reason)
+			}
+		})
 	}
 }
 

--- a/fixture_conformance_rejection_test.go
+++ b/fixture_conformance_rejection_test.go
@@ -220,6 +220,17 @@ func TestM203StrictDecodeRejectsUnknownRecordField(t *testing.T) {
 	}
 }
 
+func TestM203CorpusPreflightsAbsoluteArrayCardinality(t *testing.T) {
+	items := strings.Repeat("null,", reg.MaxProfileDependencies) + "null"
+	payload := []byte(`{"schema_version":"1.0.0","metadata":{"corpus_id":"fixture-bomb","license_expression":"CC0-1.0","provenance":"public synthetic fixture"},"profiles":[` + items + `],"records":[null]}`)
+	if len(payload) >= reg.MaxSerializedContractBytes {
+		t.Fatalf("cardinality fixture exceeds byte limit: %d", len(payload))
+	}
+	if _, err := reg.UnmarshalFixtureConformanceCorpus(payload); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonOversized) {
+		t.Fatalf("cardinality preflight error = %v", err)
+	}
+}
+
 func m203MutateView(t *testing.T, spec *reg.FixtureConformanceCorpusSpec, recordIndex, dependencyIndex int, mutate func(*reg.LogicalViewRecord)) reg.LogicalViewSnapshot {
 	t.Helper()
 	record := spec.Records[recordIndex].Observation.Dependencies[dependencyIndex].View.Record()

--- a/fixture_conformance_rejection_test.go
+++ b/fixture_conformance_rejection_test.go
@@ -1,0 +1,183 @@
+package modbusreg_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func m203MarshalCorpusSpec(t *testing.T) []byte {
+	t.Helper()
+	encoded, err := reg.MarshalFixtureConformanceCorpusSpec(m203SyntheticCorpus(t))
+	if err != nil {
+		t.Fatalf("MarshalFixtureConformanceCorpusSpec: %v", err)
+	}
+	return encoded
+}
+
+func TestM203CorpusStrictDecodeRejectsMutatedRawJSON(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func([]byte) []byte
+		reason reg.FixtureMutationReason
+	}{
+		{"missing", func([]byte) []byte { return []byte(`{"metadata":{}}`) }, reg.FixtureMutationReasonMissing},
+		{"unknown", func(encoded []byte) []byte { return append([]byte(`{"unknown":true,`), encoded[1:]...) }, reg.FixtureMutationReasonUnknown},
+		{"duplicate", func(encoded []byte) []byte { return append([]byte(`{"schema_version":"1.0.0",`), encoded[1:]...) }, reg.FixtureMutationReasonDuplicate},
+		{"case folded", func(encoded []byte) []byte {
+			return bytes.Replace(encoded, []byte(`"schema_version"`), []byte(`"Schema_Version"`), 1)
+		}, reg.FixtureMutationReasonCaseFolded},
+		{"malformed", func([]byte) []byte { return []byte(`{"schema_version":`) }, reg.FixtureMutationReasonMalformed},
+		{"oversized", func(encoded []byte) []byte {
+			return bytes.Replace(encoded, []byte("public synthetic fixture"), []byte(strings.Repeat("x", reg.MaxContractStringBytes+1)), 1)
+		}, reg.FixtureMutationReasonOversized},
+		{"contradictory", func(encoded []byte) []byte {
+			return bytes.Replace(encoded, []byte(`"expected":"qualified"`), []byte(`"expected":"rejected"`), 1)
+		}, reg.FixtureMutationReasonContradictory},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := reg.UnmarshalFixtureConformanceCorpus(test.mutate(m203MarshalCorpusSpec(t)))
+			if !reg.IsFixtureMutationReason(err, test.reason) {
+				t.Fatalf("UnmarshalFixtureConformanceCorpus error = %v, want stable reason %q", err, test.reason)
+			}
+		})
+	}
+}
+
+func TestM203CorpusRejectsUnsanitizedFixtureIdentitiesAtConstruction(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*reg.FixtureConformanceCorpusSpec)
+	}{
+		{"credential-like endpoint", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Endpoint = "https://reader:secret@fixture.invalid/registers"
+		}},
+		{"live endpoint identity", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Endpoint = "live-device-987654"
+		}},
+		{"live source identity", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.Endpoint = "site-installation-42" })
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := m203SyntheticCorpus(t)
+			test.mutate(&spec)
+			if _, err := reg.NewFixtureConformanceCorpus(spec); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonUnsanitized) {
+				t.Fatalf("unsanitized %s error = %v, want unsanitized rejection", test.name, err)
+			}
+		})
+	}
+}
+
+func TestM203IncompatibleInputsNeverCrossContaminate(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*reg.FixtureConformanceCorpusSpec)
+		reason reg.FixtureReplayReason
+	}{
+		{"unit", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.UnitID++ })
+		}, reg.FixtureReplayReasonUnitMismatch},
+		{"table access", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) {
+				record.RequestedFunction = reg.FunctionReadHoldingRegisters
+				record.ReceivedFunction = reg.FunctionReadHoldingRegisters
+				record.Table = reg.HoldingRegisters
+			})
+		}, reg.FixtureReplayReasonTableAccessMismatch},
+		{"generation", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
+		}, reg.FixtureReplayReasonGenerationMismatch},
+		{"source", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].SourceTime = reg.SourceTimeUnavailable()
+		}, reg.FixtureReplayReasonSourceMismatch},
+		{"normalization", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].NormalizationVersion = version(t, "2.0.0")
+		}, reg.FixtureReplayReasonNormalizationMismatch},
+		{"deadline", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.DeadlineIdentity++ })
+		}, reg.FixtureReplayReasonDeadlineMismatch},
+		{"coherence", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].DocumentaryConsistencyMarker = "other-coherence"
+		}, reg.FixtureReplayReasonCoherenceMismatch},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := m203SyntheticCorpus(t)
+			test.mutate(&spec)
+			spec.Records[0].ExpectedReplay = reg.FixtureReplayExpectation{Outcome: reg.FixtureReplayRejected, Reason: test.reason}
+			corpus, err := reg.NewFixtureConformanceCorpus(spec)
+			if err != nil {
+				t.Fatalf("NewFixtureConformanceCorpus(%s): %v", test.name, err)
+			}
+			report, err := corpus.Replay()
+			if err != nil {
+				t.Fatalf("Replay(%s): %v", test.name, err)
+			}
+			negative, unaffected := report.Records()[0], report.Records()[1]
+			actual := negative.Replay().Actual()
+			if !negative.Replay().MatchesExpected() || actual.Outcome() != reg.FixtureReplayRejected || actual.Reason() != test.reason {
+				t.Fatalf("%s actual=%#v expected=%#v", test.name, actual, negative.Replay().Expected())
+			}
+			if !unaffected.Replay().MatchesExpected() || unaffected.Replay().Actual().Outcome() != reg.FixtureReplayAccepted {
+				t.Fatalf("%s cross-contaminated unaffected record: %#v", test.name, unaffected)
+			}
+		})
+	}
+}
+
+func TestM203AcceptedExpectationRejectsIncompatibleOrTornFactsAtConstruction(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*reg.FixtureConformanceCorpusSpec)
+	}{
+		{"unit", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.UnitID++ })
+		}},
+		{"table access", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) {
+				record.RequestedFunction = reg.FunctionReadHoldingRegisters
+				record.ReceivedFunction = reg.FunctionReadHoldingRegisters
+				record.Table = reg.HoldingRegisters
+			})
+		}},
+		{"generation", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.PollGeneration++ })
+		}},
+		{"source", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].SourceTime = reg.SourceTimeUnavailable()
+		}},
+		{"normalization", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].NormalizationVersion = version(t, "2.0.0")
+		}},
+		{"deadline", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].View = m203MutateView(t, spec, 0, 1, func(record *reg.LogicalViewRecord) { record.DeadlineIdentity++ })
+		}},
+		{"coherence", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].DocumentaryConsistencyMarker = "other-coherence"
+		}},
+		{"torn", func(spec *reg.FixtureConformanceCorpusSpec) {
+			spec.Records[0].Observation.Dependencies[1].Status = reg.DependencyReadTorn
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			spec := m203SyntheticCorpus(t)
+			test.mutate(&spec)
+			if _, err := reg.NewFixtureConformanceCorpus(spec); !reg.IsFixtureMutationReason(err, reg.FixtureMutationReasonContradictory) {
+				t.Fatalf("accepted %s error = %v, want contradictory", test.name, err)
+			}
+		})
+	}
+}
+
+func m203MutateView(t *testing.T, spec *reg.FixtureConformanceCorpusSpec, recordIndex, dependencyIndex int, mutate func(*reg.LogicalViewRecord)) reg.LogicalViewSnapshot {
+	t.Helper()
+	record := spec.Records[recordIndex].Observation.Dependencies[dependencyIndex].View.Record()
+	mutate(&record)
+	return snapshotFromRecord(t, record)
+}


### PR DESCRIPTION
## What

Implement FMV3-M2-03 sanitized fixture, replay, and cross-profile conformance harnesses.

Closes #7.

## RED Evidence

- Test-only HEAD: `f31cbd75af5896bb989dc982cbe440e31240b820`
- Hosted RED run: `31403715208`
- 9 initial top-level tests plus 25 table subtests defined the bounded corpus, strict serialization, concrete replay, mutation-reason, immutability, overlap, incompatibility, permutation, and concurrency contracts.
- Hosted scope, 14 Python policy mutation tests, and formatting passed, then checks/lint failed as intended on absent M2-03 symbols.

## GREEN Evidence

- First GREEN HEAD: `86a9e29f45e6ffbe165e72b4b9fafee4a3285c72`
- Final exact HEAD: `0236fc208e4003a3552a9339d0ffc71932de9b08`
- Added an immutable bounded transport-neutral corpus, strict nested serialization, exact profile/detector reconstruction, concrete positive/negative replay, typed mutation/replay reasons, preserved per-dependency FC03/FC04 provenance, and deterministic bounded reports.
- Final M2-03 suite: 20 top-level tests plus table mutations.
- Canonical `FixtureReplayer` admission remains authoritative; M2-03 only assigns stable rejection reasons after canonical rejection.
- Corpus-spec serialization canonicalizes accepted top-level profile/record permutations.
- Local `./scripts/ci_local.sh`: PASS, including 14 Python scope mutation tests, race tests, vet, build, and golangci-lint.
- Full suite under `-race -shuffle=on -count=20`: PASS.
- Hosted CI run `31410975212`: PASS.
- `git diff --check`: PASS.

## Review Disposition

- Round 1: five P2. Three fixed; vendor runtime allowlist and companion docs-ebus PR independently validated by design under the stated M2-03 scope.
- Round 2: nested mutation-reason collapse and per-dependency FC03/FC04 provenance loss. Both fixed.
- Round 3: rejected-corpus round-trip asymmetry, blank-marker coherence divergence, and nested expected-raw cardinality classification. All fixed.
- Round 4: noncanonical fixture corpus bytes under accepted top-level permutations. Fixed.
- Round 5: fresh exact-HEAD `NO_BLOCKING_FINDINGS`; no P3/P4.

## Scope

Generic synthetic CC0 fixtures and transport-neutral replay/conformance only. No Fronius/SunSpec/vendor facts, transport sockets/serial/framing, credentials, live-device access, gateway behavior, production publication, or writes.

## Gates

- [x] RED-only commit published
- [x] Hosted RED observed
- [x] GREEN implementation
- [x] Local CI green
- [x] Hosted CI green on exact HEAD
- [x] Fresh exact-HEAD `NO_BLOCKING_FINDINGS`