### PR TITLE
FMV3-M3-02: implement minimal SunSpec phase-one profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ M2-01 defines immutable profile and observation contracts and consumes the
 public M1-06 opaque runtime-acquisition API. M2-02 adds bounded, deterministic,
 read-only profile detection over the immutable catalog. M2-03 adds an immutable
 transport-neutral corpus for sanitized synthetic fixture replay and cross-profile
-conformance. The repository still contains no concrete standard-family profile,
-vendor overlay, qualification record, or vendor fixture; those belong to later
-milestones and require public evidence.
+conformance. M3-02 adds the bounded, read-only SunSpec phase-one standard-family
+profile and parser. Vendor overlays, product qualification, and live access
+remain outside this milestone.
 
 ## One Registry, Multiple Vendors
 
@@ -74,6 +74,8 @@ production sample ID, seal, or publish method.
 The detailed contracts are in [`docs/m2-01-api.md`](docs/m2-01-api.md),
 [`docs/m2-02-detection.md`](docs/m2-02-detection.md), and
 [`docs/m2-03-fixture-conformance.md`](docs/m2-03-fixture-conformance.md). The
+phase-one API, evidence boundary, limits, compatibility gates, and rollback
+are documented in [`docs/sunspec-phase-one.md`](docs/sunspec-phase-one.md). The
 cross-repository architecture remains documented in the public Helianthus
 protocol documentation repository.
 

--- a/docs/sunspec-phase-one.md
+++ b/docs/sunspec-phase-one.md
@@ -24,7 +24,11 @@ first-NUL fixed-width string rules.
 The semantic coordinates are pinned to official SunSpec models revision
 `7abdf8982d5364f8ae916deee18aac86c11be36d`. Common model 1 uses payload
 coordinates `Mn 0:16`, `Md 16:32`, `Opt 32:40`, `Vr 40:48`, `SN 48:64`, and
-`DA 64`. Inverter models 101, 102, and 103 use `W 12`, `W_SF 13`, `WH 22:24`
+`DA 64`. The exact accepted Common length set is `{65,66}`: the qualified
+vendor package uses length 65, while the pinned official model uses length 66
+with a non-semantic Pad at payload offset 65. The Pad remains present in raw
+words and model extent but is not published as a typed value. Inverter models
+101, 102, and 103 use `W 12`, `W_SF 13`, `WH 22:24`
 with the high word first, and `WH_SF 24`. No legacy offset fallback is applied.
 
 `Activate` is stateless across polls. Each call takes a

--- a/docs/sunspec-phase-one.md
+++ b/docs/sunspec-phase-one.md
@@ -29,7 +29,7 @@ validated and retained exactly.
 
 The documentary source is the merged M3-01 evidence packet at
 `helianthus-docs-ebus` commit
-`54d9d178290be8e8cfaac99427e98c64c5ee5136`, specifically
+`59218d21163acb868687ed3d8196f0aa1496aab7`, specifically
 `docs/platform/fronius-sunspec-evidence-v1.md` and its phase-one manifest.
 This implementation contains only the standard contract from that packet; it
 does not imply qualification of any product or live installation.

--- a/docs/sunspec-phase-one.md
+++ b/docs/sunspec-phase-one.md
@@ -1,0 +1,41 @@
+# SunSpec phase one
+
+Issue #9 adds the small public, standard-family surface for a read-only SunSpec
+phase-one discovery image. It is vendor-neutral: it makes no manufacturer,
+product, unit-identity, endpoint, or transport-family decision.
+
+## API and compatibility
+
+`NewSunSpecPhaseOneProfile` accepts only profile and codec version `1.0.0` and
+returns an immutable `ProfileDescriptor`. `NewSunSpecPhaseOneDecoder` accepts
+only that standard-family profile. `DiscoveryRequest` describes FC03 holding
+register discovery at PDU offset `40000`, the normalized form of documentary
+register `40001`. No write or control operation is exported.
+
+`Parse` accepts a bounded raw image (at most 512 words), requires the `SunS`
+signature and a zero-length end marker, and validates every declared extent.
+It semantically exposes models 1, 101, 102, and 103; it structurally skips
+unknown models only after their bounds validate; and it explicitly rejects the
+deferred model families. `Int16`, `Acc32`, `ScaleFactor`, and `String` encode
+the phase-one signedness, high-word ordering, scale-factor range/sentinel, and
+first-NUL fixed-width string rules.
+
+`Activate` does not rebuild observations. It passes the caller-provided
+`ObservationSpec` into the existing immutable admission path, so sample, poll,
+dependency, wire/logical view, timing, version, and coherence facts remain
+validated and retained exactly.
+
+## Evidence, limits, and rollback
+
+The documentary source is the merged M3-01 evidence packet at
+`helianthus-docs-ebus` commit
+`54d9d178290be8e8cfaac99427e98c64c5ee5136`, specifically
+`docs/platform/fronius-sunspec-evidence-v1.md` and its phase-one manifest.
+This implementation contains only the standard contract from that packet; it
+does not imply qualification of any product or live installation.
+
+The raw-chain 512-word limit is an API validation limit, not a request-size or
+scheduler policy. Parsing and activation are memory-only. They open no socket,
+perform no framing, and execute no live access. To roll back phase one, remove
+the profile from a caller catalog and stop invoking the decoder; retained
+observations remain immutable evidence and are not rewritten.

--- a/docs/sunspec-phase-one.md
+++ b/docs/sunspec-phase-one.md
@@ -13,17 +13,21 @@ register discovery at PDU offset `40000`, the normalized form of documentary
 register `40001`. No write or control operation is exported.
 
 `Parse` accepts a bounded raw image (at most 512 words), requires the `SunS`
-signature and a zero-length end marker, and validates every declared extent.
+signature, Common model 1 first and exactly once, and a zero-length end marker
+that consumes all input. It validates every declared extent.
 It semantically exposes models 1, 101, 102, and 103; it structurally skips
 unknown models only after their bounds validate; and it explicitly rejects the
 deferred model families. `Int16`, `Acc32`, `ScaleFactor`, and `String` encode
 the phase-one signedness, high-word ordering, scale-factor range/sentinel, and
 first-NUL fixed-width string rules.
 
-`Activate` does not rebuild observations. It passes the caller-provided
-`ObservationSpec` into the existing immutable admission path, so sample, poll,
-dependency, wire/logical view, timing, version, and coherence facts remain
-validated and retained exactly.
+`Activate` is stateless across polls. Each call takes a
+`SunSpecPhaseOneCapture` containing ordered `LogicalViewSnapshot` source views,
+derives the exact raw chain from contiguous FC03 views beginning at offset
+`40000`, and requires the observation dependency to be the exact captured base
+view. It then passes the caller-provided `ObservationSpec` into the existing
+immutable admission path, so sample, poll, dependency, wire/logical view,
+timing, version, and coherence facts remain validated and retained exactly.
 
 ## Evidence, limits, and rollback
 

--- a/docs/sunspec-phase-one.md
+++ b/docs/sunspec-phase-one.md
@@ -21,6 +21,12 @@ deferred model families. `Int16`, `Acc32`, `ScaleFactor`, and `String` encode
 the phase-one signedness, high-word ordering, scale-factor range/sentinel, and
 first-NUL fixed-width string rules.
 
+The semantic coordinates are pinned to official SunSpec models revision
+`7abdf8982d5364f8ae916deee18aac86c11be36d`. Common model 1 uses payload
+coordinates `Mn 0:16`, `Md 16:32`, `Opt 32:40`, `Vr 40:48`, `SN 48:64`, and
+`DA 64`. Inverter models 101, 102, and 103 use `W 12`, `W_SF 13`, `WH 22:24`
+with the high word first, and `WH_SF 24`. No legacy offset fallback is applied.
+
 `Activate` is stateless across polls. Each call takes a
 `SunSpecPhaseOneCapture` containing ordered `LogicalViewSnapshot` source views,
 derives the exact raw chain from contiguous FC03 views beginning at offset

--- a/profile.go
+++ b/profile.go
@@ -1047,6 +1047,11 @@ func (profile ProfileDescriptor) Version() Version {
 	return profile.spec.Version
 }
 
