### PR TITLE
R2A: add exact SunSpec value and inverter decoder catalog (#15)

### DIFF
--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -1,0 +1,179 @@
+package modbusreg
+
+import (
+	"fmt"
+	"sort"
+)
+
+type SunSpecFact struct {
+	FieldID   string
+	PointName string
+	Unit      string
+	Required  bool
+	Value     SunSpecValue
+}
+
+type SunSpecDecodedModel struct {
+	key       SunSpecDecoderKey
+	ordinal   uint32
+	topology  SunSpecTopology
+	qualifies bool
+	raw       []uint16
+	spans     []SunSpecSourceSpan
+	facts     []SunSpecFact
+}
+
+func (m SunSpecDecodedModel) Key() SunSpecDecoderKey    { return m.key }
+func (m SunSpecDecodedModel) Ordinal() uint32           { return m.ordinal }
+func (m SunSpecDecodedModel) Topology() SunSpecTopology { return m.topology }
+func (m SunSpecDecodedModel) Qualifies() bool           { return m.qualifies }
+func (m SunSpecDecodedModel) RawWords() []uint16        { return append([]uint16(nil), m.raw...) }
+func (m SunSpecDecodedModel) SourceSpans() []SunSpecSourceSpan {
+	return append([]SunSpecSourceSpan(nil), m.spans...)
+}
+func (m SunSpecDecodedModel) Facts() []SunSpecFact {
+	out := make([]SunSpecFact, len(m.facts))
+	for index, fact := range m.facts {
+		out[index] = cloneSunSpecFact(fact)
+	}
+	return out
+}
+func (m SunSpecDecodedModel) Fact(fieldID string) (SunSpecFact, bool) {
+	for _, fact := range m.facts {
+		if fact.FieldID == fieldID {
+			return cloneSunSpecFact(fact), true
+		}
+	}
+	return SunSpecFact{}, false
+}
+func cloneSunSpecFact(fact SunSpecFact) SunSpecFact {
+	fact.Value.raw = append([]uint16(nil), fact.Value.raw...)
+	return fact
+}
+
+type SunSpecDecodedChain struct{ models []SunSpecDecodedModel }
+
+func (c SunSpecDecodedChain) Models() []SunSpecDecodedModel {
+	out := make([]SunSpecDecodedModel, len(c.models))
+	for index, model := range c.models {
+		model.raw = append([]uint16(nil), model.raw...)
+		model.spans = append([]SunSpecSourceSpan(nil), model.spans...)
+		model.facts = model.Facts()
+		out[index] = model
+	}
+	return out
+}
+
+type SunSpecDecoderRegistry struct {
+	revision    SunSpecSchemaRevision
+	definitions map[SunSpecDecoderKey]sunSpecModelDefinition
+	keys        []SunSpecDecoderKey
+}
+
+func NewStandardSunSpecDecoderRegistry(revision SunSpecSchemaRevision) (SunSpecDecoderRegistry, error) {
+	definitions, err := standardSunSpecModelDefinitions(revision)
+	if err != nil {
+		return SunSpecDecoderRegistry{}, err
+	}
+	registry := SunSpecDecoderRegistry{revision: revision, definitions: make(map[SunSpecDecoderKey]sunSpecModelDefinition, len(definitions))}
+	for _, definition := range definitions {
+		if _, duplicate := registry.definitions[definition.key]; duplicate {
+			return SunSpecDecoderRegistry{}, fmt.Errorf("SunSpec decoder key is duplicated")
+		}
+		registry.definitions[definition.key] = definition
+		registry.keys = append(registry.keys, definition.key)
+	}
+	sort.Slice(registry.keys, func(i, j int) bool {
+		if registry.keys[i].ModelID != registry.keys[j].ModelID {
+			return registry.keys[i].ModelID < registry.keys[j].ModelID
+		}
+		if registry.keys[i].ModelLength != registry.keys[j].ModelLength {
+			return registry.keys[i].ModelLength < registry.keys[j].ModelLength
+		}
+		return registry.keys[i].SchemaRevision < registry.keys[j].SchemaRevision
+	})
+	return registry, nil
+}
+
+func (r SunSpecDecoderRegistry) DecoderKeys() []SunSpecDecoderKey {
+	return append([]SunSpecDecoderKey(nil), r.keys...)
+}
+func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelDefinition, bool) {
+	definition, ok := r.definitions[key]
+	return definition, ok
+}
+
+func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (SunSpecDecodedModel, error) {
+	key, ok := occurrence.DecoderKey()
+	if !ok || occurrence.Disposition != SunSpecChainDispositionAdmitted || key.ModelID != occurrence.WireKey.ModelID || key.ModelLength != occurrence.WireKey.ModelLength || key.SchemaRevision != occurrence.SchemaRevision || key.SchemaRevision != r.revision {
+		return SunSpecDecodedModel{}, fmt.Errorf("SunSpec occurrence lacks an exact admitted decoder key")
+	}
+	definition, ok := r.definitions[key]
+	if !ok {
+		return SunSpecDecodedModel{}, fmt.Errorf("SunSpec decoder key is unsupported")
+	}
+	words := occurrence.Words()
+	if len(words) != int(key.ModelLength)+2 || words[0] != key.ModelID || words[1] != key.ModelLength {
+		return SunSpecDecodedModel{}, fmt.Errorf("SunSpec occurrence words contradict decoder key")
+	}
+	scales := make(map[string]SunSpecValue)
+	for _, point := range definition.points {
+		if point.pointType != SunSpecTypeScaleFactor {
+			continue
+		}
+		scales[point.name] = decodeSunSpecValue(point, words[point.offset:point.offset+point.size], nil)
+	}
+	model := SunSpecDecodedModel{key: key, ordinal: occurrence.Ordinal, topology: definition.topology, qualifies: true, raw: append([]uint16(nil), words...), spans: occurrence.SourceSpans()}
+	for _, point := range definition.points {
+		if point.name == "ID" || point.name == "L" {
+			continue
+		}
+		var scale *SunSpecValue
+		if point.scaleFactor != "" {
+			value, exists := scales[point.scaleFactor]
+			if !exists {
+				return SunSpecDecodedModel{}, fmt.Errorf("SunSpec scale factor reference is missing")
+			}
+			scale = &value
+		}
+		value := decodeSunSpecValue(point, words[point.offset:point.offset+point.size], scale)
+		if point.mandatory && value.State() != SunSpecValueValid {
+			model.qualifies = false
+		}
+		model.facts = append(model.facts, SunSpecFact{FieldID: point.fieldID, PointName: point.name, Unit: point.unit, Required: point.required, Value: value})
+	}
+	return model, nil
+}
+
+func (r SunSpecDecoderRegistry) DecodeChain(snapshot SunSpecChainSnapshot) (SunSpecDecodedChain, error) {
+	return r.decodeOccurrences(snapshot.Occurrences())
+}
+func (r SunSpecDecoderRegistry) decodeOccurrences(occurrences []SunSpecOccurrence) (SunSpecDecodedChain, error) {
+	if len(occurrences) == 0 || occurrences[0].ModelID() != 1 {
+		return SunSpecDecodedChain{}, fmt.Errorf("SunSpec Common Model must be first")
+	}
+	commonCount := 0
+	for _, occurrence := range occurrences {
+		if occurrence.ModelID() == 1 {
+			commonCount++
+		}
+	}
+	if commonCount != 1 {
+		return SunSpecDecodedChain{}, fmt.Errorf("SunSpec Common Model must occur exactly once")
+	}
+	if occurrences[0].Disposition != SunSpecChainDispositionAdmitted {
+		return SunSpecDecodedChain{}, fmt.Errorf("SunSpec Common Model is unsupported")
+	}
+	out := SunSpecDecodedChain{}
+	for _, occurrence := range occurrences {
+		if occurrence.Disposition != SunSpecChainDispositionAdmitted {
+			continue
+		}
+		model, err := r.DecodeOccurrence(occurrence)
+		if err != nil {
+			return SunSpecDecodedChain{}, err
+		}
+		out.models = append(out.models, model)
+	}
+	return out, nil
+}

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -48,6 +48,7 @@ func (m SunSpecDecodedModel) Fact(fieldID string) (SunSpecFact, bool) {
 }
 func cloneSunSpecFact(fact SunSpecFact) SunSpecFact {
 	fact.Value.raw = append([]uint16(nil), fact.Value.raw...)
+	fact.Value.bitSymbols = append([]string(nil), fact.Value.bitSymbols...)
 	return fact
 }
 

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -82,7 +83,9 @@ func TestSunSpecDecodedModelsAreDefensiveAndReadOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	words := modelWords(t, registry, 1, 65, map[string][]uint16{"Mn": stringWords("Maker", 16), "Md": stringWords("Model", 16)})
-	decoded, err := registry.DecodeOccurrence(admittedOccurrence(1, 65, words, 1))
+	occurrence := admittedOccurrence(1, 65, words, 1)
+	occurrence.spans = []SunSpecSourceSpan{{LogicalViewID: 17, PDUOffset: 3, WordCount: 65}}
+	decoded, err := registry.DecodeOccurrence(occurrence)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +102,81 @@ func TestSunSpecDecodedModelsAreDefensiveAndReadOnly(t *testing.T) {
 	if decoded.RawWords()[0] != 1 {
 		t.Fatal("raw words were mutable")
 	}
+	spans := decoded.SourceSpans()
+	if len(spans) != 1 || spans[0] != occurrence.spans[0] {
+		t.Fatalf("source spans=%#v", spans)
+	}
+	spans[0].LogicalViewID = 99
+	if decoded.SourceSpans()[0].LogicalViewID != 17 {
+		t.Fatal("source spans were mutable")
+	}
 }
+
+func TestSunSpecDecoderRejectsMalformedOccurrenceWithoutMutatingEvidence(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := modelWords(t, registry, 103, 50, nil)
+	for name, words := range map[string][]uint16{
+		"truncated":       append([]uint16(nil), valid[:len(valid)-1]...),
+		"extra":           append(append([]uint16(nil), valid...), 0),
+		"model mismatch":  append([]uint16{102}, valid[1:]...),
+		"length mismatch": append([]uint16{103, 49}, valid[2:]...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			occurrence := admittedOccurrence(103, 50, words, 1)
+			before := occurrence.Words()
+			if _, err := registry.DecodeOccurrence(occurrence); err == nil {
+				t.Fatal("malformed occurrence decoded")
+			}
+			if !reflect.DeepEqual(occurrence.Words(), before) {
+				t.Fatal("raw occurrence evidence changed on rejection")
+			}
+		})
+	}
+}
+
+func TestSunSpecDecoderRegistrySupportsConcurrentReadOnlyDecode(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrence := admittedOccurrence(113, 60, modelWords(t, registry, 113, 60, map[string][]uint16{
+		"A": {0x4148, 0}, "W": {0x42f6, 0}, "Hz": {0x4248, 0}, "WH": {0x42c8, 0}, "St": {4},
+	}), 1)
+
+	const workers = 64
+	var wg sync.WaitGroup
+	errors := make(chan error, workers)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			decoded, err := registry.DecodeOccurrence(occurrence)
+			if err != nil {
+				errors <- err
+				return
+			}
+			if decoded.Key().ModelID != 113 || len(decoded.Facts()) != 31 {
+				errors <- errUnexpectedConcurrentDecode
+			}
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+type sunSpecTestError string
+
+func (e sunSpecTestError) Error() string { return string(e) }
+
+const errUnexpectedConcurrentDecode sunSpecTestError = "unexpected concurrent SunSpec decode"
 
 func stringWords(value string, words int) []uint16 {
 	raw := make([]byte, words*2)

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -1,0 +1,112 @@
+package modbusreg
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const testSunSpecModelsRevision SunSpecSchemaRevision = "sunspec.models@7abdf898-v1"
+
+func admittedOccurrence(id, length uint16, words []uint16, ordinal uint32) SunSpecOccurrence {
+	key := SunSpecDecoderKey{ModelID: id, ModelLength: length, SchemaRevision: testSunSpecModelsRevision}
+	return SunSpecOccurrence{Ordinal: ordinal, WireKey: SunSpecWireKey{ModelID: id, ModelLength: length}, SchemaRevision: testSunSpecModelsRevision, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: append([]uint16(nil), words...)}
+}
+
+func modelWords(t *testing.T, registry SunSpecDecoderRegistry, id, length uint16, values map[string][]uint16) []uint16 {
+	t.Helper()
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: id, ModelLength: length, SchemaRevision: testSunSpecModelsRevision})
+	if !ok {
+		t.Fatalf("definition %d/%d absent", id, length)
+	}
+	words := make([]uint16, int(length)+2)
+	words[0], words[1] = id, length
+	for _, point := range definition.points {
+		value, exists := values[point.name]
+		if !exists || point.name == "ID" || point.name == "L" {
+			continue
+		}
+		if len(value) != int(point.size) {
+			t.Fatalf("point %s words=%d want=%d", point.name, len(value), point.size)
+		}
+		copy(words[point.offset:point.offset+point.size], value)
+	}
+	return words
+}
+
+func TestSunSpecDecoderRegistryUsesExactImmutableKeys(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := registry.DecoderKeys()
+	want := []SunSpecDecoderKey{
+		{1, 65, testSunSpecModelsRevision}, {1, 66, testSunSpecModelsRevision},
+		{101, 50, testSunSpecModelsRevision}, {102, 50, testSunSpecModelsRevision}, {103, 50, testSunSpecModelsRevision},
+		{111, 60, testSunSpecModelsRevision}, {112, 60, testSunSpecModelsRevision}, {113, 60, testSunSpecModelsRevision},
+	}
+	sort.Slice(want, func(i, j int) bool {
+		if want[i].ModelID != want[j].ModelID {
+			return want[i].ModelID < want[j].ModelID
+		}
+		return want[i].ModelLength < want[j].ModelLength
+	})
+	if !reflect.DeepEqual(keys, want) {
+		t.Fatalf("keys=%#v", keys)
+	}
+	keys[0].ModelID = 999
+	if registry.DecoderKeys()[0].ModelID == 999 {
+		t.Fatal("registry keys are mutable")
+	}
+	if _, err := NewStandardSunSpecDecoderRegistry("latest"); err == nil {
+		t.Fatal("mutable/latest revision admitted")
+	}
+	wrong := admittedOccurrence(103, 50, make([]uint16, 52), 1)
+	wrong.SchemaRevision = "other"
+	if _, err := registry.DecodeOccurrence(wrong); err == nil {
+		t.Fatal("wrong occurrence revision decoded")
+	}
+}
+
+func TestSunSpecDecodedModelsAreDefensiveAndReadOnly(t *testing.T) {
+	typ := reflect.TypeFor[SunSpecDecoderRegistry]()
+	for index := 0; index < typ.NumMethod(); index++ {
+		name := strings.ToLower(typ.Method(index).Name)
+		if strings.Contains(name, "write") || strings.Contains(name, "set") || strings.Contains(name, "register") {
+			t.Fatalf("registry exposes mutation authority: %s", typ.Method(index).Name)
+		}
+	}
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	words := modelWords(t, registry, 1, 65, map[string][]uint16{"Mn": stringWords("Maker", 16), "Md": stringWords("Model", 16)})
+	decoded, err := registry.DecodeOccurrence(admittedOccurrence(1, 65, words, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	facts := decoded.Facts()
+	if len(facts) == 0 {
+		t.Fatal("facts absent")
+	}
+	facts[0].FieldID = "mutated"
+	if decoded.Facts()[0].FieldID == "mutated" {
+		t.Fatal("facts were mutable")
+	}
+	raw := decoded.RawWords()
+	raw[0] = 0
+	if decoded.RawWords()[0] != 1 {
+		t.Fatal("raw words were mutable")
+	}
+}
+
+func stringWords(value string, words int) []uint16 {
+	raw := make([]byte, words*2)
+	copy(raw, []byte(value))
+	out := make([]uint16, words)
+	for index := range out {
+		out[index] = uint16(raw[index*2])<<8 | uint16(raw[index*2+1])
+	}
+	return out
+}

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -1,0 +1,94 @@
+package modbusreg
+
+import "fmt"
+
+const SunSpecModelsRevisionV1 SunSpecSchemaRevision = "sunspec.models@7abdf898-v1"
+
+type SunSpecTopology string
+
+const (
+	SunSpecTopologyNone        SunSpecTopology = "none"
+	SunSpecTopologySinglePhase SunSpecTopology = "single_phase"
+	SunSpecTopologySplitPhase  SunSpecTopology = "split_phase"
+	SunSpecTopologyThreePhase  SunSpecTopology = "three_phase"
+)
+
+type sunSpecPointDefinition struct {
+	name, fieldID, unit, scaleFactor string
+	pointType                        SunSpecPointType
+	offset, size                     uint16
+	mandatory, required              bool
+	symbols                          map[uint64]string
+	knownMask                        uint64
+}
+
+type sunSpecModelDefinition struct {
+	key           SunSpecDecoderKey
+	topology      SunSpecTopology
+	compatibility bool
+	points        []sunSpecPointDefinition
+}
+
+func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecModelDefinition, error) {
+	if revision != SunSpecModelsRevisionV1 {
+		return nil, fmt.Errorf("SunSpec schema revision is unsupported")
+	}
+	common := commonSunSpecPoints()
+	definitions := make([]sunSpecModelDefinition, 0, 8)
+	var err error
+	definitions, err = appendSunSpecDefinition(definitions, revision, 1, 66, SunSpecTopologyNone, false, common)
+	if err != nil {
+		return nil, err
+	}
+	definitions, err = appendSunSpecDefinition(definitions, revision, 1, 65, SunSpecTopologyNone, true, common[:len(common)-1])
+	if err != nil {
+		return nil, err
+	}
+	for _, model := range []struct {
+		id, length uint16
+		topology   SunSpecTopology
+		points     []sunSpecPointDefinition
+	}{
+		{101, 50, SunSpecTopologySinglePhase, integerInverterSunSpecPoints()},
+		{102, 50, SunSpecTopologySplitPhase, integerInverterSunSpecPoints()},
+		{103, 50, SunSpecTopologyThreePhase, integerInverterSunSpecPoints()},
+		{111, 60, SunSpecTopologySinglePhase, floatInverterSunSpecPoints()},
+		{112, 60, SunSpecTopologySplitPhase, floatInverterSunSpecPoints()},
+		{113, 60, SunSpecTopologyThreePhase, floatInverterSunSpecPoints()},
+	} {
+		points := cloneSunSpecPointDefinitions(model.points)
+		for index := range points {
+			points[index].mandatory = sunSpecPointMandatory(model.id, points[index].name)
+			points[index].required = points[index].mandatory && points[index].name != "ID" && points[index].name != "L" && points[index].pointType != SunSpecTypeScaleFactor
+		}
+		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, model.topology, false, points)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return definitions, nil
+}
+
+func appendSunSpecDefinition(values []sunSpecModelDefinition, revision SunSpecSchemaRevision, id, length uint16, topology SunSpecTopology, compatibility bool, points []sunSpecPointDefinition) ([]sunSpecModelDefinition, error) {
+	points = cloneSunSpecPointDefinitions(points)
+	var offset uint16
+	for index := range points {
+		if points[index].size == 0 {
+			return nil, fmt.Errorf("SunSpec point size is zero")
+		}
+		points[index].offset = offset
+		offset += points[index].size
+	}
+	if offset != length+2 {
+		return nil, fmt.Errorf("SunSpec model %d/%d catalog extent is %d", id, length, offset)
+	}
+	return append(values, sunSpecModelDefinition{key: SunSpecDecoderKey{id, length, revision}, topology: topology, compatibility: compatibility, points: points}), nil
+}
+
+func cloneSunSpecPointDefinitions(points []sunSpecPointDefinition) []sunSpecPointDefinition {
+	return append([]sunSpecPointDefinition(nil), points...)
+}
+
+func sunSpecPoint(name, fieldID string, pointType SunSpecPointType, size uint16, unit, scaleFactor string, mandatory bool, symbols map[uint64]string, knownMask uint64) sunSpecPointDefinition {
+	return sunSpecPointDefinition{name: name, fieldID: fieldID, pointType: pointType, size: size, unit: unit, scaleFactor: scaleFactor, mandatory: mandatory, required: mandatory && name != "ID" && name != "L" && pointType != SunSpecTypeScaleFactor, symbols: symbols, knownMask: knownMask}
+}

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -52,9 +52,9 @@ func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecM
 		{101, 50, SunSpecTopologySinglePhase, integerInverterSunSpecPoints()},
 		{102, 50, SunSpecTopologySplitPhase, integerInverterSunSpecPoints()},
 		{103, 50, SunSpecTopologyThreePhase, integerInverterSunSpecPoints()},
-		{111, 60, SunSpecTopologySinglePhase, floatInverterSunSpecPoints()},
-		{112, 60, SunSpecTopologySplitPhase, floatInverterSunSpecPoints()},
-		{113, 60, SunSpecTopologyThreePhase, floatInverterSunSpecPoints()},
+		{111, 60, SunSpecTopologySinglePhase, floatInverterSunSpecPoints(inverterModel111StatusSymbols())},
+		{112, 60, SunSpecTopologySplitPhase, floatInverterSunSpecPoints(inverterStatusSymbols())},
+		{113, 60, SunSpecTopologyThreePhase, floatInverterSunSpecPoints(inverterStatusSymbols())},
 	} {
 		points := cloneSunSpecPointDefinitions(model.points)
 		for index := range points {
@@ -86,7 +86,22 @@ func appendSunSpecDefinition(values []sunSpecModelDefinition, revision SunSpecSc
 }
 
 func cloneSunSpecPointDefinitions(points []sunSpecPointDefinition) []sunSpecPointDefinition {
-	return append([]sunSpecPointDefinition(nil), points...)
+	out := append([]sunSpecPointDefinition(nil), points...)
+	for index := range out {
+		out[index].symbols = cloneSunSpecSymbols(out[index].symbols)
+	}
+	return out
+}
+
+func cloneSunSpecSymbols(symbols map[uint64]string) map[uint64]string {
+	if symbols == nil {
+		return nil
+	}
+	out := make(map[uint64]string, len(symbols))
+	for value, symbol := range symbols {
+		out[value] = symbol
+	}
+	return out
 }
 
 func sunSpecPoint(name, fieldID string, pointType SunSpecPointType, size uint16, unit, scaleFactor string, mandatory bool, symbols map[uint64]string, knownMask uint64) sunSpecPointDefinition {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -1,0 +1,98 @@
+package modbusreg
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSunSpecModelCatalogMatchesPinnedAuthoritativeShapes(t *testing.T) {
+	data, err := os.ReadFile("testdata/sunspec/models/v1/catalog.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		SourceCommit   string                `json:"source_commit"`
+		SchemaRevision SunSpecSchemaRevision `json:"schema_revision"`
+		Models         []struct {
+			ID, Length, Points uint16
+			Compatibility      bool `json:"compatibility"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.SourceCommit != "7abdf8982d5364f8ae916deee18aac86c11be36d" || fixture.SchemaRevision != testSunSpecModelsRevision {
+		t.Fatalf("unpinned fixture: %#v", fixture)
+	}
+	registry, err := NewStandardSunSpecDecoderRegistry(fixture.SchemaRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range fixture.Models {
+		definition, ok := registry.definition(SunSpecDecoderKey{expected.ID, expected.Length, fixture.SchemaRevision})
+		if !ok {
+			t.Fatalf("model %d/%d absent", expected.ID, expected.Length)
+		}
+		if len(definition.points) != int(expected.Points) || definition.compatibility != expected.Compatibility {
+			t.Fatalf("model %d/%d points=%d compatibility=%v", expected.ID, expected.Length, len(definition.points), definition.compatibility)
+		}
+		var end uint16
+		for _, point := range definition.points {
+			if point.offset != end || point.size == 0 {
+				t.Fatalf("model %d point %#v is not contiguous", expected.ID, point)
+			}
+			end += point.size
+		}
+		if end != expected.Length+2 {
+			t.Fatalf("model %d/%d extent=%d", expected.ID, expected.Length, end)
+		}
+	}
+}
+
+func TestSunSpecPinnedPointOrderAndTypes(t *testing.T) {
+	common := "ID:uint16:1,L:uint16:1,Mn:string:16,Md:string:16,Opt:string:8,Vr:string:8,SN:string:16,DA:uint16:1,Pad:pad:1"
+	integer := "ID:uint16:1,L:uint16:1,A:uint16:1,AphA:uint16:1,AphB:uint16:1,AphC:uint16:1,A_SF:sunssf:1,PPVphAB:uint16:1,PPVphBC:uint16:1,PPVphCA:uint16:1,PhVphA:uint16:1,PhVphB:uint16:1,PhVphC:uint16:1,V_SF:sunssf:1,W:int16:1,W_SF:sunssf:1,Hz:uint16:1,Hz_SF:sunssf:1,VA:int16:1,VA_SF:sunssf:1,VAr:int16:1,VAr_SF:sunssf:1,PF:int16:1,PF_SF:sunssf:1,WH:acc32:2,WH_SF:sunssf:1,DCA:uint16:1,DCA_SF:sunssf:1,DCV:uint16:1,DCV_SF:sunssf:1,DCW:int16:1,DCW_SF:sunssf:1,TmpCab:int16:1,TmpSnk:int16:1,TmpTrns:int16:1,TmpOt:int16:1,Tmp_SF:sunssf:1,St:enum16:1,StVnd:enum16:1,Evt1:bitfield32:2,Evt2:bitfield32:2,EvtVnd1:bitfield32:2,EvtVnd2:bitfield32:2,EvtVnd3:bitfield32:2,EvtVnd4:bitfield32:2"
+	float := "ID:uint16:1,L:uint16:1,A:float32:2,AphA:float32:2,AphB:float32:2,AphC:float32:2,PPVphAB:float32:2,PPVphBC:float32:2,PPVphCA:float32:2,PhVphA:float32:2,PhVphB:float32:2,PhVphC:float32:2,W:float32:2,Hz:float32:2,VA:float32:2,VAr:float32:2,PF:float32:2,WH:float32:2,DCA:float32:2,DCV:float32:2,DCW:float32:2,TmpCab:float32:2,TmpSnk:float32:2,TmpTrns:float32:2,TmpOt:float32:2,St:enum16:1,StVnd:enum16:1,Evt1:bitfield32:2,Evt2:bitfield32:2,EvtVnd1:bitfield32:2,EvtVnd2:bitfield32:2,EvtVnd3:bitfield32:2,EvtVnd4:bitfield32:2"
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		id, length uint16
+		want       string
+	}{
+		{1, 66, common}, {101, 50, integer}, {102, 50, integer}, {103, 50, integer},
+		{111, 60, float}, {112, 60, float}, {113, 60, float},
+	} {
+		definition, ok := registry.definition(SunSpecDecoderKey{tc.id, tc.length, testSunSpecModelsRevision})
+		if !ok {
+			t.Fatalf("definition %d absent", tc.id)
+		}
+		got := make([]string, len(definition.points))
+		for index, point := range definition.points {
+			got[index] = fmt.Sprintf("%s:%s:%d", point.name, point.pointType, point.size)
+		}
+		if joined := joinSunSpecCatalog(got); joined != tc.want {
+			t.Fatalf("model %d catalog\n%s\nwant\n%s", tc.id, joined, tc.want)
+		}
+	}
+	l65, _ := registry.definition(SunSpecDecoderKey{1, 65, testSunSpecModelsRevision})
+	l66, _ := registry.definition(SunSpecDecoderKey{1, 66, testSunSpecModelsRevision})
+	if !reflect.DeepEqual(l65.points, l66.points[:len(l66.points)-1]) || l66.points[len(l66.points)-1].name != "Pad" {
+		t.Fatal("Model 1 L65 compatibility is not exactly L66 without Pad")
+	}
+}
+
+func joinSunSpecCatalog(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	result := values[0]
+	for _, value := range values[1:] {
+		result += "," + value
+	}
+	return result
+}

--- a/sunspec_models_common.go
+++ b/sunspec_models_common.go
@@ -1,0 +1,15 @@
+package modbusreg
+
+func commonSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		sunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true, nil, 0),
+		sunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true, nil, 0),
+		sunSpecPoint("Mn", "device.manufacturer", SunSpecTypeString, 16, "", "", true, nil, 0),
+		sunSpecPoint("Md", "device.model", SunSpecTypeString, 16, "", "", true, nil, 0),
+		sunSpecPoint("Opt", "device.options", SunSpecTypeString, 8, "", "", false, nil, 0),
+		sunSpecPoint("Vr", "device.version", SunSpecTypeString, 8, "", "", false, nil, 0),
+		sunSpecPoint("SN", "device.serial", SunSpecTypeString, 16, "", "", true, nil, 0),
+		sunSpecPoint("DA", "device.address", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("Pad", "device.pad", SunSpecTypePad, 1, "", "", false, nil, 0),
+	}
+}

--- a/sunspec_models_common_test.go
+++ b/sunspec_models_common_test.go
@@ -1,0 +1,62 @@
+package modbusreg
+
+import "testing"
+
+func TestSunSpecCommonL66AndL65DecodeOnlyByExactKey(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := map[string][]uint16{
+		"Mn": stringWords("Fronius", 16), "Md": stringWords("GEN24", 16),
+		"Opt": stringWords("", 8), "Vr": stringWords("1.2.3", 8), "SN": stringWords("SERIAL", 16),
+		"DA": {1}, "Pad": {0x8000},
+	}
+	for _, length := range []uint16{65, 66} {
+		decoded, err := registry.DecodeOccurrence(admittedOccurrence(1, length, modelWords(t, registry, 1, length, values), 1))
+		if err != nil {
+			t.Fatalf("L%d: %v", length, err)
+		}
+		if decoded.Key().ModelLength != length || decoded.Topology() != SunSpecTopologyNone {
+			t.Fatalf("L%d decoded=%#v", length, decoded)
+		}
+		fact, ok := decoded.Fact("device.manufacturer")
+		if !ok {
+			t.Fatalf("L%d manufacturer absent", length)
+		}
+		if text, ok := fact.Value.Text(); !ok || text != "Fronius" {
+			t.Fatalf("L%d manufacturer=%q/%v", length, text, ok)
+		}
+	}
+	unsupported := admittedOccurrence(1, 64, make([]uint16, 66), 1)
+	unsupported.decoderKey = nil
+	unsupported.Disposition = SunSpecChainDispositionUnsupportedLength
+	if _, err := registry.DecodeOccurrence(unsupported); err == nil {
+		t.Fatal("unsupported Common length decoded")
+	}
+}
+
+func TestSunSpecChainDecodeRequiresExactlyOneSupportedCommonFirst(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	common := admittedOccurrence(1, 65, modelWords(t, registry, 1, 65, map[string][]uint16{"Mn": stringWords("Maker", 16)}), 1)
+	inverter := admittedOccurrence(103, 50, modelWords(t, registry, 103, 50, nil), 2)
+	for name, occurrences := range map[string][]SunSpecOccurrence{
+		"missing": {inverter}, "out of order": {inverter, common}, "repeated": {common, common},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := registry.decodeOccurrences(occurrences); err == nil {
+				t.Fatal("invalid Common structure decoded")
+			}
+		})
+	}
+	decoded, err := registry.decodeOccurrences([]SunSpecOccurrence{common, inverter})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded.Models()) != 2 {
+		t.Fatalf("models=%d", len(decoded.Models()))
+	}
+}

--- a/sunspec_models_equivalence_test.go
+++ b/sunspec_models_equivalence_test.go
@@ -1,0 +1,51 @@
+package modbusreg
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestSunSpecModels103And113CanonicalEquivalence(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	integer := modelWords(t, registry, 103, 50, map[string][]uint16{
+		"A": {125}, "AphA": {40}, "AphB": {41}, "AphC": {44}, "A_SF": {0xfffe},
+		"W": {0x04d2}, "W_SF": {0}, "Hz": {5000}, "Hz_SF": {0xfffe}, "St": {4},
+	})
+	floating := modelWords(t, registry, 113, 60, map[string][]uint16{
+		"A": {0x3fa0, 0}, "AphA": {0x3e4c, 0xcccd}, "AphB": {0x3e51, 0xeb85}, "AphC": {0x3e61, 0x47ae},
+		"W": {0x449a, 0x4000}, "Hz": {0x4248, 0}, "St": {4},
+	})
+	left, err := registry.DecodeOccurrence(admittedOccurrence(103, 50, integer, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := registry.DecodeOccurrence(admittedOccurrence(113, 60, floating, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.Topology() != SunSpecTopologyThreePhase || right.Topology() != SunSpecTopologyThreePhase {
+		t.Fatal("three-phase topology lost")
+	}
+	leftShape, rightShape := requiredFactShape(left), requiredFactShape(right)
+	if !reflect.DeepEqual(leftShape, rightShape) {
+		t.Fatalf("103=%v\n113=%v", leftShape, rightShape)
+	}
+	if reflect.DeepEqual(left.RawWords(), right.RawWords()) {
+		t.Fatal("distinct encodings collapsed")
+	}
+}
+
+func requiredFactShape(model SunSpecDecodedModel) []string {
+	var shape []string
+	for _, fact := range model.Facts() {
+		if fact.Required && fact.Value.State() == SunSpecValueValid {
+			shape = append(shape, fact.FieldID+"|"+fact.Unit)
+		}
+	}
+	sort.Strings(shape)
+	return shape
+}

--- a/sunspec_models_equivalence_test.go
+++ b/sunspec_models_equivalence_test.go
@@ -13,11 +13,12 @@ func TestSunSpecModels103And113CanonicalEquivalence(t *testing.T) {
 	}
 	integer := modelWords(t, registry, 103, 50, map[string][]uint16{
 		"A": {125}, "AphA": {40}, "AphB": {41}, "AphC": {44}, "A_SF": {0xfffe},
-		"W": {0x04d2}, "W_SF": {0}, "Hz": {5000}, "Hz_SF": {0xfffe}, "St": {4},
+		"W": {0x04d2}, "W_SF": {0}, "Hz": {5000}, "Hz_SF": {0xfffe},
+		"WH": {0, 100}, "WH_SF": {0}, "St": {4},
 	})
 	floating := modelWords(t, registry, 113, 60, map[string][]uint16{
 		"A": {0x3fa0, 0}, "AphA": {0x3e4c, 0xcccd}, "AphB": {0x3e51, 0xeb85}, "AphC": {0x3e61, 0x47ae},
-		"W": {0x449a, 0x4000}, "Hz": {0x4248, 0}, "St": {4},
+		"W": {0x449a, 0x4000}, "Hz": {0x4248, 0}, "WH": {0x42c8, 0}, "St": {4},
 	})
 	left, err := registry.DecodeOccurrence(admittedOccurrence(103, 50, integer, 1))
 	if err != nil {

--- a/sunspec_models_inverter.go
+++ b/sunspec_models_inverter.go
@@ -1,0 +1,109 @@
+package modbusreg
+
+func integerInverterSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		inverterSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", ""), inverterSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", ""),
+		inverterSunSpecPoint("A", "inverter.ac.current.total", SunSpecTypeUint16, 1, "A", "A_SF"),
+		inverterSunSpecPoint("AphA", "inverter.ac.current.phase_a", SunSpecTypeUint16, 1, "A", "A_SF"),
+		inverterSunSpecPoint("AphB", "inverter.ac.current.phase_b", SunSpecTypeUint16, 1, "A", "A_SF"),
+		inverterSunSpecPoint("AphC", "inverter.ac.current.phase_c", SunSpecTypeUint16, 1, "A", "A_SF"),
+		inverterSunSpecPoint("A_SF", "inverter.scale.current", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("PPVphAB", "inverter.ac.voltage.line_ab", SunSpecTypeUint16, 1, "V", "V_SF"),
+		inverterSunSpecPoint("PPVphBC", "inverter.ac.voltage.line_bc", SunSpecTypeUint16, 1, "V", "V_SF"),
+		inverterSunSpecPoint("PPVphCA", "inverter.ac.voltage.line_ca", SunSpecTypeUint16, 1, "V", "V_SF"),
+		inverterSunSpecPoint("PhVphA", "inverter.ac.voltage.phase_a", SunSpecTypeUint16, 1, "V", "V_SF"),
+		inverterSunSpecPoint("PhVphB", "inverter.ac.voltage.phase_b", SunSpecTypeUint16, 1, "V", "V_SF"),
+		inverterSunSpecPoint("PhVphC", "inverter.ac.voltage.phase_c", SunSpecTypeUint16, 1, "V", "V_SF"),
+		inverterSunSpecPoint("V_SF", "inverter.scale.voltage", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("W", "inverter.ac.power.active", SunSpecTypeInt16, 1, "W", "W_SF"),
+		inverterSunSpecPoint("W_SF", "inverter.scale.active_power", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("Hz", "inverter.ac.frequency", SunSpecTypeUint16, 1, "Hz", "Hz_SF"),
+		inverterSunSpecPoint("Hz_SF", "inverter.scale.frequency", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("VA", "inverter.ac.power.apparent", SunSpecTypeInt16, 1, "VA", "VA_SF"),
+		inverterSunSpecPoint("VA_SF", "inverter.scale.apparent_power", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("VAr", "inverter.ac.power.reactive", SunSpecTypeInt16, 1, "var", "VAr_SF"),
+		inverterSunSpecPoint("VAr_SF", "inverter.scale.reactive_power", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("PF", "inverter.ac.power_factor", SunSpecTypeInt16, 1, "Pct", "PF_SF"),
+		inverterSunSpecPoint("PF_SF", "inverter.scale.power_factor", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("WH", "inverter.ac.energy_lifetime", SunSpecTypeAccumulator32, 2, "Wh", "WH_SF"),
+		inverterSunSpecPoint("WH_SF", "inverter.scale.energy", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("DCA", "inverter.dc.current", SunSpecTypeUint16, 1, "A", "DCA_SF"),
+		inverterSunSpecPoint("DCA_SF", "inverter.scale.dc_current", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("DCV", "inverter.dc.voltage", SunSpecTypeUint16, 1, "V", "DCV_SF"),
+		inverterSunSpecPoint("DCV_SF", "inverter.scale.dc_voltage", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("DCW", "inverter.dc.power", SunSpecTypeInt16, 1, "W", "DCW_SF"),
+		inverterSunSpecPoint("DCW_SF", "inverter.scale.dc_power", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecPoint("TmpCab", "inverter.temperature.cabinet", SunSpecTypeInt16, 1, "C", "Tmp_SF"),
+		inverterSunSpecPoint("TmpSnk", "inverter.temperature.heatsink", SunSpecTypeInt16, 1, "C", "Tmp_SF"),
+		inverterSunSpecPoint("TmpTrns", "inverter.temperature.transformer", SunSpecTypeInt16, 1, "C", "Tmp_SF"),
+		inverterSunSpecPoint("TmpOt", "inverter.temperature.other", SunSpecTypeInt16, 1, "C", "Tmp_SF"),
+		inverterSunSpecPoint("Tmp_SF", "inverter.scale.temperature", SunSpecTypeScaleFactor, 1, "", ""),
+		inverterSunSpecEnumPoint("St", "inverter.operating_state", inverterStatusSymbols()),
+		inverterSunSpecEnumPoint("StVnd", "inverter.vendor_state", nil),
+		inverterSunSpecBitfieldPoint("Evt1", "inverter.events.1", 0x0000ffff),
+		inverterSunSpecBitfieldPoint("Evt2", "inverter.events.2", 0),
+		inverterSunSpecBitfieldPoint("EvtVnd1", "inverter.vendor_events.1", 0),
+		inverterSunSpecBitfieldPoint("EvtVnd2", "inverter.vendor_events.2", 0),
+		inverterSunSpecBitfieldPoint("EvtVnd3", "inverter.vendor_events.3", 0),
+		inverterSunSpecBitfieldPoint("EvtVnd4", "inverter.vendor_events.4", 0),
+	}
+}
+
+func floatInverterSunSpecPoints() []sunSpecPointDefinition {
+	points := []sunSpecPointDefinition{
+		inverterSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", ""), inverterSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", ""),
+	}
+	for _, point := range []struct{ name, field, unit string }{
+		{"A", "inverter.ac.current.total", "A"}, {"AphA", "inverter.ac.current.phase_a", "A"}, {"AphB", "inverter.ac.current.phase_b", "A"}, {"AphC", "inverter.ac.current.phase_c", "A"},
+		{"PPVphAB", "inverter.ac.voltage.line_ab", "V"}, {"PPVphBC", "inverter.ac.voltage.line_bc", "V"}, {"PPVphCA", "inverter.ac.voltage.line_ca", "V"},
+		{"PhVphA", "inverter.ac.voltage.phase_a", "V"}, {"PhVphB", "inverter.ac.voltage.phase_b", "V"}, {"PhVphC", "inverter.ac.voltage.phase_c", "V"},
+		{"W", "inverter.ac.power.active", "W"}, {"Hz", "inverter.ac.frequency", "Hz"}, {"VA", "inverter.ac.power.apparent", "VA"}, {"VAr", "inverter.ac.power.reactive", "var"}, {"PF", "inverter.ac.power_factor", "Pct"},
+		{"WH", "inverter.ac.energy_lifetime", "Wh"}, {"DCA", "inverter.dc.current", "A"}, {"DCV", "inverter.dc.voltage", "V"}, {"DCW", "inverter.dc.power", "W"},
+		{"TmpCab", "inverter.temperature.cabinet", "C"}, {"TmpSnk", "inverter.temperature.heatsink", "C"}, {"TmpTrns", "inverter.temperature.transformer", "C"}, {"TmpOt", "inverter.temperature.other", "C"},
+	} {
+		points = append(points, inverterSunSpecPoint(point.name, point.field, SunSpecTypeFloat32, 2, point.unit, ""))
+	}
+	return append(points,
+		inverterSunSpecEnumPoint("St", "inverter.operating_state", inverterStatusSymbols()), inverterSunSpecEnumPoint("StVnd", "inverter.vendor_state", nil),
+		inverterSunSpecBitfieldPoint("Evt1", "inverter.events.1", 0x0000ffff), inverterSunSpecBitfieldPoint("Evt2", "inverter.events.2", 0),
+		inverterSunSpecBitfieldPoint("EvtVnd1", "inverter.vendor_events.1", 0), inverterSunSpecBitfieldPoint("EvtVnd2", "inverter.vendor_events.2", 0),
+		inverterSunSpecBitfieldPoint("EvtVnd3", "inverter.vendor_events.3", 0), inverterSunSpecBitfieldPoint("EvtVnd4", "inverter.vendor_events.4", 0),
+	)
+}
+
+func inverterSunSpecPoint(name, field string, pointType SunSpecPointType, size uint16, unit, scale string) sunSpecPointDefinition {
+	return sunSpecPoint(name, field, pointType, size, unit, scale, false, nil, 0)
+}
+
+func inverterSunSpecEnumPoint(name, field string, symbols map[uint64]string) sunSpecPointDefinition {
+	return sunSpecPoint(name, field, SunSpecTypeEnum16, 1, "", "", false, symbols, 0)
+}
+
+func inverterSunSpecBitfieldPoint(name, field string, knownMask uint64) sunSpecPointDefinition {
+	return sunSpecPoint(name, field, SunSpecTypeBitfield32, 2, "", "", false, nil, knownMask)
+}
+
+func inverterStatusSymbols() map[uint64]string {
+	return map[uint64]string{1: "OFF", 2: "SLEEPING", 3: "STARTING", 4: "MPPT", 5: "THROTTLED", 6: "SHUTTING_DOWN", 7: "FAULT", 8: "STANDBY"}
+}
+
+func sunSpecPointMandatory(modelID uint16, name string) bool {
+	mandatory := map[uint16]map[string]struct{}{
+		101: sunSpecNameSet("ID", "L", "A", "AphA", "A_SF", "PhVphA", "V_SF", "W", "W_SF", "Hz", "Hz_SF", "WH", "WH_SF", "TmpCab", "Tmp_SF", "St", "Evt1", "Evt2"),
+		102: sunSpecNameSet("ID", "L", "A", "AphA", "AphB", "A_SF", "PhVphA", "PhVphB", "V_SF", "W", "W_SF", "Hz", "Hz_SF", "WH", "WH_SF", "TmpCab", "Tmp_SF", "St", "Evt1", "Evt2"),
+		103: sunSpecNameSet("ID", "L", "A", "AphA", "AphB", "AphC", "A_SF", "PhVphA", "PhVphB", "PhVphC", "V_SF", "W", "W_SF", "Hz", "Hz_SF", "WH", "WH_SF", "TmpCab", "Tmp_SF", "St", "Evt1", "Evt2"),
+		111: sunSpecNameSet("ID", "L", "A", "AphA", "PhVphA", "W", "Hz", "WH", "TmpCab", "St", "Evt1", "Evt2"),
+		112: sunSpecNameSet("ID", "L", "A", "AphA", "AphB", "PhVphA", "PhVphB", "W", "Hz", "WH", "TmpCab", "St", "Evt1", "Evt2"),
+		113: sunSpecNameSet("ID", "L", "A", "AphA", "AphB", "AphC", "PhVphA", "PhVphB", "PhVphC", "W", "Hz", "WH", "TmpCab", "St", "Evt1", "Evt2"),
+	}
+	_, ok := mandatory[modelID][name]
+	return ok
+}
+
+func sunSpecNameSet(values ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		out[value] = struct{}{}
+	}
+	return out
+}

--- a/sunspec_models_inverter.go
+++ b/sunspec_models_inverter.go
@@ -40,16 +40,16 @@ func integerInverterSunSpecPoints() []sunSpecPointDefinition {
 		inverterSunSpecPoint("Tmp_SF", "inverter.scale.temperature", SunSpecTypeScaleFactor, 1, "", ""),
 		inverterSunSpecEnumPoint("St", "inverter.operating_state", inverterStatusSymbols()),
 		inverterSunSpecEnumPoint("StVnd", "inverter.vendor_state", nil),
-		inverterSunSpecBitfieldPoint("Evt1", "inverter.events.1", 0x0000ffff),
-		inverterSunSpecBitfieldPoint("Evt2", "inverter.events.2", 0),
-		inverterSunSpecBitfieldPoint("EvtVnd1", "inverter.vendor_events.1", 0),
-		inverterSunSpecBitfieldPoint("EvtVnd2", "inverter.vendor_events.2", 0),
-		inverterSunSpecBitfieldPoint("EvtVnd3", "inverter.vendor_events.3", 0),
-		inverterSunSpecBitfieldPoint("EvtVnd4", "inverter.vendor_events.4", 0),
+		inverterSunSpecBitfieldPoint("Evt1", "inverter.events.1", inverterEvent1Symbols()),
+		inverterSunSpecBitfieldPoint("Evt2", "inverter.events.2", nil),
+		inverterSunSpecBitfieldPoint("EvtVnd1", "inverter.vendor_events.1", nil),
+		inverterSunSpecBitfieldPoint("EvtVnd2", "inverter.vendor_events.2", nil),
+		inverterSunSpecBitfieldPoint("EvtVnd3", "inverter.vendor_events.3", nil),
+		inverterSunSpecBitfieldPoint("EvtVnd4", "inverter.vendor_events.4", nil),
 	}
 }
 
-func floatInverterSunSpecPoints() []sunSpecPointDefinition {
+func floatInverterSunSpecPoints(statusSymbols map[uint64]string) []sunSpecPointDefinition {
 	points := []sunSpecPointDefinition{
 		inverterSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", ""), inverterSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", ""),
 	}
@@ -64,10 +64,10 @@ func floatInverterSunSpecPoints() []sunSpecPointDefinition {
 		points = append(points, inverterSunSpecPoint(point.name, point.field, SunSpecTypeFloat32, 2, point.unit, ""))
 	}
 	return append(points,
-		inverterSunSpecEnumPoint("St", "inverter.operating_state", inverterStatusSymbols()), inverterSunSpecEnumPoint("StVnd", "inverter.vendor_state", nil),
-		inverterSunSpecBitfieldPoint("Evt1", "inverter.events.1", 0x0000ffff), inverterSunSpecBitfieldPoint("Evt2", "inverter.events.2", 0),
-		inverterSunSpecBitfieldPoint("EvtVnd1", "inverter.vendor_events.1", 0), inverterSunSpecBitfieldPoint("EvtVnd2", "inverter.vendor_events.2", 0),
-		inverterSunSpecBitfieldPoint("EvtVnd3", "inverter.vendor_events.3", 0), inverterSunSpecBitfieldPoint("EvtVnd4", "inverter.vendor_events.4", 0),
+		inverterSunSpecEnumPoint("St", "inverter.operating_state", statusSymbols), inverterSunSpecEnumPoint("StVnd", "inverter.vendor_state", nil),
+		inverterSunSpecBitfieldPoint("Evt1", "inverter.events.1", inverterEvent1Symbols()), inverterSunSpecBitfieldPoint("Evt2", "inverter.events.2", nil),
+		inverterSunSpecBitfieldPoint("EvtVnd1", "inverter.vendor_events.1", nil), inverterSunSpecBitfieldPoint("EvtVnd2", "inverter.vendor_events.2", nil),
+		inverterSunSpecBitfieldPoint("EvtVnd3", "inverter.vendor_events.3", nil), inverterSunSpecBitfieldPoint("EvtVnd4", "inverter.vendor_events.4", nil),
 	)
 }
 
@@ -79,12 +79,31 @@ func inverterSunSpecEnumPoint(name, field string, symbols map[uint64]string) sun
 	return sunSpecPoint(name, field, SunSpecTypeEnum16, 1, "", "", false, symbols, 0)
 }
 
-func inverterSunSpecBitfieldPoint(name, field string, knownMask uint64) sunSpecPointDefinition {
-	return sunSpecPoint(name, field, SunSpecTypeBitfield32, 2, "", "", false, nil, knownMask)
+func inverterSunSpecBitfieldPoint(name, field string, symbols map[uint64]string) sunSpecPointDefinition {
+	var knownMask uint64
+	for bit := range symbols {
+		if bit < 31 {
+			knownMask |= uint64(1) << bit
+		}
+	}
+	return sunSpecPoint(name, field, SunSpecTypeBitfield32, 2, "", "", false, symbols, knownMask)
 }
 
 func inverterStatusSymbols() map[uint64]string {
 	return map[uint64]string{1: "OFF", 2: "SLEEPING", 3: "STARTING", 4: "MPPT", 5: "THROTTLED", 6: "SHUTTING_DOWN", 7: "FAULT", 8: "STANDBY"}
+}
+
+func inverterModel111StatusSymbols() map[uint64]string {
+	return map[uint64]string{1: "ggOFF", 2: "ggSLEEPING", 3: "ggSTARTING", 4: "ggMPPT", 5: "ggTHROTTLED", 6: "ggSHUTTING_DOWN", 7: "ggFAULT", 8: "ggSTANDBY"}
+}
+
+func inverterEvent1Symbols() map[uint64]string {
+	return map[uint64]string{
+		0: "GROUND_FAULT", 1: "DC_OVER_VOLT", 2: "AC_DISCONNECT", 3: "DC_DISCONNECT",
+		4: "GRID_DISCONNECT", 5: "CABINET_OPEN", 6: "MANUAL_SHUTDOWN", 7: "OVER_TEMP",
+		8: "OVER_FREQUENCY", 9: "UNDER_FREQUENCY", 10: "AC_OVER_VOLT", 11: "AC_UNDER_VOLT",
+		12: "BLOWN_STRING_FUSE", 13: "UNDER_TEMP", 14: "MEMORY_LOSS", 15: "HW_TEST_FAILURE",
+	}
 }
 
 func sunSpecPointMandatory(modelID uint16, name string) bool {

--- a/sunspec_models_inverter_test.go
+++ b/sunspec_models_inverter_test.go
@@ -79,6 +79,36 @@ func TestSunSpecInverterEventDefinitionsMatchPinnedSource(t *testing.T) {
 	}
 }
 
+func TestSunSpecInverterStatusDefinitionsMatchPinnedSource(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	standard := map[uint64]string{1: "OFF", 2: "SLEEPING", 3: "STARTING", 4: "MPPT", 5: "THROTTLED", 6: "SHUTTING_DOWN", 7: "FAULT", 8: "STANDBY"}
+	model111 := map[uint64]string{1: "ggOFF", 2: "ggSLEEPING", 3: "ggSTARTING", 4: "ggMPPT", 5: "ggTHROTTLED", 6: "ggSHUTTING_DOWN", 7: "ggFAULT", 8: "ggSTANDBY"}
+	for _, modelID := range []uint16{101, 102, 103, 111, 112, 113} {
+		length, want := uint16(50), standard
+		if modelID >= 111 {
+			length = 60
+		}
+		if modelID == 111 {
+			want = model111
+		}
+		definition, ok := registry.definition(SunSpecDecoderKey{modelID, length, testSunSpecModelsRevision})
+		if !ok {
+			t.Fatalf("model %d absent", modelID)
+		}
+		for _, point := range definition.points {
+			if point.name == "St" {
+				if !reflect.DeepEqual(point.symbols, want) {
+					t.Fatalf("model %d status symbols=%v", modelID, point.symbols)
+				}
+				break
+			}
+		}
+	}
+}
+
 func TestSunSpecModelDecodeFailsClosedOnInvalidRequiredEncoding(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
 	if err != nil {

--- a/sunspec_models_inverter_test.go
+++ b/sunspec_models_inverter_test.go
@@ -1,0 +1,75 @@
+package modbusreg
+
+import "testing"
+
+func TestSunSpecIntegerAndFloatInvertersDecodeAllFields(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	integerValues := map[string][]uint16{
+		"A": {123}, "A_SF": {0xfffe}, "W": {0xff85}, "W_SF": {0}, "Hz": {5000}, "Hz_SF": {0xfffe},
+		"WH": {0, 42}, "WH_SF": {0}, "St": {4}, "StVnd": {99}, "Evt1": {0, 3},
+	}
+	for _, id := range []uint16{101, 102, 103} {
+		decoded, err := registry.DecodeOccurrence(admittedOccurrence(id, 50, modelWords(t, registry, id, 50, integerValues), 1))
+		if err != nil {
+			t.Fatalf("model %d: %v", id, err)
+		}
+		if len(decoded.Facts()) != 43 {
+			t.Fatalf("model %d facts=%d", id, len(decoded.Facts()))
+		}
+		power, _ := decoded.Fact("inverter.ac.power.active")
+		decimal, ok := power.Value.Decimal()
+		if !ok || decimal.Coefficient != -123 || decimal.Exponent != 0 {
+			t.Fatalf("model %d power=%#v", id, power)
+		}
+		state, _ := decoded.Fact("inverter.operating_state")
+		if number, symbol, ok := state.Value.Enum(); !ok || number != 4 || symbol != "MPPT" {
+			t.Fatalf("state=%d/%q/%v", number, symbol, ok)
+		}
+	}
+	floatValues := map[string][]uint16{"A": {0x4148, 0}, "W": {0xc2f6, 0}, "Hz": {0x4248, 0}, "St": {4}, "Evt1": {0, 3}}
+	for _, id := range []uint16{111, 112, 113} {
+		decoded, err := registry.DecodeOccurrence(admittedOccurrence(id, 60, modelWords(t, registry, id, 60, floatValues), 1))
+		if err != nil {
+			t.Fatalf("model %d: %v", id, err)
+		}
+		if len(decoded.Facts()) != 31 {
+			t.Fatalf("model %d facts=%d", id, len(decoded.Facts()))
+		}
+		power, _ := decoded.Fact("inverter.ac.power.active")
+		if value, ok := power.Value.Float32(); !ok || value != -123 {
+			t.Fatalf("model %d power=%v/%v", id, value, ok)
+		}
+	}
+}
+
+func TestSunSpecModelDecodeFailsClosedOnInvalidRequiredEncoding(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, tc := range map[string]struct {
+		id, length uint16
+		values     map[string][]uint16
+	}{
+		"invalid scale":            {103, 50, map[string][]uint16{"A": {1}, "A_SF": {11}}},
+		"canonical float sentinel": {113, 60, map[string][]uint16{"A": {0x7fc0, 0}}},
+		"infinite float":           {113, 60, map[string][]uint16{"A": {0x7f80, 0}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			decoded, err := registry.DecodeOccurrence(admittedOccurrence(tc.id, tc.length, modelWords(t, registry, tc.id, tc.length, tc.values), 1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			fact, ok := decoded.Fact("inverter.ac.current.total")
+			if !ok || fact.Value.State() == SunSpecValueValid {
+				t.Fatalf("fact=%#v", fact)
+			}
+			if decoded.Qualifies() {
+				t.Fatal("invalid required fact qualified")
+			}
+		})
+	}
+}

--- a/sunspec_models_inverter_test.go
+++ b/sunspec_models_inverter_test.go
@@ -1,6 +1,9 @@
 package modbusreg
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestSunSpecIntegerAndFloatInvertersDecodeAllFields(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
@@ -41,6 +44,37 @@ func TestSunSpecIntegerAndFloatInvertersDecodeAllFields(t *testing.T) {
 		power, _ := decoded.Fact("inverter.ac.power.active")
 		if value, ok := power.Value.Float32(); !ok || value != -123 {
 			t.Fatalf("model %d power=%v/%v", id, value, ok)
+		}
+	}
+}
+
+func TestSunSpecInverterEventDefinitionsMatchPinnedSource(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[uint64]string{
+		0: "GROUND_FAULT", 1: "DC_OVER_VOLT", 2: "AC_DISCONNECT", 3: "DC_DISCONNECT",
+		4: "GRID_DISCONNECT", 5: "CABINET_OPEN", 6: "MANUAL_SHUTDOWN", 7: "OVER_TEMP",
+		8: "OVER_FREQUENCY", 9: "UNDER_FREQUENCY", 10: "AC_OVER_VOLT", 11: "AC_UNDER_VOLT",
+		12: "BLOWN_STRING_FUSE", 13: "UNDER_TEMP", 14: "MEMORY_LOSS", 15: "HW_TEST_FAILURE",
+	}
+	for _, modelID := range []uint16{101, 102, 103, 111, 112, 113} {
+		length := uint16(50)
+		if modelID >= 111 {
+			length = 60
+		}
+		definition, ok := registry.definition(SunSpecDecoderKey{modelID, length, testSunSpecModelsRevision})
+		if !ok {
+			t.Fatalf("model %d absent", modelID)
+		}
+		for _, point := range definition.points {
+			if point.name == "Evt1" {
+				if point.knownMask != 0x0000ffff || !reflect.DeepEqual(point.symbols, want) {
+					t.Fatalf("model %d Evt1 mask=%x symbols=%v", modelID, point.knownMask, point.symbols)
+				}
+				break
+			}
 		}
 	}
 }

--- a/sunspec_value.go
+++ b/sunspec_value.go
@@ -54,6 +54,7 @@ type SunSpecValue struct {
 	hasEnum     bool
 	bits        uint64
 	unknown     uint64
+	bitSymbols  []string
 	hasBits     bool
 }
 
@@ -67,6 +68,9 @@ func (v SunSpecValue) Unsigned() (uint64, bool)         { return v.unsigned, v.h
 func (v SunSpecValue) Text() (string, bool)             { return v.text, v.hasText }
 func (v SunSpecValue) Enum() (uint64, string, bool)     { return v.enumNumber, v.enumSymbol, v.hasEnum }
 func (v SunSpecValue) Bitfield() (uint64, uint64, bool) { return v.bits, v.unknown, v.hasBits }
+func (v SunSpecValue) BitfieldSymbols() []string {
+	return append([]string(nil), v.bitSymbols...)
+}
 
 func invalidSunSpecValue(pointType SunSpecPointType, words []uint16, state SunSpecValueState) SunSpecValue {
 	return SunSpecValue{pointType: pointType, state: state, raw: append([]uint16(nil), words...)}
@@ -133,6 +137,12 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 			return value
 		}
 		value.bits, value.unknown, value.hasBits = bits, bits&^def.knownMask, true
+		for bit := uint64(0); bit < 31; bit++ {
+			mask := uint64(1) << bit
+			if bits&mask != 0 && def.knownMask&mask != 0 && def.symbols[bit] != "" {
+				value.bitSymbols = append(value.bitSymbols, def.symbols[bit])
+			}
+		}
 	case SunSpecTypeString:
 		return decodeSunSpecString(def, words)
 	case SunSpecTypePad:

--- a/sunspec_value.go
+++ b/sunspec_value.go
@@ -1,0 +1,218 @@
+package modbusreg
+
+import (
+	"encoding/binary"
+	"math"
+	"unicode/utf8"
+)
+
+type SunSpecPointType string
+
+const (
+	SunSpecTypeInt16         SunSpecPointType = "int16"
+	SunSpecTypeUint16        SunSpecPointType = "uint16"
+	SunSpecTypeUint32        SunSpecPointType = "uint32"
+	SunSpecTypeAccumulator32 SunSpecPointType = "acc32"
+	SunSpecTypeEnum16        SunSpecPointType = "enum16"
+	SunSpecTypeBitfield32    SunSpecPointType = "bitfield32"
+	SunSpecTypeString        SunSpecPointType = "string"
+	SunSpecTypeFloat32       SunSpecPointType = "float32"
+	SunSpecTypeScaleFactor   SunSpecPointType = "sunssf"
+	SunSpecTypePad           SunSpecPointType = "pad"
+)
+
+type SunSpecValueState string
+
+const (
+	SunSpecValueValid           SunSpecValueState = "valid"
+	SunSpecValueNotImplemented  SunSpecValueState = "not_implemented"
+	SunSpecValueNotAccumulated  SunSpecValueState = "not_accumulated"
+	SunSpecValueInvalidEncoding SunSpecValueState = "invalid_encoding"
+)
+
+type SunSpecDecimal struct {
+	Coefficient int64
+	Exponent    int16
+}
+
+type SunSpecValue struct {
+	pointType   SunSpecPointType
+	state       SunSpecValueState
+	raw         []uint16
+	decimal     SunSpecDecimal
+	hasDecimal  bool
+	float32     float32
+	hasFloat    bool
+	signed      int64
+	hasSigned   bool
+	unsigned    uint64
+	hasUnsigned bool
+	text        string
+	hasText     bool
+	enumNumber  uint64
+	enumSymbol  string
+	hasEnum     bool
+	bits        uint64
+	unknown     uint64
+	hasBits     bool
+}
+
+func (v SunSpecValue) PointType() SunSpecPointType      { return v.pointType }
+func (v SunSpecValue) State() SunSpecValueState         { return v.state }
+func (v SunSpecValue) RawWords() []uint16               { return append([]uint16(nil), v.raw...) }
+func (v SunSpecValue) Decimal() (SunSpecDecimal, bool)  { return v.decimal, v.hasDecimal }
+func (v SunSpecValue) Float32() (float32, bool)         { return v.float32, v.hasFloat }
+func (v SunSpecValue) Signed() (int64, bool)            { return v.signed, v.hasSigned }
+func (v SunSpecValue) Unsigned() (uint64, bool)         { return v.unsigned, v.hasUnsigned }
+func (v SunSpecValue) Text() (string, bool)             { return v.text, v.hasText }
+func (v SunSpecValue) Enum() (uint64, string, bool)     { return v.enumNumber, v.enumSymbol, v.hasEnum }
+func (v SunSpecValue) Bitfield() (uint64, uint64, bool) { return v.bits, v.unknown, v.hasBits }
+
+func invalidSunSpecValue(pointType SunSpecPointType, words []uint16, state SunSpecValueState) SunSpecValue {
+	return SunSpecValue{pointType: pointType, state: state, raw: append([]uint16(nil), words...)}
+}
+
+func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSpecValue) SunSpecValue {
+	value := invalidSunSpecValue(def.pointType, words, SunSpecValueInvalidEncoding)
+	if len(words) != int(def.size) {
+		return value
+	}
+	switch def.pointType {
+	case SunSpecTypeInt16:
+		if words[0] == 0x8000 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		value.signed, value.hasSigned = int64(int16(words[0])), true
+	case SunSpecTypeUint16:
+		if words[0] == 0xffff {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		value.unsigned, value.hasUnsigned = uint64(words[0]), true
+	case SunSpecTypeUint32:
+		raw := uint64(uint32(words[0])<<16 | uint32(words[1]))
+		if raw == math.MaxUint32 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		value.unsigned, value.hasUnsigned = raw, true
+	case SunSpecTypeAccumulator32:
+		raw := uint64(uint32(words[0])<<16 | uint32(words[1]))
+		if raw == 0 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotAccumulated)
+		}
+		value.unsigned, value.hasUnsigned = raw, true
+	case SunSpecTypeScaleFactor:
+		if words[0] == 0x8000 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		sf := int16(words[0])
+		if sf < -10 || sf > 10 {
+			return value
+		}
+		value.signed, value.hasSigned = int64(sf), true
+	case SunSpecTypeFloat32:
+		bits := uint32(words[0])<<16 | uint32(words[1])
+		if bits == 0x7fc00000 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		decoded := math.Float32frombits(bits)
+		if math.IsNaN(float64(decoded)) || math.IsInf(float64(decoded), 0) {
+			return value
+		}
+		value.float32, value.hasFloat = decoded, true
+	case SunSpecTypeEnum16:
+		if words[0] == 0xffff {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		value.enumNumber, value.enumSymbol, value.hasEnum = uint64(words[0]), def.symbols[uint64(words[0])], true
+	case SunSpecTypeBitfield32:
+		bits := uint64(uint32(words[0])<<16 | uint32(words[1]))
+		if bits == math.MaxUint32 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		if bits > math.MaxInt32 {
+			return value
+		}
+		value.bits, value.unknown, value.hasBits = bits, bits&^def.knownMask, true
+	case SunSpecTypeString:
+		return decodeSunSpecString(def, words)
+	case SunSpecTypePad:
+		if words[0] != 0x8000 {
+			return value
+		}
+	default:
+		return value
+	}
+	value.state = SunSpecValueValid
+	if def.scaleFactor != "" {
+		return applySunSpecScale(value, scale)
+	}
+	return value
+}
+
+func applySunSpecScale(value SunSpecValue, scale *SunSpecValue) SunSpecValue {
+	if scale == nil || scale.state == SunSpecValueInvalidEncoding {
+		value.state = SunSpecValueInvalidEncoding
+		value.hasDecimal = false
+		return value
+	}
+	if scale.state != SunSpecValueValid || !scale.hasSigned {
+		value.state = SunSpecValueNotImplemented
+		value.hasDecimal = false
+		return value
+	}
+	coefficient := value.signed
+	if !value.hasSigned {
+		if !value.hasUnsigned || value.unsigned > math.MaxInt64 {
+			value.state = SunSpecValueInvalidEncoding
+			return value
+		}
+		coefficient = int64(value.unsigned)
+	}
+	value.decimal = SunSpecDecimal{Coefficient: coefficient, Exponent: int16(scale.signed)}
+	value.hasDecimal = true
+	return value
+}
+
+func decodeSunSpecString(def sunSpecPointDefinition, words []uint16) SunSpecValue {
+	value := invalidSunSpecValue(def.pointType, words, SunSpecValueInvalidEncoding)
+	raw := make([]byte, len(words)*2)
+	for index, word := range words {
+		binary.BigEndian.PutUint16(raw[index*2:], word)
+	}
+	allZero := true
+	for _, b := range raw {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+	}
+	if len(raw) >= 2 && raw[0] == 0 && raw[1] == 0x80 {
+		for _, b := range raw[2:] {
+			if b != 0 {
+				return value
+			}
+		}
+		value.state, value.text, value.hasText = SunSpecValueValid, "", true
+		return value
+	}
+	end := len(raw)
+	for index, b := range raw {
+		if b == 0 {
+			end = index
+			break
+		}
+	}
+	for _, b := range raw[end:] {
+		if b != 0 {
+			return value
+		}
+	}
+	if !utf8.Valid(raw[:end]) {
+		return value
+	}
+	value.state, value.text, value.hasText = SunSpecValueValid, string(raw[:end]), true
+	return value
+}

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -73,9 +73,18 @@ func TestSunSpecValueFloatEnumBitfieldAndStringAreLossless(t *testing.T) {
 	}
 	bitfieldDefinition := sizedSunSpecPoint(SunSpecTypeBitfield32, 2)
 	bitfieldDefinition.knownMask = 0x0000ffff
+	bitfieldDefinition.symbols = map[uint64]string{0: "GROUND_FAULT", 16: "VENDOR_EXTENSION"}
 	bits := decodeSunSpecValue(bitfieldDefinition, []uint16{0x0001, 0x0001}, nil)
 	if value, unknown, ok := bits.Bitfield(); !ok || value != 0x00010001 || unknown != 0x00010000 {
 		t.Fatalf("bitfield=%x unknown=%x ok=%v", value, unknown, ok)
+	}
+	if symbols := bits.BitfieldSymbols(); !reflect.DeepEqual(symbols, []string{"GROUND_FAULT"}) {
+		t.Fatalf("bitfield symbols=%v", symbols)
+	}
+	symbols := bits.BitfieldSymbols()
+	symbols[0] = "MUTATED"
+	if bits.BitfieldSymbols()[0] != "GROUND_FAULT" {
+		t.Fatal("bitfield symbols were mutable")
 	}
 	text := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeString, 2), []uint16{0x41c4, 0x8300}, nil)
 	if got, ok := text.Text(); !ok || got != "Aă" {

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -14,13 +14,13 @@ func TestSunSpecValueSentinelsAndExactDecimal(t *testing.T) {
 		sf    *SunSpecValue
 		state SunSpecValueState
 	}{
-		{name: "int16 sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeInt16}, words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
-		{name: "uint16 sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeUint16}, words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
-		{name: "enum sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeEnum16}, words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
-		{name: "bitfield sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeBitfield32}, words: []uint16{0xffff, 0xffff}, state: SunSpecValueNotImplemented},
-		{name: "accumulator zero", def: sunSpecPointDefinition{pointType: SunSpecTypeAccumulator32}, words: []uint16{0, 0}, state: SunSpecValueNotAccumulated},
-		{name: "scale sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeScaleFactor}, words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
-		{name: "scale out of range", def: sunSpecPointDefinition{pointType: SunSpecTypeScaleFactor}, words: []uint16{11}, state: SunSpecValueInvalidEncoding},
+		{name: "int16 sentinel", def: sizedSunSpecPoint(SunSpecTypeInt16, 1), words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
+		{name: "uint16 sentinel", def: sizedSunSpecPoint(SunSpecTypeUint16, 1), words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
+		{name: "enum sentinel", def: sizedSunSpecPoint(SunSpecTypeEnum16, 1), words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
+		{name: "bitfield sentinel", def: sizedSunSpecPoint(SunSpecTypeBitfield32, 2), words: []uint16{0xffff, 0xffff}, state: SunSpecValueNotImplemented},
+		{name: "accumulator zero", def: sizedSunSpecPoint(SunSpecTypeAccumulator32, 2), words: []uint16{0, 0}, state: SunSpecValueNotAccumulated},
+		{name: "scale sentinel", def: sizedSunSpecPoint(SunSpecTypeScaleFactor, 1), words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
+		{name: "scale out of range", def: sizedSunSpecPoint(SunSpecTypeScaleFactor, 1), words: []uint16{11}, state: SunSpecValueInvalidEncoding},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -30,8 +30,10 @@ func TestSunSpecValueSentinelsAndExactDecimal(t *testing.T) {
 			}
 		})
 	}
-	scale := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeScaleFactor}, []uint16{0xfffe}, nil)
-	value := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeInt16, scaleFactor: "W_SF"}, []uint16{0xff85}, &scale)
+	scale := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeScaleFactor, 1), []uint16{0xfffe}, nil)
+	definition := sizedSunSpecPoint(SunSpecTypeInt16, 1)
+	definition.scaleFactor = "W_SF"
+	value := decodeSunSpecValue(definition, []uint16{0xff85}, &scale)
 	decimal, ok := value.Decimal()
 	if !ok || decimal.Coefficient != -123 || decimal.Exponent != -2 {
 		t.Fatalf("decimal=%#v ok=%v", decimal, ok)
@@ -44,7 +46,7 @@ func TestSunSpecValueSentinelsAndExactDecimal(t *testing.T) {
 }
 
 func TestSunSpecValueFloatEnumBitfieldAndStringAreLossless(t *testing.T) {
-	canonicalNaN := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeFloat32}, []uint16{0x7fc0, 0}, nil)
+	canonicalNaN := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeFloat32, 2), []uint16{0x7fc0, 0}, nil)
 	if canonicalNaN.State() != SunSpecValueNotImplemented {
 		t.Fatalf("canonical NaN=%s", canonicalNaN.State())
 	}
@@ -54,29 +56,37 @@ func TestSunSpecValueFloatEnumBitfieldAndStringAreLossless(t *testing.T) {
 		"negative infinity": {0xff80, 0},
 	} {
 		t.Run(name, func(t *testing.T) {
-			if got := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeFloat32}, words, nil); got.State() != SunSpecValueInvalidEncoding {
+			if got := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeFloat32, 2), words, nil); got.State() != SunSpecValueInvalidEncoding {
 				t.Fatalf("state=%s", got.State())
 			}
 		})
 	}
-	finite := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeFloat32}, []uint16{0x4148, 0}, nil)
+	finite := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeFloat32, 2), []uint16{0x4148, 0}, nil)
 	if got, ok := finite.Float32(); !ok || got != 12.5 || math.Float32bits(got) != 0x41480000 {
 		t.Fatalf("float=%v ok=%v", got, ok)
 	}
-	enum := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeEnum16, symbols: map[uint64]string{1: "OFF"}}, []uint16{99}, nil)
+	enumDefinition := sizedSunSpecPoint(SunSpecTypeEnum16, 1)
+	enumDefinition.symbols = map[uint64]string{1: "OFF"}
+	enum := decodeSunSpecValue(enumDefinition, []uint16{99}, nil)
 	if number, symbol, ok := enum.Enum(); !ok || number != 99 || symbol != "" {
 		t.Fatalf("enum=%d/%q/%v", number, symbol, ok)
 	}
-	bits := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeBitfield32, knownMask: 0x0000ffff}, []uint16{0x0001, 0x0001}, nil)
+	bitfieldDefinition := sizedSunSpecPoint(SunSpecTypeBitfield32, 2)
+	bitfieldDefinition.knownMask = 0x0000ffff
+	bits := decodeSunSpecValue(bitfieldDefinition, []uint16{0x0001, 0x0001}, nil)
 	if value, unknown, ok := bits.Bitfield(); !ok || value != 0x00010001 || unknown != 0x00010000 {
 		t.Fatalf("bitfield=%x unknown=%x ok=%v", value, unknown, ok)
 	}
-	text := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeString}, []uint16{0x41c4, 0x8300}, nil)
+	text := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeString, 2), []uint16{0x41c4, 0x8300}, nil)
 	if got, ok := text.Text(); !ok || got != "Aă" {
 		t.Fatalf("text=%q ok=%v state=%s", got, ok, text.State())
 	}
-	invalidText := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeString}, []uint16{0xc300}, nil)
+	invalidText := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeString, 1), []uint16{0xc300}, nil)
 	if invalidText.State() != SunSpecValueInvalidEncoding {
 		t.Fatalf("invalid UTF-8 state=%s", invalidText.State())
 	}
+}
+
+func sizedSunSpecPoint(pointType SunSpecPointType, size uint16) sunSpecPointDefinition {
+	return sunSpecPointDefinition{pointType: pointType, size: size}
 }

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -96,6 +96,22 @@ func TestSunSpecValueFloatEnumBitfieldAndStringAreLossless(t *testing.T) {
 	}
 }
 
+func TestSunSpecBitfield32DomainBoundary(t *testing.T) {
+	definition := sizedSunSpecPoint(SunSpecTypeBitfield32, 2)
+	valid := decodeSunSpecValue(definition, []uint16{0x7fff, 0xffff}, nil)
+	if bits, unknown, ok := valid.Bitfield(); valid.State() != SunSpecValueValid || !ok || bits != 0x7fffffff || unknown != 0x7fffffff {
+		t.Fatalf("valid boundary state=%s bits=%x unknown=%x ok=%v", valid.State(), bits, unknown, ok)
+	}
+	invalid := decodeSunSpecValue(definition, []uint16{0x8000, 0}, nil)
+	if _, _, ok := invalid.Bitfield(); invalid.State() != SunSpecValueInvalidEncoding || ok || !reflect.DeepEqual(invalid.RawWords(), []uint16{0x8000, 0}) {
+		t.Fatalf("invalid boundary=%#v", invalid)
+	}
+	sentinel := decodeSunSpecValue(definition, []uint16{0xffff, 0xffff}, nil)
+	if sentinel.State() != SunSpecValueNotImplemented || !reflect.DeepEqual(sentinel.RawWords(), []uint16{0xffff, 0xffff}) {
+		t.Fatalf("sentinel=%#v", sentinel)
+	}
+}
+
 func sizedSunSpecPoint(pointType SunSpecPointType, size uint16) sunSpecPointDefinition {
 	return sunSpecPointDefinition{pointType: pointType, size: size}
 }

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -1,0 +1,82 @@
+package modbusreg
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestSunSpecValueSentinelsAndExactDecimal(t *testing.T) {
+	tests := []struct {
+		name  string
+		def   sunSpecPointDefinition
+		words []uint16
+		sf    *SunSpecValue
+		state SunSpecValueState
+	}{
+		{name: "int16 sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeInt16}, words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
+		{name: "uint16 sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeUint16}, words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
+		{name: "enum sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeEnum16}, words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
+		{name: "bitfield sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeBitfield32}, words: []uint16{0xffff, 0xffff}, state: SunSpecValueNotImplemented},
+		{name: "accumulator zero", def: sunSpecPointDefinition{pointType: SunSpecTypeAccumulator32}, words: []uint16{0, 0}, state: SunSpecValueNotAccumulated},
+		{name: "scale sentinel", def: sunSpecPointDefinition{pointType: SunSpecTypeScaleFactor}, words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
+		{name: "scale out of range", def: sunSpecPointDefinition{pointType: SunSpecTypeScaleFactor}, words: []uint16{11}, state: SunSpecValueInvalidEncoding},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			value := decodeSunSpecValue(tc.def, tc.words, tc.sf)
+			if value.State() != tc.state || !reflect.DeepEqual(value.RawWords(), tc.words) {
+				t.Fatalf("value=%#v raw=%v", value, value.RawWords())
+			}
+		})
+	}
+	scale := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeScaleFactor}, []uint16{0xfffe}, nil)
+	value := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeInt16, scaleFactor: "W_SF"}, []uint16{0xff85}, &scale)
+	decimal, ok := value.Decimal()
+	if !ok || decimal.Coefficient != -123 || decimal.Exponent != -2 {
+		t.Fatalf("decimal=%#v ok=%v", decimal, ok)
+	}
+	copyWords := value.RawWords()
+	copyWords[0] = 0
+	if value.RawWords()[0] != 0xff85 {
+		t.Fatal("raw words were mutable")
+	}
+}
+
+func TestSunSpecValueFloatEnumBitfieldAndStringAreLossless(t *testing.T) {
+	canonicalNaN := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeFloat32}, []uint16{0x7fc0, 0}, nil)
+	if canonicalNaN.State() != SunSpecValueNotImplemented {
+		t.Fatalf("canonical NaN=%s", canonicalNaN.State())
+	}
+	for name, words := range map[string][]uint16{
+		"noncanonical NaN":  {0x7fc0, 1},
+		"positive infinity": {0x7f80, 0},
+		"negative infinity": {0xff80, 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeFloat32}, words, nil); got.State() != SunSpecValueInvalidEncoding {
+				t.Fatalf("state=%s", got.State())
+			}
+		})
+	}
+	finite := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeFloat32}, []uint16{0x4148, 0}, nil)
+	if got, ok := finite.Float32(); !ok || got != 12.5 || math.Float32bits(got) != 0x41480000 {
+		t.Fatalf("float=%v ok=%v", got, ok)
+	}
+	enum := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeEnum16, symbols: map[uint64]string{1: "OFF"}}, []uint16{99}, nil)
+	if number, symbol, ok := enum.Enum(); !ok || number != 99 || symbol != "" {
+		t.Fatalf("enum=%d/%q/%v", number, symbol, ok)
+	}
+	bits := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeBitfield32, knownMask: 0x0000ffff}, []uint16{0x0001, 0x0001}, nil)
+	if value, unknown, ok := bits.Bitfield(); !ok || value != 0x00010001 || unknown != 0x00010000 {
+		t.Fatalf("bitfield=%x unknown=%x ok=%v", value, unknown, ok)
+	}
+	text := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeString}, []uint16{0x41c4, 0x8300}, nil)
+	if got, ok := text.Text(); !ok || got != "Aă" {
+		t.Fatalf("text=%q ok=%v state=%s", got, ok, text.State())
+	}
+	invalidText := decodeSunSpecValue(sunSpecPointDefinition{pointType: SunSpecTypeString}, []uint16{0xc300}, nil)
+	if invalidText.State() != SunSpecValueInvalidEncoding {
+		t.Fatalf("invalid UTF-8 state=%s", invalidText.State())
+	}
+}

--- a/testdata/sunspec/models/v1/catalog.json
+++ b/testdata/sunspec/models/v1/catalog.json
@@ -1,0 +1,14 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "schema_revision": "sunspec.models@7abdf898-v1",
+  "models": [
+    {"id": 1, "length": 66, "points": 9},
+    {"id": 1, "length": 65, "points": 8, "compatibility": true},
+    {"id": 101, "length": 50, "points": 45},
+    {"id": 102, "length": 50, "points": 45},
+    {"id": 103, "length": 50, "points": 45},
+    {"id": 111, "length": 60, "points": 33},
+    {"id": 112, "length": 60, "points": 33},
+    {"id": 113, "length": 60, "points": 33}
+  ]
+}


### PR DESCRIPTION
Closes #15

R2A implements the exact immutable SunSpec decoder registry for Model 1 L66/L65, integer inverter models 101/102/103 L50 and FLOAT inverter models 111/112/113 L60.

TDD evidence:
- initial RED: `9adfedbe8278bf416f04c0e10a1a12e732b2a026`
- initial GREEN: `d05f273584ca9647bb0c5ef512f2856df6edabeb`
- exact event-definition RED: `fa9ec7015d4f49b0819d1a1862b9d3fdba8e6cab`
- Model 111 status RED: `2567e99e434e8b05a30a0a7e8f39096ce6fb193f`
- current GREEN exact HEAD: `b056c06183ee231a614e052256cf0b51804186c4`
- focused SunSpec race+shuffle count=20: PASS
- `./scripts/ci_local.sh`: PASS (scope/terminology/gofmt/vet/build/full race/lint 0)

Review closure:
- P2 Model 111 `gg*` status symbols: fixed with exact per-model source tests.
- P2 bitfield32 bit 31: independently validated BY_DESIGN. SunSpec DIM v1.2 section 6.4.2 Table 9 defines valid range through `0x7fffffff`; `0x80000000` is invalid and `0xffffffff` is not-implemented. Boundary regression retains exact raw evidence.
- Self-review completion: all 16 standard Evt1 bit definitions are exact and decoded set-symbol slices are defensive; unknown valid-domain bits remain lossless.

Docs gate: Project-Helianthus/helianthus-docs-ebus#437 merged at `735621e57352856bb005e6678ce5a4d209ca3ff8`.

Authoritative definitions: `sunspec/models` at `7abdf8982d5364f8ae916deee18aac86c11be36d`; value encodings/sentinels: SunSpec Device Information Model Specification v1.2.

T01..T88: N/A by owner. Registry decoding only; no transport, framing, socket, acquisition, live device, write/control, gateway, capability or vendor flavor path.