+// Kind returns whether this immutable profile is a standard family or overlay.
+func (profile ProfileDescriptor) Kind() ProfileKind {
+	return profile.spec.Kind
+}
+
 // RuntimeContractVersion returns the required transport contract version.
 func (profile ProfileDescriptor) RuntimeContractVersion() Version {
 	return profile.spec.RuntimeContractVersion

--- a/sunspec_phase1.go
+++ b/sunspec_phase1.go
@@ -1,8 +1,11 @@
 package modbusreg
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"reflect"
+	"sync"
 )
 
 const (
@@ -25,7 +28,7 @@ func NewSunSpecPhaseOneProfile(versions SunSpecPhaseOneVersions) (ProfileDescrip
 	if err != nil {
 		return ProfileDescriptor{}, err
 	}
-	normalization := AddressNormalizationSpec{Version: versions.Profile, SourceLocator: "urn:helianthus:evidence:sunspec-phase-one-v1", DocumentaryNotation: "40001-to-40000", DocumentaryBase: AddressBaseZeroBased, AddressSpaceLabel: string(HoldingRegisters), DocumentaryAddress: 40000, Transformation: TransformIdentity, ResolvedPDUOffset: 40000}
+	normalization := AddressNormalizationSpec{Version: versions.Profile, SourceLocator: "urn:helianthus:evidence:sunspec-phase-one-v1", DocumentaryNotation: "40001", DocumentaryBase: AddressBaseOneBased, AddressSpaceLabel: string(HoldingRegisters), DocumentaryAddress: 40001, Transformation: TransformSubtractOne, ResolvedPDUOffset: 40000}
 	dependency, err := NewDependency(DependencySpec{ID: "sunspec-chain-base", Version: versions.Profile, Table: HoldingRegisters, Normalization: normalization, WordCount: 1, CodecID: codec.ID(), CodecVersion: codec.Version(), CoherenceGroup: "sunspec-chain", EvidenceReferences: []string{"sunspec-phase-one-v1"}, ApplicabilityRefs: []string{"sunspec-standard-v1"}})
 	if err != nil {
 		return ProfileDescriptor{}, err
@@ -46,7 +49,15 @@ func (SunSpecDiscoveryRequest) Offset() uint16         { return 40000 }
 func (SunSpecDiscoveryRequest) ReadOnly() bool         { return true }
 
 // SunSpecPhaseOneDecoder validates and decodes the v1 standard family only.
-type SunSpecPhaseOneDecoder struct{ profile ProfileDescriptor }
+type SunSpecPhaseOneDecoder struct {
+	profile  ProfileDescriptor
+	bindings *sunSpecBindingStore
+}
+
+type sunSpecBindingStore struct {
+	mu     sync.Mutex
+	values map[[32]byte][]byte
+}
 
 func NewSunSpecPhaseOneDecoder(profile ProfileDescriptor) (SunSpecPhaseOneDecoder, error) {
 	if profile.ID() != sunSpecPhaseOneProfileID || profile.Kind() != ProfileStandardFamily || profile.Version() != CurrentSchemaVersion() || profile.CodecContractVersion() != CurrentCodecContractVersion() {
@@ -59,7 +70,7 @@ func NewSunSpecPhaseOneDecoder(profile ProfileDescriptor) (SunSpecPhaseOneDecode
 	if err != nil || !reflect.DeepEqual(profile.Spec(), expected.Spec()) {
 		return SunSpecPhaseOneDecoder{}, fmt.Errorf("SunSpec phase-one profile is not exact")
 	}
-	return SunSpecPhaseOneDecoder{profile: profile}, nil
+	return SunSpecPhaseOneDecoder{profile: profile, bindings: &sunSpecBindingStore{values: make(map[[32]byte][]byte)}}, nil
 }
 func (SunSpecPhaseOneDecoder) DiscoveryRequest() SunSpecDiscoveryRequest {
 	return SunSpecDiscoveryRequest{}
@@ -75,6 +86,9 @@ func (model SunSpecPhaseOneModel) Length() uint16 { return model.length }
 // SunSpecPhaseOneChain retains semantic and structurally skipped models.
 type SunSpecPhaseOneChain struct {
 	models, skipped []SunSpecPhaseOneModel
+	raw             []uint16
+	common          *SunSpecCommonModel
+	inverters       map[uint16]SunSpecInverterModel
 	valid           bool
 }
 
@@ -85,12 +99,50 @@ func (chain SunSpecPhaseOneChain) SkippedModels() []SunSpecPhaseOneModel {
 	return append([]SunSpecPhaseOneModel(nil), chain.skipped...)
 }
 
+// RawWords returns the exact ordered discovery image.
+func (chain SunSpecPhaseOneChain) RawWords() []uint16 { return append([]uint16(nil), chain.raw...) }
+
+// SunSpecCommonModel exposes the admitted Common model fields.
+type SunSpecCommonModel struct{ manufacturer, model, serial, version string }
+
+func (model SunSpecCommonModel) Manufacturer() string { return model.manufacturer }
+func (model SunSpecCommonModel) Model() string        { return model.model }
+func (model SunSpecCommonModel) SerialNumber() string { return model.serial }
+func (model SunSpecCommonModel) Version() string      { return model.version }
+
+// SunSpecScaledValue preserves raw integer, scale factor, and scaled value.
+type SunSpecScaledValue struct {
+	raw   int64
+	scale int16
+	value float64
+}
+
+func (value SunSpecScaledValue) Raw() int64         { return value.raw }
+func (value SunSpecScaledValue) ScaleFactor() int16 { return value.scale }
+func (value SunSpecScaledValue) Value() float64     { return value.value }
+
+// SunSpecInverterModel exposes admitted int-plus-scale-factor values.
+type SunSpecInverterModel struct{ power, energy SunSpecScaledValue }
+
+func (model SunSpecInverterModel) Power() SunSpecScaledValue  { return model.power }
+func (model SunSpecInverterModel) Energy() SunSpecScaledValue { return model.energy }
+func (chain SunSpecPhaseOneChain) Common() (SunSpecCommonModel, bool) {
+	if chain.common == nil {
+		return SunSpecCommonModel{}, false
+	}
+	return *chain.common, true
+}
+func (chain SunSpecPhaseOneChain) Inverter(id uint16) (SunSpecInverterModel, bool) {
+	value, ok := chain.inverters[id]
+	return value, ok
+}
+
 // Parse validates a bounded raw chain and its required terminal marker.
 func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error) {
 	if len(words) > MaxSunSpecPhaseOneChainWords || len(words) < 4 || words[0] != sunSpecSignatureFirst || words[1] != sunSpecSignatureSecond {
 		return SunSpecPhaseOneChain{}, fmt.Errorf("invalid SunSpec chain signature or bounds")
 	}
-	chain := SunSpecPhaseOneChain{}
+	chain := SunSpecPhaseOneChain{raw: append([]uint16(nil), words...), inverters: make(map[uint16]SunSpecInverterModel)}
 	for offset := 2; ; {
 		if offset+2 > len(words) {
 			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec chain is missing end marker")
@@ -112,7 +164,25 @@ func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error
 		}
 		model := SunSpecPhaseOneModel{id: id, offset: uint16(offset), length: length}
 		switch {
-		case id == 1 || id == 101 || id == 102 || id == 103:
+		case id == 1:
+			if length != 65 {
+				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model length is invalid")
+			}
+			common, err := decodeSunSpecCommon(words[offset+2 : end])
+			if err != nil {
+				return SunSpecPhaseOneChain{}, err
+			}
+			chain.common = &common
+			chain.models = append(chain.models, model)
+		case id == 101 || id == 102 || id == 103:
+			if length != 50 {
+				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec inverter model length is invalid")
+			}
+			inverter, err := decodeSunSpecInverter(words[offset+2 : end])
+			if err != nil {
+				return SunSpecPhaseOneChain{}, err
+			}
+			chain.inverters[id] = inverter
 			chain.models = append(chain.models, model)
 		case deferredSunSpecModel(id):
 			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec model is deferred")
@@ -123,7 +193,64 @@ func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error
 	}
 }
 func deferredSunSpecModel(id uint16) bool {
-	return (id >= 111 && id <= 113) || (id >= 120 && id <= 124) || id == 160 || (id >= 200 && id <= 299) || (id >= 700 && id <= 799)
+	return (id >= 200 && id <= 219) || (id >= 700 && id <= 799)
+}
+
+func decodeSunSpecCommon(words []uint16) (SunSpecCommonModel, error) {
+	decode := func(offset, width int) (string, error) {
+		return SunSpecPhaseOneDecoder{}.String(words[offset : offset+width])
+	}
+	manufacturer, err := decode(0, 16)
+	if err != nil {
+		return SunSpecCommonModel{}, err
+	}
+	model, err := decode(16, 16)
+	if err != nil {
+		return SunSpecCommonModel{}, err
+	}
+	serial, err := decode(32, 16)
+	if err != nil {
+		return SunSpecCommonModel{}, err
+	}
+	version, err := decode(48, 8)
+	if err != nil {
+		return SunSpecCommonModel{}, err
+	}
+	return SunSpecCommonModel{manufacturer: manufacturer, model: model, serial: serial, version: version}, nil
+}
+
+func decodeSunSpecInverter(words []uint16) (SunSpecInverterModel, error) {
+	decoder := SunSpecPhaseOneDecoder{}
+	powerRaw, err := decoder.Int16(words[8])
+	if err != nil {
+		return SunSpecInverterModel{}, err
+	}
+	powerScale, err := decoder.ScaleFactor(words[9])
+	if err != nil {
+		return SunSpecInverterModel{}, err
+	}
+	energyRaw, err := decoder.Acc32(words[16], words[17])
+	if err != nil {
+		return SunSpecInverterModel{}, err
+	}
+	energyScale, err := decoder.ScaleFactor(words[18])
+	if err != nil {
+		return SunSpecInverterModel{}, err
+	}
+	return SunSpecInverterModel{power: SunSpecScaledValue{raw: int64(powerRaw), scale: powerScale, value: float64(powerRaw) * decimalScale(powerScale)}, energy: SunSpecScaledValue{raw: energyRaw, scale: energyScale, value: float64(energyRaw) * decimalScale(energyScale)}}, nil
+}
+
+func decimalScale(exponent int16) float64 {
+	value := 1.0
+	for exponent < 0 {
+		value /= 10
+		exponent++
+	}
+	for exponent > 0 {
+		value *= 10
+		exponent--
+	}
+	return value
 }
 func (SunSpecPhaseOneDecoder) Int16(word uint16) (int16, error) { return int16(word), nil }
 func (SunSpecPhaseOneDecoder) Acc32(high, low uint16) (int64, error) {
@@ -155,12 +282,56 @@ func (SunSpecPhaseOneDecoder) String(words []uint16) (string, error) {
 // SunSpecPhaseOneActivation joins a validated chain to the existing source envelope.
 type SunSpecPhaseOneActivation struct {
 	Chain       SunSpecPhaseOneChain
+	RawWords    []uint16
 	Observation ObservationSpec
 }
 
-func (decoder SunSpecPhaseOneDecoder) Activate(activation SunSpecPhaseOneActivation) (Observation, error) {
-	if !activation.Chain.valid {
-		return Observation{}, fmt.Errorf("SunSpec chain was not parsed")
+// SunSpecPhaseOneObservation retains one admitted observation with its raw chain.
+type SunSpecPhaseOneObservation struct {
+	observation Observation
+	raw         []uint16
+}
+
+func (observation SunSpecPhaseOneObservation) Spec() ObservationSpec {
+	return observation.observation.Spec()
+}
+func (observation SunSpecPhaseOneObservation) RawWords() []uint16 {
+	return append([]uint16(nil), observation.raw...)
+}
+
+func (decoder SunSpecPhaseOneDecoder) Activate(activation SunSpecPhaseOneActivation) (SunSpecPhaseOneObservation, error) {
+	raw := activation.RawWords
+	if raw == nil {
+		raw = activation.Chain.raw
 	}
-	return buildObservation(decoder.profile, activation.Observation)
+	if !activation.Chain.valid || !bytes.Equal(wordsToBytes(activation.Chain.raw), wordsToBytes(raw)) {
+		return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec chain does not match raw words")
+	}
+	observation, err := buildObservation(decoder.profile, activation.Observation)
+	if err != nil {
+		return SunSpecPhaseOneObservation{}, err
+	}
+	encoded := []byte(fmt.Sprintf("%#v", observation.Spec()))
+	key := sha256.Sum256(wordsToBytes(raw))
+	decoder.bindings.mu.Lock()
+	defer decoder.bindings.mu.Unlock()
+	if prior, exists := decoder.bindings.values[key]; exists {
+		if !bytes.Equal(prior, encoded) {
+			return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec raw chain provenance is mismatched")
+		}
+		return SunSpecPhaseOneObservation{observation: observation, raw: append([]uint16(nil), raw...)}, nil
+	}
+	if len(decoder.bindings.values) >= 64 {
+		return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec retained binding limit reached")
+	}
+	decoder.bindings.values[key] = append([]byte(nil), encoded...)
+	return SunSpecPhaseOneObservation{observation: observation, raw: append([]uint16(nil), raw...)}, nil
+}
+
+func wordsToBytes(words []uint16) []byte {
+	result := make([]byte, len(words)*2)
+	for index, word := range words {
+		result[index*2], result[index*2+1] = byte(word>>8), byte(word)
+	}
+	return result
 }

--- a/sunspec_phase1.go
+++ b/sunspec_phase1.go
@@ -93,12 +93,17 @@ func (chain SunSpecPhaseOneChain) SkippedModels() []SunSpecPhaseOneModel {
 func (chain SunSpecPhaseOneChain) RawWords() []uint16 { return append([]uint16(nil), chain.raw...) }
 
 // SunSpecCommonModel exposes the admitted Common model fields.
-type SunSpecCommonModel struct{ manufacturer, model, serial, version string }
+type SunSpecCommonModel struct {
+	manufacturer, model, options, version, serial string
+	deviceAddress                                 uint16
+}
 
-func (model SunSpecCommonModel) Manufacturer() string { return model.manufacturer }
-func (model SunSpecCommonModel) Model() string        { return model.model }
-func (model SunSpecCommonModel) SerialNumber() string { return model.serial }
-func (model SunSpecCommonModel) Version() string      { return model.version }
+func (model SunSpecCommonModel) Manufacturer() string  { return model.manufacturer }
+func (model SunSpecCommonModel) Model() string         { return model.model }
+func (model SunSpecCommonModel) Options() string       { return model.options }
+func (model SunSpecCommonModel) SerialNumber() string  { return model.serial }
+func (model SunSpecCommonModel) Version() string       { return model.version }
+func (model SunSpecCommonModel) DeviceAddress() uint16 { return model.deviceAddress }
 
 // SunSpecScaledValue preserves raw integer, scale factor, and scaled value.
 type SunSpecScaledValue struct {
@@ -211,32 +216,43 @@ func decodeSunSpecCommon(words []uint16) (SunSpecCommonModel, error) {
 	if err != nil {
 		return SunSpecCommonModel{}, err
 	}
-	serial, err := decode(32, 16)
+	options, err := decode(32, 8)
 	if err != nil {
 		return SunSpecCommonModel{}, err
 	}
-	version, err := decode(48, 8)
+	version, err := decode(40, 8)
 	if err != nil {
 		return SunSpecCommonModel{}, err
 	}
-	return SunSpecCommonModel{manufacturer: manufacturer, model: model, serial: serial, version: version}, nil
+	serial, err := decode(48, 16)
+	if err != nil {
+		return SunSpecCommonModel{}, err
+	}
+	return SunSpecCommonModel{
+		manufacturer:  manufacturer,
+		model:         model,
+		options:       options,
+		version:       version,
+		serial:        serial,
+		deviceAddress: words[64],
+	}, nil
 }
 
 func decodeSunSpecInverter(words []uint16) (SunSpecInverterModel, error) {
 	decoder := SunSpecPhaseOneDecoder{}
-	powerRaw, err := decoder.Int16(words[8])
+	powerRaw, err := decoder.Int16(words[12])
 	if err != nil {
 		return SunSpecInverterModel{}, err
 	}
-	powerScale, err := decoder.ScaleFactor(words[9])
+	powerScale, err := decoder.ScaleFactor(words[13])
 	if err != nil {
 		return SunSpecInverterModel{}, err
 	}
-	energyRaw, err := decoder.Acc32(words[16], words[17])
+	energyRaw, err := decoder.Acc32(words[22], words[23])
 	if err != nil {
 		return SunSpecInverterModel{}, err
 	}
-	energyScale, err := decoder.ScaleFactor(words[18])
+	energyScale, err := decoder.ScaleFactor(words[24])
 	if err != nil {
 		return SunSpecInverterModel{}, err
 	}

--- a/sunspec_phase1.go
+++ b/sunspec_phase1.go
@@ -172,7 +172,7 @@ func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error
 			if offset != 2 || chain.common != nil {
 				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model is duplicated or reordered")
 			}
-			if length != 65 {
+			if length != 65 && length != 66 {
 				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model length is invalid")
 			}
 			common, err := decodeSunSpecCommon(words[offset+2 : end])

--- a/sunspec_phase1.go
+++ b/sunspec_phase1.go
@@ -1,11 +1,9 @@
 package modbusreg
 
 import (
-	"bytes"
-	"crypto/sha256"
 	"fmt"
 	"reflect"
-	"sync"
+	"slices"
 )
 
 const (
@@ -49,15 +47,7 @@ func (SunSpecDiscoveryRequest) Offset() uint16         { return 40000 }
 func (SunSpecDiscoveryRequest) ReadOnly() bool         { return true }
 
 // SunSpecPhaseOneDecoder validates and decodes the v1 standard family only.
-type SunSpecPhaseOneDecoder struct {
-	profile  ProfileDescriptor
-	bindings *sunSpecBindingStore
-}
-
-type sunSpecBindingStore struct {
-	mu     sync.Mutex
-	values map[[32]byte][]byte
-}
+type SunSpecPhaseOneDecoder struct{ profile ProfileDescriptor }
 
 func NewSunSpecPhaseOneDecoder(profile ProfileDescriptor) (SunSpecPhaseOneDecoder, error) {
 	if profile.ID() != sunSpecPhaseOneProfileID || profile.Kind() != ProfileStandardFamily || profile.Version() != CurrentSchemaVersion() || profile.CodecContractVersion() != CurrentCodecContractVersion() {
@@ -70,7 +60,7 @@ func NewSunSpecPhaseOneDecoder(profile ProfileDescriptor) (SunSpecPhaseOneDecode
 	if err != nil || !reflect.DeepEqual(profile.Spec(), expected.Spec()) {
 		return SunSpecPhaseOneDecoder{}, fmt.Errorf("SunSpec phase-one profile is not exact")
 	}
-	return SunSpecPhaseOneDecoder{profile: profile, bindings: &sunSpecBindingStore{values: make(map[[32]byte][]byte)}}, nil
+	return SunSpecPhaseOneDecoder{profile: profile}, nil
 }
 func (SunSpecPhaseOneDecoder) DiscoveryRequest() SunSpecDiscoveryRequest {
 	return SunSpecDiscoveryRequest{}
@@ -152,6 +142,12 @@ func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error
 			if length != 0 {
 				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec end marker has nonzero length")
 			}
+			if offset+2 != len(words) {
+				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec chain has trailing words")
+			}
+			if chain.common == nil {
+				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model is missing")
+			}
 			chain.valid = true
 			return chain, nil
 		}
@@ -163,8 +159,14 @@ func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error
 			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec model extent overruns raw chain")
 		}
 		model := SunSpecPhaseOneModel{id: id, offset: uint16(offset), length: length}
+		if offset == 2 && id != 1 {
+			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model must be first")
+		}
 		switch {
 		case id == 1:
+			if offset != 2 || chain.common != nil {
+				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model is duplicated or reordered")
+			}
 			if length != 65 {
 				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec Common model length is invalid")
 			}
@@ -193,7 +195,8 @@ func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error
 	}
 }
 func deferredSunSpecModel(id uint16) bool {
-	return (id >= 200 && id <= 219) || (id >= 700 && id <= 799)
+	return (id >= 111 && id <= 113) || (id >= 120 && id <= 124) || id == 160 ||
+		(id >= 200 && id <= 219) || (id >= 700 && id <= 799)
 }
 
 func decodeSunSpecCommon(words []uint16) (SunSpecCommonModel, error) {
@@ -279,10 +282,21 @@ func (SunSpecPhaseOneDecoder) String(words []uint16) (string, error) {
 	return string(bytes), nil
 }
 
-// SunSpecPhaseOneActivation joins a validated chain to the existing source envelope.
+// SunSpecPhaseOneCapture is the ordered source-view input for one activation.
+type SunSpecPhaseOneCapture struct {
+	SourceViews []LogicalViewSnapshot
+}
+
+// Views returns defensive copies of the ordered source views.
+func (capture SunSpecPhaseOneCapture) Views() []LogicalViewSnapshot {
+	return cloneSunSpecViews(capture.SourceViews)
+}
+
+// SunSpecPhaseOneActivation joins a validated chain to one exact source capture.
 type SunSpecPhaseOneActivation struct {
 	Chain       SunSpecPhaseOneChain
 	RawWords    []uint16
+	Capture     SunSpecPhaseOneCapture
 	Observation ObservationSpec
 }
 
@@ -290,6 +304,7 @@ type SunSpecPhaseOneActivation struct {
 type SunSpecPhaseOneObservation struct {
 	observation Observation
 	raw         []uint16
+	views       []LogicalViewSnapshot
 }
 
 func (observation SunSpecPhaseOneObservation) Spec() ObservationSpec {
@@ -298,40 +313,134 @@ func (observation SunSpecPhaseOneObservation) Spec() ObservationSpec {
 func (observation SunSpecPhaseOneObservation) RawWords() []uint16 {
 	return append([]uint16(nil), observation.raw...)
 }
+func (observation SunSpecPhaseOneObservation) SourceViews() []LogicalViewSnapshot {
+	return cloneSunSpecViews(observation.views)
+}
 
 func (decoder SunSpecPhaseOneDecoder) Activate(activation SunSpecPhaseOneActivation) (SunSpecPhaseOneObservation, error) {
-	raw := activation.RawWords
-	if raw == nil {
-		raw = activation.Chain.raw
+	if !activation.Chain.valid {
+		return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec chain was not parsed")
 	}
-	if !activation.Chain.valid || !bytes.Equal(wordsToBytes(activation.Chain.raw), wordsToBytes(raw)) {
+	raw, views, err := validateSunSpecCapture(activation.Capture)
+	if err != nil {
+		return SunSpecPhaseOneObservation{}, err
+	}
+	if !slices.Equal(activation.Chain.raw, raw) ||
+		(activation.RawWords != nil && !slices.Equal(activation.RawWords, raw)) {
 		return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec chain does not match raw words")
 	}
 	observation, err := buildObservation(decoder.profile, activation.Observation)
 	if err != nil {
 		return SunSpecPhaseOneObservation{}, err
 	}
-	encoded := []byte(fmt.Sprintf("%#v", observation.Spec()))
-	key := sha256.Sum256(wordsToBytes(raw))
-	decoder.bindings.mu.Lock()
-	defer decoder.bindings.mu.Unlock()
-	if prior, exists := decoder.bindings.values[key]; exists {
-		if !bytes.Equal(prior, encoded) {
-			return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec raw chain provenance is mismatched")
-		}
-		return SunSpecPhaseOneObservation{observation: observation, raw: append([]uint16(nil), raw...)}, nil
+	if err := bindSunSpecObservation(decoder.profile, observation.Spec(), views); err != nil {
+		return SunSpecPhaseOneObservation{}, err
 	}
-	if len(decoder.bindings.values) >= 64 {
-		return SunSpecPhaseOneObservation{}, fmt.Errorf("SunSpec retained binding limit reached")
-	}
-	decoder.bindings.values[key] = append([]byte(nil), encoded...)
-	return SunSpecPhaseOneObservation{observation: observation, raw: append([]uint16(nil), raw...)}, nil
+	return SunSpecPhaseOneObservation{
+		observation: observation,
+		raw:         append([]uint16(nil), raw...),
+		views:       cloneSunSpecViews(views),
+	}, nil
 }
 
-func wordsToBytes(words []uint16) []byte {
-	result := make([]byte, len(words)*2)
-	for index, word := range words {
-		result[index*2], result[index*2+1] = byte(word>>8), byte(word)
+func validateSunSpecCapture(capture SunSpecPhaseOneCapture) ([]uint16, []LogicalViewSnapshot, error) {
+	if len(capture.SourceViews) == 0 || len(capture.SourceViews) > MaxSunSpecPhaseOneChainWords {
+		return nil, nil, fmt.Errorf("SunSpec source-view count is invalid")
+	}
+	views := cloneSunSpecViews(capture.SourceViews)
+	first := views[0].Record()
+	expectedOffset := uint32(40000)
+	raw := make([]uint16, 0, MaxSunSpecPhaseOneChainWords)
+	logicalIDs := make(map[uint64]struct{}, len(views))
+	type physicalIdentity struct {
+		wireResponseID, connectionID, transportGeneration uint64
+		function                                          FunctionCode
+		table                                             LogicalTable
+		offset, count                                     uint16
+	}
+	physicalIDs := make(map[uint64]physicalIdentity, len(views))
+	type wireIdentity struct {
+		physicalRequestID uint64
+		responseBytes     []byte
+	}
+	wireIDs := make(map[uint64]wireIdentity, len(views))
+	for index, view := range views {
+		if !view.valid {
+			return nil, nil, fmt.Errorf("SunSpec source view %d is invalid", index)
+		}
+		record := view.Record()
+		if uint32(record.LogicalOffset) != expectedOffset ||
+			record.Table != HoldingRegisters ||
+			record.RequestedFunction != FunctionReadHoldingRegisters ||
+			record.ReceivedFunction != FunctionReadHoldingRegisters ||
+			record.Endpoint != first.Endpoint || record.UnitID != first.UnitID ||
+			record.PollGeneration != first.PollGeneration ||
+			record.Transport != first.Transport ||
+			record.TransportGeneration != first.TransportGeneration ||
+			record.ConnectionID != first.ConnectionID ||
+			record.AuthorizationScope != first.AuthorizationScope {
+			return nil, nil, fmt.Errorf("SunSpec source views are detached or incoherent")
+		}
+		if _, duplicate := logicalIDs[record.LogicalViewID]; duplicate {
+			return nil, nil, fmt.Errorf("SunSpec logical-view identity is duplicated")
+		}
+		logicalIDs[record.LogicalViewID] = struct{}{}
+		physical := physicalIdentity{
+			wireResponseID: record.WireResponseID, connectionID: record.ConnectionID,
+			transportGeneration: record.TransportGeneration, function: record.RequestedFunction,
+			table: record.Table, offset: record.PhysicalOffset, count: record.PhysicalWordCount,
+		}
+		if prior, exists := physicalIDs[record.PhysicalRequestID]; exists && prior != physical {
+			return nil, nil, fmt.Errorf("SunSpec physical-request identity is contradictory")
+		}
+		physicalIDs[record.PhysicalRequestID] = physical
+		if prior, exists := wireIDs[record.WireResponseID]; exists {
+			if prior.physicalRequestID != record.PhysicalRequestID ||
+				!slices.Equal(prior.responseBytes, record.WireResponseBytes) {
+				return nil, nil, fmt.Errorf("SunSpec wire-response identity is contradictory")
+			}
+		}
+		wireIDs[record.WireResponseID] = wireIdentity{
+			physicalRequestID: record.PhysicalRequestID,
+			responseBytes:     append([]byte(nil), record.WireResponseBytes...),
+		}
+		if len(raw)+len(record.Words) > MaxSunSpecPhaseOneChainWords {
+			return nil, nil, fmt.Errorf("SunSpec source views exceed the raw bound")
+		}
+		raw = append(raw, record.Words...)
+		expectedOffset += uint32(record.LogicalWordCount)
+	}
+	return raw, views, nil
+}
+
+func bindSunSpecObservation(profile ProfileDescriptor, spec ObservationSpec, views []LogicalViewSnapshot) error {
+	if len(spec.Dependencies) != 1 || len(views) == 0 {
+		return fmt.Errorf("SunSpec observation has no exact base source view")
+	}
+	dependency := profile.Dependencies().Dependencies()[0]
+	result := spec.Dependencies[0]
+	if result.DependencyID != dependency.ID() ||
+		result.DependencyVersion != dependency.Version() ||
+		result.CodecID != dependency.CodecID() ||
+		result.CodecVersion != dependency.CodecVersion() ||
+		result.NormalizationVersion != dependency.Normalization().Spec().Version ||
+		!reflect.DeepEqual(result.View.Record(), views[0].Record()) {
+		return fmt.Errorf("SunSpec observation base view is detached from capture")
+	}
+	first := views[0].Record()
+	if spec.Endpoint != first.Endpoint || spec.UnitID != first.UnitID ||
+		spec.PollGenerationID != first.PollGeneration ||
+		first.LogicalOffset != dependency.Normalization().ResolvedPDUOffset() ||
+		first.LogicalWordCount != dependency.WordCount() {
+		return fmt.Errorf("SunSpec observation provenance disagrees with capture")
+	}
+	return nil
+}
+
+func cloneSunSpecViews(values []LogicalViewSnapshot) []LogicalViewSnapshot {
+	result := make([]LogicalViewSnapshot, len(values))
+	for index, value := range values {
+		result[index], _ = NewLogicalViewSnapshot(value.Record())
 	}
 	return result
 }

--- a/sunspec_phase1.go
+++ b/sunspec_phase1.go
@@ -1,0 +1,166 @@
+package modbusreg
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const (
+	sunSpecPhaseOneProfileID     = "sunspec.phase1"
+	sunSpecSignatureFirst        = 0x5375
+	sunSpecSignatureSecond       = 0x6e53
+	sunSpecEndModel              = 0xffff
+	MaxSunSpecPhaseOneChainWords = 512
+)
+
+// SunSpecPhaseOneVersions selects the only supported profile and codec forms.
+type SunSpecPhaseOneVersions struct{ Profile, Codec Version }
+
+// NewSunSpecPhaseOneProfile returns the vendor-neutral, read-only v1 profile.
+func NewSunSpecPhaseOneProfile(versions SunSpecPhaseOneVersions) (ProfileDescriptor, error) {
+	if versions.Profile != CurrentSchemaVersion() || versions.Codec != CurrentCodecContractVersion() {
+		return ProfileDescriptor{}, fmt.Errorf("unsupported SunSpec phase-one version")
+	}
+	codec, err := NewCodec(CodecSpec{ID: "sunspec-chain-word", Version: versions.Codec, RawWordCount: 1, WordPermutation: []uint16{0}, IntraWordByteOrder: ByteOrderModbus, Representation: RepresentationUnsignedInteger, Scale: ScaleSpec{Source: ScaleNotApplicable, ApplicationOrder: ScaleOrderNotApplicable}, String: StringSpec{Applicability: StringNotApplicable}, OutputProfileType: "uint16", ValidityBehavior: ValidityPreserveRaw})
+	if err != nil {
+		return ProfileDescriptor{}, err
+	}
+	normalization := AddressNormalizationSpec{Version: versions.Profile, SourceLocator: "urn:helianthus:evidence:sunspec-phase-one-v1", DocumentaryNotation: "40001-to-40000", DocumentaryBase: AddressBaseZeroBased, AddressSpaceLabel: string(HoldingRegisters), DocumentaryAddress: 40000, Transformation: TransformIdentity, ResolvedPDUOffset: 40000}
+	dependency, err := NewDependency(DependencySpec{ID: "sunspec-chain-base", Version: versions.Profile, Table: HoldingRegisters, Normalization: normalization, WordCount: 1, CodecID: codec.ID(), CodecVersion: codec.Version(), CoherenceGroup: "sunspec-chain", EvidenceReferences: []string{"sunspec-phase-one-v1"}, ApplicabilityRefs: []string{"sunspec-standard-v1"}})
+	if err != nil {
+		return ProfileDescriptor{}, err
+	}
+	dependencies, err := NewDependencySet(versions.Profile, []Dependency{dependency})
+	if err != nil {
+		return ProfileDescriptor{}, err
+	}
+	return NewProfileDescriptor(ProfileDescriptorSpec{SchemaVersion: CurrentSchemaVersion(), ID: sunSpecPhaseOneProfileID, Version: versions.Profile, Kind: ProfileStandardFamily, StandardApplicability: []string{"sunspec-standard-v1"}, ModelApplicability: []string{"model-1", "model-101", "model-102", "model-103"}, KnownExclusions: []string{}, RuntimeContractVersion: PinnedRuntimeContractVersion(), DetectorVersion: versions.Profile, CodecContractVersion: versions.Codec, NormalizationVersion: versions.Profile, CoherenceVersion: versions.Profile, QualificationVersion: versions.Profile, Codecs: []Codec{codec}, Dependencies: dependencies, Coherence: CoherencePolicySpec{Version: versions.Profile, Mode: CoherenceSingleWireResponse, AcquisitionOrder: AcquisitionOrderNotApplicable, RetrySetBehavior: RetrySetNotApplicable}, Evidence: []EvidenceReference{{ID: "sunspec-phase-one-v1", PublicationDisposition: PublicationPublished}}, Maturity: MaturityExperimental, State: ProfileActive})
+}
+
+// SunSpecDiscoveryRequest declares the protocol's one read-only base request.
+type SunSpecDiscoveryRequest struct{}
+
+func (SunSpecDiscoveryRequest) Function() FunctionCode { return FunctionReadHoldingRegisters }
+func (SunSpecDiscoveryRequest) Table() LogicalTable    { return HoldingRegisters }
+func (SunSpecDiscoveryRequest) Offset() uint16         { return 40000 }
+func (SunSpecDiscoveryRequest) ReadOnly() bool         { return true }
+
+// SunSpecPhaseOneDecoder validates and decodes the v1 standard family only.
+type SunSpecPhaseOneDecoder struct{ profile ProfileDescriptor }
+
+func NewSunSpecPhaseOneDecoder(profile ProfileDescriptor) (SunSpecPhaseOneDecoder, error) {
+	if profile.ID() != sunSpecPhaseOneProfileID || profile.Kind() != ProfileStandardFamily || profile.Version() != CurrentSchemaVersion() || profile.CodecContractVersion() != CurrentCodecContractVersion() {
+		return SunSpecPhaseOneDecoder{}, fmt.Errorf("unsupported SunSpec phase-one profile")
+	}
+	expected, err := NewSunSpecPhaseOneProfile(SunSpecPhaseOneVersions{
+		Profile: CurrentSchemaVersion(),
+		Codec:   CurrentCodecContractVersion(),
+	})
+	if err != nil || !reflect.DeepEqual(profile.Spec(), expected.Spec()) {
+		return SunSpecPhaseOneDecoder{}, fmt.Errorf("SunSpec phase-one profile is not exact")
+	}
+	return SunSpecPhaseOneDecoder{profile: profile}, nil
+}
+func (SunSpecPhaseOneDecoder) DiscoveryRequest() SunSpecDiscoveryRequest {
+	return SunSpecDiscoveryRequest{}
+}
+
+// SunSpecPhaseOneModel records one structural model extent in the raw chain.
+type SunSpecPhaseOneModel struct{ id, offset, length uint16 }
+
+func (model SunSpecPhaseOneModel) ID() uint16     { return model.id }
+func (model SunSpecPhaseOneModel) Offset() uint16 { return model.offset }
+func (model SunSpecPhaseOneModel) Length() uint16 { return model.length }
+
+// SunSpecPhaseOneChain retains semantic and structurally skipped models.
+type SunSpecPhaseOneChain struct {
+	models, skipped []SunSpecPhaseOneModel
+	valid           bool
+}
+
+func (chain SunSpecPhaseOneChain) Models() []SunSpecPhaseOneModel {
+	return append([]SunSpecPhaseOneModel(nil), chain.models...)
+}
+func (chain SunSpecPhaseOneChain) SkippedModels() []SunSpecPhaseOneModel {
+	return append([]SunSpecPhaseOneModel(nil), chain.skipped...)
+}
+
+// Parse validates a bounded raw chain and its required terminal marker.
+func (SunSpecPhaseOneDecoder) Parse(words []uint16) (SunSpecPhaseOneChain, error) {
+	if len(words) > MaxSunSpecPhaseOneChainWords || len(words) < 4 || words[0] != sunSpecSignatureFirst || words[1] != sunSpecSignatureSecond {
+		return SunSpecPhaseOneChain{}, fmt.Errorf("invalid SunSpec chain signature or bounds")
+	}
+	chain := SunSpecPhaseOneChain{}
+	for offset := 2; ; {
+		if offset+2 > len(words) {
+			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec chain is missing end marker")
+		}
+		id, length := words[offset], words[offset+1]
+		if id == sunSpecEndModel {
+			if length != 0 {
+				return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec end marker has nonzero length")
+			}
+			chain.valid = true
+			return chain, nil
+		}
+		if length == 0 {
+			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec non-end model has zero length")
+		}
+		end := offset + 2 + int(length)
+		if end > len(words) {
+			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec model extent overruns raw chain")
+		}
+		model := SunSpecPhaseOneModel{id: id, offset: uint16(offset), length: length}
+		switch {
+		case id == 1 || id == 101 || id == 102 || id == 103:
+			chain.models = append(chain.models, model)
+		case deferredSunSpecModel(id):
+			return SunSpecPhaseOneChain{}, fmt.Errorf("SunSpec model is deferred")
+		default:
+			chain.skipped = append(chain.skipped, model)
+		}
+		offset = end
+	}
+}
+func deferredSunSpecModel(id uint16) bool {
+	return (id >= 111 && id <= 113) || (id >= 120 && id <= 124) || id == 160 || (id >= 200 && id <= 299) || (id >= 700 && id <= 799)
+}
+func (SunSpecPhaseOneDecoder) Int16(word uint16) (int16, error) { return int16(word), nil }
+func (SunSpecPhaseOneDecoder) Acc32(high, low uint16) (int64, error) {
+	return int64(uint32(high)<<16 | uint32(low)), nil
+}
+func (SunSpecPhaseOneDecoder) ScaleFactor(word uint16) (int16, error) {
+	value := int16(word)
+	if value == -32768 || value < -10 || value > 10 {
+		return 0, fmt.Errorf("invalid SunSpec scale factor")
+	}
+	return value, nil
+}
+func (SunSpecPhaseOneDecoder) String(words []uint16) (string, error) {
+	if len(words) > MaxRawWords {
+		return "", fmt.Errorf("SunSpec string exceeds word bound")
+	}
+	bytes := make([]byte, 0, len(words)*2)
+	for _, word := range words {
+		for _, value := range []byte{byte(word >> 8), byte(word)} {
+			if value == 0 {
+				return string(bytes), nil
+			}
+			bytes = append(bytes, value)
+		}
+	}
+	return string(bytes), nil
+}
+
+// SunSpecPhaseOneActivation joins a validated chain to the existing source envelope.
+type SunSpecPhaseOneActivation struct {
+	Chain       SunSpecPhaseOneChain
+	Observation ObservationSpec
+}
+
+func (decoder SunSpecPhaseOneDecoder) Activate(activation SunSpecPhaseOneActivation) (Observation, error) {
+	if !activation.Chain.valid {
+		return Observation{}, fmt.Errorf("SunSpec chain was not parsed")
+	}
+	return buildObservation(decoder.profile, activation.Observation)
+}

--- a/sunspec_phase1_review_test.go
+++ b/sunspec_phase1_review_test.go
@@ -123,25 +123,35 @@ func TestSunSpecPhaseOneIdenticalRawAllowsDistinctCoherentPolls(t *testing.T) {
 
 func TestSunSpecPhaseOneParsesFixtureSemanticsFromRawModels(t *testing.T) {
 	decoder, _ := reviewDecoder(t)
-	// Values are the public M3-01 synthetic FSS-P-002 and FSS-P-003 examples.
+	// Offsets follow official models commit 7abdf8982d5364f8ae916deee18aac86c11be36d.
 	chain, err := decoder.Parse(reviewRawChain(101, 102, 103))
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
 	common, ok := chain.Common()
 	if !ok || common.Manufacturer() != "FixtureCo" || common.Model() != "Fixture-1" ||
-		common.SerialNumber() != "PLACEHOLDER" || common.Version() != "VERSION123456789" {
+		common.Options() != "A" || common.Version() != "VERSION123456789" ||
+		common.SerialNumber() != "PLACEHOLDER" || common.DeviceAddress() != 42 {
 		t.Fatalf("Common model 1 = %#v, present=%t", common, ok)
+	}
+	expected := map[uint16]struct {
+		powerRaw, powerScale, energyRaw, energyScale int64
+		powerValue, energyValue                      float64
+	}{
+		101: {-123, -1, 120000, 0, -12.3, 120000},
+		102: {321, -1, 131072, 0, 32.1, 131072},
+		103: {-10, -2, 4660, 0, -0.1, 4660},
 	}
 	for _, id := range []uint16{101, 102, 103} {
 		inverter, ok := chain.Inverter(id)
 		if !ok {
 			t.Fatalf("model %d was not semantically exposed", id)
 		}
-		if power := inverter.Power(); power.Raw() != -123 || power.ScaleFactor() != -1 || power.Value() != -12.3 {
+		want := expected[id]
+		if power := inverter.Power(); power.Raw() != want.powerRaw || int64(power.ScaleFactor()) != want.powerScale || power.Value() != want.powerValue {
 			t.Fatalf("model %d power = %#v", id, power)
 		}
-		if energy := inverter.Energy(); energy.Raw() != 120000 || energy.ScaleFactor() != 0 || energy.Value() != 120000 {
+		if energy := inverter.Energy(); energy.Raw() != want.energyRaw || int64(energy.ScaleFactor()) != want.energyScale || energy.Value() != want.energyValue {
 			t.Fatalf("model %d energy = %#v", id, energy)
 		}
 	}
@@ -216,14 +226,28 @@ func reviewRawChain(ids ...uint16) []uint16 {
 	common := make([]uint16, 65)
 	copy(common[0:], reviewStringWords("FixtureCo", 16))
 	copy(common[16:], reviewStringWords("Fixture-1", 16))
-	copy(common[32:], reviewStringWords("PLACEHOLDER", 16))
-	copy(common[48:], reviewStringWords("VERSION123456789", 8))
+	copy(common[32:], reviewStringWords("A", 8))
+	copy(common[40:], reviewStringWords("VERSION123456789", 8))
+	copy(common[48:], reviewStringWords("PLACEHOLDER", 16))
+	common[64] = 42
 	words = append(words, common...)
 	for _, id := range ids {
 		words = append(words, id, 50)
 		payload := make([]uint16, 50)
-		payload[8], payload[9] = 0xff85, 0xffff
-		payload[16], payload[17], payload[18] = 1, 0xd4c0, 0
+		// Poison the old incorrect offsets with valid but unmistakably wrong values.
+		payload[8], payload[9] = 123, 1
+		payload[16], payload[17], payload[18] = 3, 4, 1
+		switch id {
+		case 101:
+			payload[12], payload[13] = 0xff85, 0xffff
+			payload[22], payload[23], payload[24] = 1, 0xd4c0, 0
+		case 102:
+			payload[12], payload[13] = 321, 0xffff
+			payload[22], payload[23], payload[24] = 2, 0, 0
+		case 103:
+			payload[12], payload[13] = 0xfff6, 0xfffe
+			payload[22], payload[23], payload[24] = 0, 0x1234, 0
+		}
 		words = append(words, payload...)
 	}
 	return append(words, 0xffff, 0)

--- a/sunspec_phase1_review_test.go
+++ b/sunspec_phase1_review_test.go
@@ -1,6 +1,7 @@
 package modbusreg_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -14,10 +15,11 @@ func TestSunSpecPhaseOneActivationBindsRawChainAndObservation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	observation := sunSpecObservation(t, profile)
+	capture, observation := reviewCapture(t, profile, raw, 77, 900, reg.TransportTCP)
 	activated, err := decoder.Activate(reg.SunSpecPhaseOneActivation{
 		Chain:       chain,
 		RawWords:    raw,
+		Capture:     capture,
 		Observation: observation,
 	})
 	if err != nil {
@@ -42,6 +44,11 @@ func TestSunSpecPhaseOneActivationBindsRawChainAndObservation(t *testing.T) {
 			record.WireResponseID++
 			a.Observation.Dependencies[0].View = snapshotFromRecord(t, record)
 		}},
+		{"physical identity", func(a *reg.SunSpecPhaseOneActivation) {
+			record := a.Observation.Dependencies[0].View.Record()
+			record.PhysicalRequestID++
+			a.Observation.Dependencies[0].View = snapshotFromRecord(t, record)
+		}},
 		{"logical identity", func(a *reg.SunSpecPhaseOneActivation) {
 			record := a.Observation.Dependencies[0].View.Record()
 			record.LogicalViewID++
@@ -52,13 +59,63 @@ func TestSunSpecPhaseOneActivationBindsRawChainAndObservation(t *testing.T) {
 			record.TransportGeneration++
 			a.Observation.Dependencies[0].View = snapshotFromRecord(t, record)
 		}},
+		{"reordered source views", func(a *reg.SunSpecPhaseOneActivation) {
+			a.Capture.SourceViews[0], a.Capture.SourceViews[1] = a.Capture.SourceViews[1], a.Capture.SourceViews[0]
+		}},
+		{"mixed acquisition generation", func(a *reg.SunSpecPhaseOneActivation) {
+			record := a.Capture.SourceViews[1].Record()
+			record.TransportGeneration++
+			a.Capture.SourceViews[1] = snapshotFromRecord(t, record)
+		}},
 	}
 	for _, test := range mutations {
 		t.Run(test.name, func(t *testing.T) {
-			activation := reg.SunSpecPhaseOneActivation{Chain: chain, RawWords: raw, Observation: observation}
+			activation := reg.SunSpecPhaseOneActivation{Chain: chain, RawWords: raw, Capture: capture, Observation: observation}
+			activation.Capture.SourceViews = append([]reg.LogicalViewSnapshot(nil), capture.SourceViews...)
 			test.mutate(&activation)
 			if _, err := decoder.Activate(activation); err == nil {
 				t.Fatal("Activate accepted a mismatched chain/observation binding")
+			}
+		})
+	}
+}
+
+func TestSunSpecPhaseOneFreshActivationRequiresExactSourceViews(t *testing.T) {
+	decoder, profile := reviewDecoder(t)
+	raw := reviewRawChain(101)
+	chain, err := decoder.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	capture, _ := reviewCapture(t, profile, raw, 81, 1000, reg.TransportTCP)
+	_, unrelated := reviewCapture(t, profile, raw, 82, 2000, reg.TransportTCP)
+	if _, err := decoder.Activate(reg.SunSpecPhaseOneActivation{
+		Chain: chain, RawWords: raw, Capture: capture, Observation: unrelated,
+	}); err == nil {
+		t.Fatal("fresh decoder accepted an unrelated but internally valid observation")
+	}
+}
+
+func TestSunSpecPhaseOneIdenticalRawAllowsDistinctCoherentPolls(t *testing.T) {
+	for _, transport := range []reg.TransportFamily{reg.TransportTCP, reg.TransportRTU} {
+		t.Run(string(transport), func(t *testing.T) {
+			decoder, profile := reviewDecoder(t)
+			raw := reviewRawChain(101)
+			chain, err := decoder.Parse(raw)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			for index, poll := range []uint64{91, 92} {
+				capture, observation := reviewCapture(t, profile, raw, poll, uint64(3000+index*100), transport)
+				activated, err := decoder.Activate(reg.SunSpecPhaseOneActivation{
+					Chain: chain, RawWords: raw, Capture: capture, Observation: observation,
+				})
+				if err != nil {
+					t.Fatalf("Activate(poll %d): %v", poll, err)
+				}
+				if activated.Spec().PollGenerationID != poll || activated.Spec().SampleID != observation.SampleID {
+					t.Fatalf("poll %d provenance was not retained", poll)
+				}
 			}
 		})
 	}
@@ -108,7 +165,7 @@ func TestSunSpecPhaseOneUsesExactNormalizationLengthsAndDeferredSet(t *testing.T
 			t.Fatalf("model %d length %d was accepted", test.id, test.length)
 		}
 	}
-	for _, id := range []uint16{200, 219, 777} {
+	for _, id := range []uint16{111, 113, 120, 124, 160, 200, 219, 777} {
 		if _, err := decoder.Parse(reviewRawChainWithLength(id, 3)); err == nil {
 			t.Fatalf("deferred model %d was accepted", id)
 		}
@@ -116,6 +173,27 @@ func TestSunSpecPhaseOneUsesExactNormalizationLengthsAndDeferredSet(t *testing.T
 	chain, err := decoder.Parse(reviewRawChainWithLength(220, 3))
 	if err != nil || !reflect.DeepEqual(modelIDs(chain.SkippedModels()), []uint16{220}) {
 		t.Fatalf("model 220 was not structurally skipped: %#v, %v", chain, err)
+	}
+	chain, err = decoder.Parse(reviewRawChainWithLength(666, 3))
+	if err != nil || !reflect.DeepEqual(modelIDs(chain.SkippedModels()), []uint16{666}) {
+		t.Fatalf("model 666 was not structurally skipped: %#v, %v", chain, err)
+	}
+}
+
+func TestSunSpecPhaseOneRejectsTrailingWordsAndInvalidCommonOrder(t *testing.T) {
+	decoder, _ := reviewDecoder(t)
+	valid := reviewRawChain(101)
+	if _, err := decoder.Parse(append(append([]uint16(nil), valid...), 0)); err == nil {
+		t.Fatal("chain with words after the terminal marker was accepted")
+	}
+	for _, words := range [][]uint16{
+		reviewRawChainWithLength(101, 50),
+		sunSpecWords(1, 65, 1, 65, 0xffff, 0),
+		sunSpecWords(666, 3, 1, 65, 0xffff, 0),
+	} {
+		if _, err := decoder.Parse(words); err == nil {
+			t.Fatalf("invalid Common model ordering accepted: %v", modelIDsFromWords(words))
+		}
 	}
 }
 
@@ -163,4 +241,40 @@ func reviewStringWords(value string, width int) []uint16 {
 		words[index] = uint16(bytes[index*2])<<8 | uint16(bytes[index*2+1])
 	}
 	return words
+}
+
+func reviewCapture(t *testing.T, profile reg.ProfileDescriptor, raw []uint16, poll, base uint64, transport reg.TransportFamily) (reg.SunSpecPhaseOneCapture, reg.ObservationSpec) {
+	t.Helper()
+	makeView := func(id uint64, offset uint16, words []uint16) reg.LogicalViewSnapshot {
+		record := logicalViewRecord(id, offset, 0, words)
+		record.Endpoint, record.UnitID, record.PollGeneration = "fixture:source", 7, poll
+		record.Transport, record.TransportGeneration = transport, 19
+		record.ConnectionID = 23
+		if transport == reg.TransportRTU {
+			record.ConnectionID = 0
+		}
+		record.WireResponseID, record.PhysicalRequestID = base+id, base+id+10
+		record.PhysicalOffset, record.PhysicalWordCount = offset, uint16(len(words))
+		record.LogicalWordCount, record.SliceWordCount = uint16(len(words)), uint16(len(words))
+		return snapshotFromRecord(t, record)
+	}
+	first := makeView(base+1, 40000, raw[:1])
+	second := makeView(base+2, 40001, raw[1:])
+	observation := sunSpecObservation(t, profile)
+	observation.SampleID = fmt.Sprintf("sunspec-sample-%d", poll)
+	observation.PollGenerationID, observation.Endpoint, observation.UnitID = poll, "fixture:source", 7
+	observation.Dependencies[0].View = first
+	return reg.SunSpecPhaseOneCapture{SourceViews: []reg.LogicalViewSnapshot{first, second}}, observation
+}
+
+func modelIDsFromWords(words []uint16) []uint16 {
+	var ids []uint16
+	for offset := 2; offset+1 < len(words); {
+		ids = append(ids, words[offset])
+		if words[offset] == 0xffff {
+			break
+		}
+		offset += 2 + int(words[offset+1])
+	}
+	return ids
 }

--- a/sunspec_phase1_review_test.go
+++ b/sunspec_phase1_review_test.go
@@ -157,6 +157,39 @@ func TestSunSpecPhaseOneParsesFixtureSemanticsFromRawModels(t *testing.T) {
 	}
 }
 
+func TestSunSpecPhaseOneAcceptsOfficialCommonLengthWithPad(t *testing.T) {
+	decoder, _ := reviewDecoder(t)
+	raw65 := reviewRawChain(101)
+	const commonEnd = 4 + 65
+	raw66 := make([]uint16, 0, len(raw65)+1)
+	raw66 = append(raw66, raw65[:commonEnd]...)
+	raw66 = append(raw66, 0xa55a) // Official Pad at Common payload offset 65.
+	raw66 = append(raw66, raw65[commonEnd:]...)
+	raw66[3] = 66
+
+	chain, err := decoder.Parse(raw66)
+	if err != nil {
+		t.Fatalf("Parse(Common L=66): %v", err)
+	}
+	models := chain.Models()
+	if len(models) != 2 || models[0].ID() != 1 || models[0].Length() != 66 ||
+		models[1].ID() != 101 || models[1].Offset() != 70 {
+		t.Fatalf("model traversal after Common L=66 = %#v", models)
+	}
+	common, ok := chain.Common()
+	if !ok || common.Manufacturer() != "FixtureCo" || common.Model() != "Fixture-1" ||
+		common.Options() != "A" || common.Version() != "VERSION123456789" ||
+		common.SerialNumber() != "PLACEHOLDER" || common.DeviceAddress() != 42 {
+		t.Fatalf("Common L=66 semantics = %#v, present=%t", common, ok)
+	}
+	inverter, ok := chain.Inverter(101)
+	if !ok || inverter.Power().Raw() != -123 || inverter.Power().ScaleFactor() != -1 ||
+		inverter.Power().Value() != -12.3 || inverter.Energy().Raw() != 120000 ||
+		inverter.Energy().ScaleFactor() != 0 || inverter.Energy().Value() != 120000 {
+		t.Fatalf("model 101 after Common L=66 = %#v, present=%t", inverter, ok)
+	}
+}
+
 func TestSunSpecPhaseOneUsesExactNormalizationLengthsAndDeferredSet(t *testing.T) {
 	decoder, profile := reviewDecoder(t)
 	dependency := profile.Dependencies().Dependencies()[0]
@@ -169,7 +202,7 @@ func TestSunSpecPhaseOneUsesExactNormalizationLengthsAndDeferredSet(t *testing.T
 		t.Fatal("runtime normalization differs from documentary record")
 	}
 	for _, test := range []struct{ id, length uint16 }{
-		{1, 64}, {1, 66}, {101, 49}, {101, 51}, {102, 49}, {102, 51}, {103, 49}, {103, 51},
+		{1, 64}, {1, 67}, {101, 49}, {101, 51}, {102, 49}, {102, 51}, {103, 49}, {103, 51},
 	} {
 		if _, err := decoder.Parse(reviewRawChainWithLength(test.id, test.length)); err == nil {
 			t.Fatalf("model %d length %d was accepted", test.id, test.length)

--- a/sunspec_phase1_review_test.go
+++ b/sunspec_phase1_review_test.go
@@ -1,0 +1,166 @@
+package modbusreg_test
+
+import (
+	"reflect"
+	"testing"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func TestSunSpecPhaseOneActivationBindsRawChainAndObservation(t *testing.T) {
+	decoder, profile := reviewDecoder(t)
+	raw := reviewRawChain(101)
+	chain, err := decoder.Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	observation := sunSpecObservation(t, profile)
+	activated, err := decoder.Activate(reg.SunSpecPhaseOneActivation{
+		Chain:       chain,
+		RawWords:    raw,
+		Observation: observation,
+	})
+	if err != nil {
+		t.Fatalf("Activate(valid): %v", err)
+	}
+	if !reflect.DeepEqual(activated.RawWords(), raw) ||
+		!reflect.DeepEqual(activated.Spec(), observation) {
+		t.Fatal("activation did not preserve exact raw chain and observation facts")
+	}
+
+	mutations := []struct {
+		name   string
+		mutate func(*reg.SunSpecPhaseOneActivation)
+	}{
+		{"unrelated raw words", func(a *reg.SunSpecPhaseOneActivation) { a.RawWords = reviewRawChain(102) }},
+		{"endpoint", func(a *reg.SunSpecPhaseOneActivation) { a.Observation.Endpoint = "fixture:other" }},
+		{"unit", func(a *reg.SunSpecPhaseOneActivation) { a.Observation.UnitID++ }},
+		{"poll generation", func(a *reg.SunSpecPhaseOneActivation) { a.Observation.PollGenerationID++ }},
+		{"dependency identity", func(a *reg.SunSpecPhaseOneActivation) { a.Observation.Dependencies[0].DependencyID = "other" }},
+		{"wire identity", func(a *reg.SunSpecPhaseOneActivation) {
+			record := a.Observation.Dependencies[0].View.Record()
+			record.WireResponseID++
+			a.Observation.Dependencies[0].View = snapshotFromRecord(t, record)
+		}},
+		{"logical identity", func(a *reg.SunSpecPhaseOneActivation) {
+			record := a.Observation.Dependencies[0].View.Record()
+			record.LogicalViewID++
+			a.Observation.Dependencies[0].View = snapshotFromRecord(t, record)
+		}},
+		{"torn generation", func(a *reg.SunSpecPhaseOneActivation) {
+			record := a.Observation.Dependencies[0].View.Record()
+			record.TransportGeneration++
+			a.Observation.Dependencies[0].View = snapshotFromRecord(t, record)
+		}},
+	}
+	for _, test := range mutations {
+		t.Run(test.name, func(t *testing.T) {
+			activation := reg.SunSpecPhaseOneActivation{Chain: chain, RawWords: raw, Observation: observation}
+			test.mutate(&activation)
+			if _, err := decoder.Activate(activation); err == nil {
+				t.Fatal("Activate accepted a mismatched chain/observation binding")
+			}
+		})
+	}
+}
+
+func TestSunSpecPhaseOneParsesFixtureSemanticsFromRawModels(t *testing.T) {
+	decoder, _ := reviewDecoder(t)
+	// Values are the public M3-01 synthetic FSS-P-002 and FSS-P-003 examples.
+	chain, err := decoder.Parse(reviewRawChain(101, 102, 103))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	common, ok := chain.Common()
+	if !ok || common.Manufacturer() != "FixtureCo" || common.Model() != "Fixture-1" ||
+		common.SerialNumber() != "PLACEHOLDER" || common.Version() != "VERSION123456789" {
+		t.Fatalf("Common model 1 = %#v, present=%t", common, ok)
+	}
+	for _, id := range []uint16{101, 102, 103} {
+		inverter, ok := chain.Inverter(id)
+		if !ok {
+			t.Fatalf("model %d was not semantically exposed", id)
+		}
+		if power := inverter.Power(); power.Raw() != -123 || power.ScaleFactor() != -1 || power.Value() != -12.3 {
+			t.Fatalf("model %d power = %#v", id, power)
+		}
+		if energy := inverter.Energy(); energy.Raw() != 120000 || energy.ScaleFactor() != 0 || energy.Value() != 120000 {
+			t.Fatalf("model %d energy = %#v", id, energy)
+		}
+	}
+}
+
+func TestSunSpecPhaseOneUsesExactNormalizationLengthsAndDeferredSet(t *testing.T) {
+	decoder, profile := reviewDecoder(t)
+	dependency := profile.Dependencies().Dependencies()[0]
+	normalization := dependency.Normalization().Spec()
+	if normalization.DocumentaryAddress != 40001 || normalization.DocumentaryBase != reg.AddressBaseOneBased ||
+		normalization.Transformation != reg.TransformSubtractOne || normalization.ResolvedPDUOffset != 40000 {
+		t.Fatalf("SunSpec normalization = %#v", normalization)
+	}
+	if dependency.Normalization().ResolvedPDUOffset() != 40000 {
+		t.Fatal("runtime normalization differs from documentary record")
+	}
+	for _, test := range []struct{ id, length uint16 }{
+		{1, 64}, {1, 66}, {101, 49}, {101, 51}, {102, 49}, {102, 51}, {103, 49}, {103, 51},
+	} {
+		if _, err := decoder.Parse(reviewRawChainWithLength(test.id, test.length)); err == nil {
+			t.Fatalf("model %d length %d was accepted", test.id, test.length)
+		}
+	}
+	for _, id := range []uint16{200, 219, 777} {
+		if _, err := decoder.Parse(reviewRawChainWithLength(id, 3)); err == nil {
+			t.Fatalf("deferred model %d was accepted", id)
+		}
+	}
+	chain, err := decoder.Parse(reviewRawChainWithLength(220, 3))
+	if err != nil || !reflect.DeepEqual(modelIDs(chain.SkippedModels()), []uint16{220}) {
+		t.Fatalf("model 220 was not structurally skipped: %#v, %v", chain, err)
+	}
+}
+
+func reviewDecoder(t *testing.T) (reg.SunSpecPhaseOneDecoder, reg.ProfileDescriptor) {
+	t.Helper()
+	profile, err := reg.NewSunSpecPhaseOneProfile(reg.SunSpecPhaseOneVersions{Profile: version(t, "1.0.0"), Codec: version(t, "1.0.0")})
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneProfile: %v", err)
+	}
+	decoder, err := reg.NewSunSpecPhaseOneDecoder(profile)
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneDecoder: %v", err)
+	}
+	return decoder, profile
+}
+
+func reviewRawChain(ids ...uint16) []uint16 {
+	words := []uint16{0x5375, 0x6e53}
+	words = append(words, 1, 65)
+	common := make([]uint16, 65)
+	copy(common[0:], reviewStringWords("FixtureCo", 16))
+	copy(common[16:], reviewStringWords("Fixture-1", 16))
+	copy(common[32:], reviewStringWords("PLACEHOLDER", 16))
+	copy(common[48:], reviewStringWords("VERSION123456789", 8))
+	words = append(words, common...)
+	for _, id := range ids {
+		words = append(words, id, 50)
+		payload := make([]uint16, 50)
+		payload[8], payload[9] = 0xff85, 0xffff
+		payload[16], payload[17], payload[18] = 1, 0xd4c0, 0
+		words = append(words, payload...)
+	}
+	return append(words, 0xffff, 0)
+}
+
+func reviewRawChainWithLength(id, length uint16) []uint16 {
+	return append(append([]uint16{0x5375, 0x6e53, id, length}, make([]uint16, length)...), 0xffff, 0)
+}
+
+func reviewStringWords(value string, width int) []uint16 {
+	bytes := make([]byte, width*2)
+	copy(bytes, value)
+	words := make([]uint16, width)
+	for index := range words {
+		words[index] = uint16(bytes[index*2])<<8 | uint16(bytes[index*2+1])
+	}
+	return words
+}

--- a/sunspec_phase1_review_test.go
+++ b/sunspec_phase1_review_test.go
@@ -187,7 +187,7 @@ func TestSunSpecPhaseOneRejectsTrailingWordsAndInvalidCommonOrder(t *testing.T) 
 		t.Fatal("chain with words after the terminal marker was accepted")
 	}
 	for _, words := range [][]uint16{
-		reviewRawChainWithLength(101, 50),
+		append(append([]uint16{0x5375, 0x6e53, 101, 50}, make([]uint16, 50)...), 0xffff, 0),
 		sunSpecWords(1, 65, 1, 65, 0xffff, 0),
 		sunSpecWords(666, 3, 1, 65, 0xffff, 0),
 	} {
@@ -230,6 +230,9 @@ func reviewRawChain(ids ...uint16) []uint16 {
 }
 
 func reviewRawChainWithLength(id, length uint16) []uint16 {
+	if id != 1 {
+		return sunSpecWords(1, 65, id, length, 0xffff, 0)
+	}
 	return append(append([]uint16{0x5375, 0x6e53, id, length}, make([]uint16, length)...), 0xffff, 0)
 }
 
@@ -248,6 +251,8 @@ func reviewCapture(t *testing.T, profile reg.ProfileDescriptor, raw []uint16, po
 	makeView := func(id uint64, offset uint16, words []uint16) reg.LogicalViewSnapshot {
 		record := logicalViewRecord(id, offset, 0, words)
 		record.Endpoint, record.UnitID, record.PollGeneration = "fixture:source", 7, poll
+		record.RequestedFunction, record.ReceivedFunction = reg.FunctionReadHoldingRegisters, reg.FunctionReadHoldingRegisters
+		record.Table = reg.HoldingRegisters
 		record.Transport, record.TransportGeneration = transport, 19
 		record.ConnectionID = 23
 		if transport == reg.TransportRTU {

--- a/sunspec_phase1_test.go
+++ b/sunspec_phase1_test.go
@@ -29,6 +29,15 @@ func TestSunSpecPhaseOneProfileIsVersionGatedAndReadOnly(t *testing.T) {
 			t.Fatalf("unsupported versions accepted: %#v", unsupported)
 		}
 	}
+	altered := profile.Spec()
+	altered.ModelApplicability = []string{"model-1"}
+	otherProfile, err := reg.NewProfileDescriptor(altered)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(altered): %v", err)
+	}
+	if _, err := reg.NewSunSpecPhaseOneDecoder(otherProfile); err == nil {
+		t.Fatal("decoder accepted a same-ID profile with altered applicability")
+	}
 
 	decoder, err := reg.NewSunSpecPhaseOneDecoder(profile)
 	if err != nil {
@@ -58,7 +67,7 @@ func TestSunSpecPhaseOneChainIsBoundedAndSupportsOnlyIntScaleModels(t *testing.T
 	if err != nil {
 		t.Fatalf("NewSunSpecPhaseOneDecoder: %v", err)
 	}
-	valid := sunSpecWords(1, 65, 101, 50, 777, 3, 102, 50, 103, 50, 0xffff, 0)
+	valid := sunSpecWords(1, 65, 101, 50, 666, 3, 102, 50, 103, 50, 0xffff, 0)
 	chain, err := decoder.Parse(valid)
 	if err != nil {
 		t.Fatalf("Parse(valid chain): %v", err)
@@ -66,7 +75,7 @@ func TestSunSpecPhaseOneChainIsBoundedAndSupportsOnlyIntScaleModels(t *testing.T
 	if got := chain.Models(); !reflect.DeepEqual(modelIDs(got), []uint16{1, 101, 102, 103}) {
 		t.Fatalf("published models = %#v", got)
 	}
-	if skipped := chain.SkippedModels(); !reflect.DeepEqual(modelIDs(skipped), []uint16{777}) {
+	if skipped := chain.SkippedModels(); !reflect.DeepEqual(modelIDs(skipped), []uint16{666}) {
 		t.Fatalf("structurally skipped models = %#v", skipped)
 	}
 	for _, words := range [][]uint16{
@@ -76,6 +85,7 @@ func TestSunSpecPhaseOneChainIsBoundedAndSupportsOnlyIntScaleModels(t *testing.T
 		sunSpecWords(1, 65),                                            // missing end
 		sunSpecWords(1, 65, 0xffff, 1),                                 // nonzero end length
 		sunSpecWords(111, 50, 0xffff, 0),                               // deferred model
+		sunSpecWords(777, 3, 0xffff, 0),                                // deferred 7xx model
 	} {
 		if _, err := decoder.Parse(words); err == nil {
 			t.Fatalf("invalid or deferred chain accepted: %v", words)
@@ -161,6 +171,7 @@ func sunSpecObservation(t *testing.T, profile reg.ProfileDescriptor) reg.Observa
 		record := logicalViewRecord(uint64(900+index), dependency.Normalization().ResolvedPDUOffset(), 0, make([]uint16, dependency.WordCount()))
 		record.RequestedFunction, record.ReceivedFunction = reg.FunctionReadHoldingRegisters, reg.FunctionReadHoldingRegisters
 		record.Table, record.PhysicalOffset, record.PhysicalWordCount = reg.HoldingRegisters, record.LogicalOffset, record.LogicalWordCount
+		record.Endpoint, record.UnitID, record.PollGeneration = "fixture:transport-neutral", 7, 77
 		view := snapshotFromRecord(t, record)
 		result, err := reg.NewDependencyResult(reg.DependencyResult{DependencyID: dependency.ID(), DependencyVersion: dependency.Version(), CodecID: dependency.CodecID(), CodecVersion: dependency.CodecVersion(), NormalizationVersion: dependency.Normalization().Spec().Version, Status: reg.DependencyReadSuccessful, View: view, SourceTime: reg.SourceTimeUnavailable()})
 		if err != nil {

--- a/sunspec_phase1_test.go
+++ b/sunspec_phase1_test.go
@@ -122,14 +122,13 @@ func TestSunSpecPhaseOneDecodingAndObservationActivationPreserveProvenance(t *te
 		t.Fatalf("full-width string = %q, %v", got, err)
 	}
 
-	chain, err := decoder.Parse(sunSpecWords(1, 65, 102, 50, 0xffff, 0))
+	raw := sunSpecWords(1, 65, 102, 50, 0xffff, 0)
+	chain, err := decoder.Parse(raw)
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	activation := reg.SunSpecPhaseOneActivation{
-		Chain:       chain,
-		Observation: sunSpecObservation(t, profile),
-	}
+	capture, observationSpec := reviewCapture(t, profile, raw, 77, 5000, reg.TransportTCP)
+	activation := reg.SunSpecPhaseOneActivation{Chain: chain, RawWords: raw, Capture: capture, Observation: observationSpec}
 	observation, err := decoder.Activate(activation)
 	if err != nil {
 		t.Fatalf("Activate: %v", err)

--- a/sunspec_phase1_test.go
+++ b/sunspec_phase1_test.go
@@ -84,7 +84,7 @@ func TestSunSpecPhaseOneChainIsBoundedAndSupportsOnlyIntScaleModels(t *testing.T
 		append([]uint16{0x5375, 0x6e53, 1, 65}, make([]uint16, 64)...), // declared extent overruns
 		sunSpecWords(1, 65),                                            // missing end
 		sunSpecWords(1, 65, 0xffff, 1),                                 // nonzero end length
-		sunSpecWords(111, 50, 0xffff, 0),                               // deferred model
+		sunSpecWords(200, 50, 0xffff, 0),                               // deferred model
 		sunSpecWords(777, 3, 0xffff, 0),                                // deferred 7xx model
 	} {
 		if _, err := decoder.Parse(words); err == nil {

--- a/sunspec_phase1_test.go
+++ b/sunspec_phase1_test.go
@@ -1,0 +1,172 @@
+package modbusreg_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+func TestSunSpecPhaseOneProfileIsVersionGatedAndReadOnly(t *testing.T) {
+	profile, err := reg.NewSunSpecPhaseOneProfile(
+		reg.SunSpecPhaseOneVersions{Profile: version(t, "1.0.0"), Codec: version(t, "1.0.0")},
+	)
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneProfile(v1): %v", err)
+	}
+	if profile.Kind() != reg.ProfileStandardFamily || len(profile.Spec().VendorApplicability) != 0 {
+		t.Fatalf("profile leaked a vendor assumption: %#v", profile.Spec())
+	}
+	if profile.CodecContractVersion() != version(t, "1.0.0") {
+		t.Fatalf("codec contract version = %s", profile.CodecContractVersion())
+	}
+	for _, unsupported := range []reg.SunSpecPhaseOneVersions{
+		{Profile: version(t, "2.0.0"), Codec: version(t, "1.0.0")},
+		{Profile: version(t, "1.0.0"), Codec: version(t, "2.0.0")},
+	} {
+		if _, err := reg.NewSunSpecPhaseOneProfile(unsupported); err == nil {
+			t.Fatalf("unsupported versions accepted: %#v", unsupported)
+		}
+	}
+
+	decoder, err := reg.NewSunSpecPhaseOneDecoder(profile)
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneDecoder: %v", err)
+	}
+	request := decoder.DiscoveryRequest()
+	if request.Function() != reg.FunctionReadHoldingRegisters || request.Table() != reg.HoldingRegisters ||
+		request.Offset() != 40000 || !request.ReadOnly() {
+		t.Fatalf("discovery request = %#v", request)
+	}
+	for _, value := range []any{decoder, request} {
+		typ := reflect.TypeOf(value)
+		for method := 0; method < typ.NumMethod(); method++ {
+			name := typ.Method(method).Name
+			if name == "Write" || name == "Control" || name == "Set" {
+				t.Fatalf("phase-one surface exposes %s on %s", name, typ)
+			}
+		}
+	}
+}
+
+func TestSunSpecPhaseOneChainIsBoundedAndSupportsOnlyIntScaleModels(t *testing.T) {
+	profile, _ := reg.NewSunSpecPhaseOneProfile(reg.SunSpecPhaseOneVersions{
+		Profile: version(t, "1.0.0"), Codec: version(t, "1.0.0"),
+	})
+	decoder, err := reg.NewSunSpecPhaseOneDecoder(profile)
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneDecoder: %v", err)
+	}
+	valid := sunSpecWords(1, 65, 101, 50, 777, 3, 102, 50, 103, 50, 0xffff, 0)
+	chain, err := decoder.Parse(valid)
+	if err != nil {
+		t.Fatalf("Parse(valid chain): %v", err)
+	}
+	if got := chain.Models(); !reflect.DeepEqual(modelIDs(got), []uint16{1, 101, 102, 103}) {
+		t.Fatalf("published models = %#v", got)
+	}
+	if skipped := chain.SkippedModels(); !reflect.DeepEqual(modelIDs(skipped), []uint16{777}) {
+		t.Fatalf("structurally skipped models = %#v", skipped)
+	}
+	for _, words := range [][]uint16{
+		{0, 0, 1, 1, 0, 0xffff, 0},                                     // invalid signature
+		sunSpecWords(1, 0, 0xffff, 0),                                  // zero non-end length
+		append([]uint16{0x5375, 0x6e53, 1, 65}, make([]uint16, 64)...), // declared extent overruns
+		sunSpecWords(1, 65),                                            // missing end
+		sunSpecWords(1, 65, 0xffff, 1),                                 // nonzero end length
+		sunSpecWords(111, 50, 0xffff, 0),                               // deferred model
+	} {
+		if _, err := decoder.Parse(words); err == nil {
+			t.Fatalf("invalid or deferred chain accepted: %v", words)
+		}
+	}
+}
+
+func TestSunSpecPhaseOneDecodingAndObservationActivationPreserveProvenance(t *testing.T) {
+	profile, _ := reg.NewSunSpecPhaseOneProfile(reg.SunSpecPhaseOneVersions{
+		Profile: version(t, "1.0.0"), Codec: version(t, "1.0.0"),
+	})
+	decoder, err := reg.NewSunSpecPhaseOneDecoder(profile)
+	if err != nil {
+		t.Fatalf("NewSunSpecPhaseOneDecoder: %v", err)
+	}
+	if got, err := decoder.Int16(0xff85); err != nil || got != -123 {
+		t.Fatalf("Int16 = %d, %v", got, err)
+	}
+	if got, err := decoder.Acc32(0x0001, 0xd4c0); err != nil || got != 120000 {
+		t.Fatalf("Acc32 = %d, %v", got, err)
+	}
+	for raw, want := range map[uint16]int16{0xfff6: -10, 0x000a: 10} {
+		if got, err := decoder.ScaleFactor(raw); err != nil || got != want {
+			t.Fatalf("ScaleFactor(%#x) = %d, %v", raw, got, err)
+		}
+	}
+	if _, err := decoder.ScaleFactor(0x8000); err == nil {
+		t.Fatal("sunssf sentinel was accepted")
+	}
+	if got, err := decoder.String([]uint16{0x4142, 0x0043, 0x4445}); err != nil || got != "AB" {
+		t.Fatalf("first-NUL string = %q, %v", got, err)
+	}
+	if got, err := decoder.String([]uint16{0x4142, 0x4344}); err != nil || got != "ABCD" {
+		t.Fatalf("full-width string = %q, %v", got, err)
+	}
+
+	chain, err := decoder.Parse(sunSpecWords(1, 65, 102, 50, 0xffff, 0))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	activation := reg.SunSpecPhaseOneActivation{
+		Chain:       chain,
+		Observation: sunSpecObservation(t, profile),
+	}
+	observation, err := decoder.Activate(activation)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	got := observation.Spec()
+	want := activation.Observation
+	if got.SampleID != want.SampleID || got.PollGenerationID != want.PollGenerationID ||
+		got.ProfileVersion != want.ProfileVersion || got.CodecContractVersion != want.CodecContractVersion ||
+		got.Endpoint != want.Endpoint || got.UnitID != want.UnitID ||
+		!got.LocalReceiptTime.Equal(want.LocalReceiptTime) || len(got.Dependencies) != len(want.Dependencies) {
+		t.Fatalf("activation did not preserve exact observation provenance: %#v", got)
+	}
+}
+
+func sunSpecWords(headers ...uint16) []uint16 {
+	words := []uint16{0x5375, 0x6e53}
+	for index := 0; index < len(headers); index += 2 {
+		words = append(words, headers[index], headers[index+1])
+		if headers[index] != 0xffff {
+			words = append(words, make([]uint16, headers[index+1])...)
+		}
+	}
+	return words
+}
+
+func modelIDs(models []reg.SunSpecPhaseOneModel) []uint16 {
+	ids := make([]uint16, len(models))
+	for index, model := range models {
+		ids[index] = model.ID()
+	}
+	return ids
+}
+
+func sunSpecObservation(t *testing.T, profile reg.ProfileDescriptor) reg.ObservationSpec {
+	t.Helper()
+	dependencies := profile.Dependencies().Dependencies()
+	results := make([]reg.DependencyResult, 0, len(dependencies))
+	for index, dependency := range dependencies {
+		record := logicalViewRecord(uint64(900+index), dependency.Normalization().ResolvedPDUOffset(), 0, make([]uint16, dependency.WordCount()))
+		record.RequestedFunction, record.ReceivedFunction = reg.FunctionReadHoldingRegisters, reg.FunctionReadHoldingRegisters
+		record.Table, record.PhysicalOffset, record.PhysicalWordCount = reg.HoldingRegisters, record.LogicalOffset, record.LogicalWordCount
+		view := snapshotFromRecord(t, record)
+		result, err := reg.NewDependencyResult(reg.DependencyResult{DependencyID: dependency.ID(), DependencyVersion: dependency.Version(), CodecID: dependency.CodecID(), CodecVersion: dependency.CodecVersion(), NormalizationVersion: dependency.Normalization().Spec().Version, Status: reg.DependencyReadSuccessful, View: view, SourceTime: reg.SourceTimeUnavailable()})
+		if err != nil {
+			t.Fatalf("NewDependencyResult: %v", err)
+		}
+		results = append(results, result)
+	}
+	return reg.ObservationSpec{SchemaVersion: version(t, "1.0.0"), RuntimeContractVersion: profile.RuntimeContractVersion(), ProfileID: profile.ID(), ProfileVersion: profile.Version(), CodecContractVersion: profile.CodecContractVersion(), DetectorVersion: profile.DetectorVersion(), NormalizationVersion: profile.NormalizationVersion(), CoherenceVersion: profile.CoherenceVersion(), QualificationVersion: profile.QualificationVersion(), SampleID: "sunspec-sample-102", PollGenerationID: 77, DependencySetID: profile.Dependencies().ID(), DependencySetVersion: profile.Dependencies().Version(), SourceValidity: reg.SourceValid, SourceTime: reg.SourceTimeUnavailable(), LocalReceiptTime: time.Unix(1_700_000_000, 0).UTC(), Endpoint: "fixture:transport-neutral", UnitID: 7, Dependencies: results}
+}


### PR DESCRIPTION
## What

Implement FMV3-M3-02: the minimal vendor-neutral SunSpec phase-one profile required by the merged M3-01 evidence packet.

Closes #9.

## RED Evidence

- Initial test-only HEAD `9a8ce9dcc5a8f4ae2dbfe6537513eec751f6a83a`; hosted RED `31423298487`.
- Semantic repair HEAD `492530289d7a9436d56b0a700b9c3deb356f25b0`; hosted RED `31424582369`.
- Capture repair HEAD `d96e0cafdbfd981af4ba45097e1dccf9e0af8405`; hosted RED `31425958609`.
- Official-offset repair HEAD `24a4d79684c48aa5cde300edaf4103cb613c807a`; hosted RED `31426682535`.
- Common-length compatibility repair HEAD `97b75f90831cc0b531def18f76f1fa9f821f0091`; hosted RED `31428484706`.
- Each hosted RED passed the applicable structural stages and failed on the specifically absent API or behavior.

## Dependencies

- M2-03 merge: `1045dfa2c90d065c099ebd249d00d643b871361a`
- M3-01 docs/evidence merge: `54d9d178290be8e8cfaac99427e98c64c5ee5136`
- M3-01 corrective docs merge: `59218d21163acb868687ed3d8196f0aa1496aab7`
- Official SunSpec model revision: `7abdf8982d5364f8ae916deee18aac86c11be36d`
- Execution guide: `83db52aca5f11f6abcc090c9a0be9f7956440515`

## Scope

Vendor-neutral, transport-neutral, read-only SunSpec phase one only. No Fronius overlay, gateway, transport framing or ownership, live hardware, credentials, write/control operations, canonical PV semantics, private bindings, or M4 work.

## Blocker Repairs

- [x] Exact per-activation source views/raw/provenance without cross-poll cache
- [x] Distinct coherent polls may retain identical raw values
- [x] Common and inverter typed semantics use pinned official coordinates
- [x] Exact 40001 one-based -> subtract-one -> PDU 40000 normalization
- [x] Exact inverter lengths and Common compatibility set {65,66}
- [x] Complete deferred rejection, bounded unknown skip, terminal consumption, Common ordering
- [x] Docs hash-lock demand independently rejected by design; P3 drift risk triaged nonblocking

## Gates

- [x] Five RED-only commits public with hosted RED evidence
- [x] Final GREEN head `ed11ce4e3cd4a128bd36e77dcfd6e8c123d7f546`
- [x] Local CI and 20x race/shuffle focused suite green
- [x] Hosted CI run `31428643279` green
- [x] Fresh exact-HEAD NO_BLOCKING_FINDINGS
