### PR TITLE
R2B: add extended SunSpec models and bounded MPPT geometry (#17)

### DIFF
--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -6,27 +6,32 @@ import (
 )
 
 type SunSpecFact struct {
-	FieldID   string
-	PointName string
-	Unit      string
-	Required  bool
-	Value     SunSpecValue
+	FieldID     string
+	PointName   string
+	Unit        string
+	Required    bool
+	GroupID     string
+	RepeatIndex uint16
+	Repeated    bool
+	Value       SunSpecValue
 }
 
 type SunSpecDecodedModel struct {
-	key       SunSpecDecoderKey
-	ordinal   uint32
-	topology  SunSpecTopology
-	qualifies bool
-	raw       []uint16
-	spans     []SunSpecSourceSpan
-	facts     []SunSpecFact
+	key           SunSpecDecoderKey
+	ordinal       uint32
+	topology      SunSpecTopology
+	qualifies     bool
+	geometryValid bool
+	raw           []uint16
+	spans         []SunSpecSourceSpan
+	facts         []SunSpecFact
 }
 
 func (m SunSpecDecodedModel) Key() SunSpecDecoderKey    { return m.key }
 func (m SunSpecDecodedModel) Ordinal() uint32           { return m.ordinal }
 func (m SunSpecDecodedModel) Topology() SunSpecTopology { return m.topology }
 func (m SunSpecDecodedModel) Qualifies() bool           { return m.qualifies }
+func (m SunSpecDecodedModel) GeometryValid() bool       { return m.geometryValid }
 func (m SunSpecDecodedModel) RawWords() []uint16        { return append([]uint16(nil), m.raw...) }
 func (m SunSpecDecodedModel) SourceSpans() []SunSpecSourceSpan {
 	return append([]SunSpecSourceSpan(nil), m.spans...)
@@ -84,6 +89,9 @@ func NewStandardSunSpecDecoderRegistry(revision SunSpecSchemaRevision) (SunSpecD
 		registry.definitions[definition.key] = definition
 		registry.keys = append(registry.keys, definition.key)
 	}
+	for modules := uint32(0); modules <= maxSunSpecMPPTModules; modules++ {
+		registry.keys = append(registry.keys, SunSpecDecoderKey{ModelID: 160, ModelLength: uint16(8 + 20*modules), SchemaRevision: revision})
+	}
 	sort.Slice(registry.keys, func(i, j int) bool {
 		if registry.keys[i].ModelID != registry.keys[j].ModelID {
 			return registry.keys[i].ModelID < registry.keys[j].ModelID
@@ -101,7 +109,14 @@ func (r SunSpecDecoderRegistry) DecoderKeys() []SunSpecDecoderKey {
 }
 func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelDefinition, bool) {
 	definition, ok := r.definitions[key]
-	return definition, ok
+	if ok {
+		return definition, true
+	}
+	if key.SchemaRevision != r.revision || key.ModelID != 160 {
+		return sunSpecModelDefinition{}, false
+	}
+	definition, err := mpptSunSpecDefinition(key.SchemaRevision, key.ModelLength)
+	return definition, err == nil
 }
 
 func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (SunSpecDecodedModel, error) {
@@ -109,13 +124,19 @@ func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (
 	if !ok || occurrence.Disposition != SunSpecChainDispositionAdmitted || key.ModelID != occurrence.WireKey.ModelID || key.ModelLength != occurrence.WireKey.ModelLength || key.SchemaRevision != occurrence.SchemaRevision || key.SchemaRevision != r.revision {
 		return SunSpecDecodedModel{}, fmt.Errorf("SunSpec occurrence lacks an exact admitted decoder key")
 	}
-	definition, ok := r.definitions[key]
+	definition, ok := r.definition(key)
 	if !ok {
 		return SunSpecDecodedModel{}, fmt.Errorf("SunSpec decoder key is unsupported")
 	}
 	words := occurrence.Words()
 	if len(words) != int(key.ModelLength)+2 || words[0] != key.ModelID || words[1] != key.ModelLength {
 		return SunSpecDecodedModel{}, fmt.Errorf("SunSpec occurrence words contradict decoder key")
+	}
+	model := SunSpecDecodedModel{key: key, ordinal: occurrence.Ordinal, topology: definition.topology, qualifies: true, geometryValid: true, raw: append([]uint16(nil), words...), spans: occurrence.SourceSpans()}
+	if definition.geometry != nil && !definition.geometry(words) {
+		model.geometryValid = false
+		model.qualifies = false
+		return model, nil
 	}
 	scales := make(map[string]SunSpecValue)
 	for _, point := range definition.points {
@@ -124,9 +145,8 @@ func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (
 		}
 		scales[point.name] = decodeSunSpecValue(point, words[point.offset:point.offset+point.size], nil)
 	}
-	model := SunSpecDecodedModel{key: key, ordinal: occurrence.Ordinal, topology: definition.topology, qualifies: true, raw: append([]uint16(nil), words...), spans: occurrence.SourceSpans()}
 	for _, point := range definition.points {
-		if point.name == "ID" || point.name == "L" {
+		if point.offset < 2 {
 			continue
 		}
 		var scale *SunSpecValue
@@ -141,7 +161,7 @@ func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (
 		if point.mandatory && value.State() != SunSpecValueValid {
 			model.qualifies = false
 		}
-		model.facts = append(model.facts, SunSpecFact{FieldID: point.fieldID, PointName: point.name, Unit: point.unit, Required: point.required, Value: value})
+		model.facts = append(model.facts, SunSpecFact{FieldID: point.fieldID, PointName: point.name, Unit: point.unit, Required: point.required, GroupID: point.groupID, RepeatIndex: point.repeatIndex, Repeated: point.repeated, Value: value})
 	}
 	return model, nil
 }

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -46,6 +46,8 @@ func TestSunSpecDecoderRegistryUsesExactImmutableKeys(t *testing.T) {
 		{1, 65, testSunSpecModelsRevision}, {1, 66, testSunSpecModelsRevision},
 		{101, 50, testSunSpecModelsRevision}, {102, 50, testSunSpecModelsRevision}, {103, 50, testSunSpecModelsRevision},
 		{111, 60, testSunSpecModelsRevision}, {112, 60, testSunSpecModelsRevision}, {113, 60, testSunSpecModelsRevision},
+		{120, 26, testSunSpecModelsRevision}, {121, 30, testSunSpecModelsRevision},
+		{122, 44, testSunSpecModelsRevision}, {124, 24, testSunSpecModelsRevision},
 	}
 	sort.Slice(want, func(i, j int) bool {
 		if want[i].ModelID != want[j].ModelID {
@@ -53,8 +55,8 @@ func TestSunSpecDecoderRegistryUsesExactImmutableKeys(t *testing.T) {
 		}
 		return want[i].ModelLength < want[j].ModelLength
 	})
-	if !reflect.DeepEqual(keys, want) {
-		t.Fatalf("keys=%#v", keys)
+	if len(keys) != len(want)+3277 || !reflect.DeepEqual(keys[:len(want)], want) {
+		t.Fatalf("fixed keys=%#v total=%d", keys[:min(len(keys), len(want))], len(keys))
 	}
 	keys[0].ModelID = 999
 	if registry.DecoderKeys()[0].ModelID == 999 {

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -15,9 +15,10 @@ const (
 
 type sunSpecPointDefinition struct {
 	name, fieldID, unit, scaleFactor string
+	groupID                          string
 	pointType                        SunSpecPointType
-	offset, size                     uint16
-	mandatory, required              bool
+	offset, size, repeatIndex        uint16
+	mandatory, required, repeated    bool
 	symbols                          map[uint64]string
 	knownMask                        uint64
 }
@@ -27,6 +28,7 @@ type sunSpecModelDefinition struct {
 	topology      SunSpecTopology
 	compatibility bool
 	points        []sunSpecPointDefinition
+	geometry      func([]uint16) bool
 }
 
 func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecModelDefinition, error) {
@@ -34,7 +36,7 @@ func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecM
 		return nil, fmt.Errorf("SunSpec schema revision is unsupported")
 	}
 	common := commonSunSpecPoints()
-	definitions := make([]sunSpecModelDefinition, 0, 8)
+	definitions := make([]sunSpecModelDefinition, 0, 12)
 	var err error
 	definitions, err = appendSunSpecDefinition(definitions, revision, 1, 66, SunSpecTopologyNone, false, common)
 	if err != nil {
@@ -62,6 +64,20 @@ func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecM
 			points[index].required = points[index].mandatory && points[index].name != "ID" && points[index].name != "L" && points[index].pointType != SunSpecTypeScaleFactor
 		}
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, model.topology, false, points)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, model := range []struct {
+		id, length uint16
+		points     []sunSpecPointDefinition
+	}{
+		{120, 26, nameplateSunSpecPoints()},
+		{121, 30, settingsSunSpecPoints()},
+		{122, 44, statusSunSpecPoints()},
+		{124, 24, storageSunSpecPoints()},
+	} {
+		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {
 			return nil, err
 		}

--- a/sunspec_models_extended.go
+++ b/sunspec_models_extended.go
@@ -1,0 +1,170 @@
+package modbusreg
+
+func nameplateSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecEnum("DERTyp", "der.type", true, map[uint64]string{4: "PV", 82: "PV_STOR"}),
+		extendedSunSpecPoint("WRtg", "der.rating.active_power", SunSpecTypeUint16, 1, "W", "WRtg_SF", true),
+		extendedSunSpecPoint("WRtg_SF", "der.scale.active_power_rating", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("VARtg", "der.rating.apparent_power", SunSpecTypeUint16, 1, "VA", "VARtg_SF", true),
+		extendedSunSpecPoint("VARtg_SF", "der.scale.apparent_power_rating", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("VArRtgQ1", "der.rating.reactive_power.q1", SunSpecTypeInt16, 1, "var", "VArRtg_SF", true),
+		extendedSunSpecPoint("VArRtgQ2", "der.rating.reactive_power.q2", SunSpecTypeInt16, 1, "var", "VArRtg_SF", true),
+		extendedSunSpecPoint("VArRtgQ3", "der.rating.reactive_power.q3", SunSpecTypeInt16, 1, "var", "VArRtg_SF", true),
+		extendedSunSpecPoint("VArRtgQ4", "der.rating.reactive_power.q4", SunSpecTypeInt16, 1, "var", "VArRtg_SF", true),
+		extendedSunSpecPoint("VArRtg_SF", "der.scale.reactive_power_rating", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("ARtg", "der.rating.current", SunSpecTypeUint16, 1, "A", "ARtg_SF", true),
+		extendedSunSpecPoint("ARtg_SF", "der.scale.current_rating", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("PFRtgQ1", "der.rating.power_factor.q1", SunSpecTypeInt16, 1, "cos()", "PFRtg_SF", true),
+		extendedSunSpecPoint("PFRtgQ2", "der.rating.power_factor.q2", SunSpecTypeInt16, 1, "cos()", "PFRtg_SF", true),
+		extendedSunSpecPoint("PFRtgQ3", "der.rating.power_factor.q3", SunSpecTypeInt16, 1, "cos()", "PFRtg_SF", true),
+		extendedSunSpecPoint("PFRtgQ4", "der.rating.power_factor.q4", SunSpecTypeInt16, 1, "cos()", "PFRtg_SF", true),
+		extendedSunSpecPoint("PFRtg_SF", "der.scale.power_factor_rating", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("WHRtg", "storage.rating.energy", SunSpecTypeUint16, 1, "Wh", "WHRtg_SF", false),
+		extendedSunSpecPoint("WHRtg_SF", "storage.scale.energy_rating", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("AhrRtg", "storage.rating.charge", SunSpecTypeUint16, 1, "AH", "AhrRtg_SF", false),
+		extendedSunSpecPoint("AhrRtg_SF", "storage.scale.charge_rating", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("MaxChaRte", "storage.rating.max_charge_power", SunSpecTypeUint16, 1, "W", "MaxChaRte_SF", false),
+		extendedSunSpecPoint("MaxChaRte_SF", "storage.scale.max_charge_power", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("MaxDisChaRte", "storage.rating.max_discharge_power", SunSpecTypeUint16, 1, "W", "MaxDisChaRte_SF", false),
+		extendedSunSpecPoint("MaxDisChaRte_SF", "storage.scale.max_discharge_power", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("Pad", "der.pad", SunSpecTypePad, 1, "", "", false),
+	}
+}
+
+func settingsSunSpecPoints() []sunSpecPointDefinition {
+	points := []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true), extendedSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecPoint("WMax", "der.settings.max_active_power", SunSpecTypeUint16, 1, "W", "WMax_SF", true),
+		extendedSunSpecPoint("VRef", "der.settings.reference_voltage", SunSpecTypeUint16, 1, "V", "VRef_SF", true),
+		extendedSunSpecPoint("VRefOfs", "der.settings.reference_voltage_offset", SunSpecTypeInt16, 1, "V", "VRefOfs_SF", true),
+	}
+	for _, point := range []struct {
+		name, field string
+		typ         SunSpecPointType
+		unit, sf    string
+	}{
+		{"VMax", "der.settings.max_voltage", SunSpecTypeUint16, "V", "VMinMax_SF"}, {"VMin", "der.settings.min_voltage", SunSpecTypeUint16, "V", "VMinMax_SF"},
+		{"VAMax", "der.settings.max_apparent_power", SunSpecTypeUint16, "VA", "VAMax_SF"},
+		{"VArMaxQ1", "der.settings.max_reactive_power.q1", SunSpecTypeInt16, "var", "VArMax_SF"}, {"VArMaxQ2", "der.settings.max_reactive_power.q2", SunSpecTypeInt16, "var", "VArMax_SF"},
+		{"VArMaxQ3", "der.settings.max_reactive_power.q3", SunSpecTypeInt16, "var", "VArMax_SF"}, {"VArMaxQ4", "der.settings.max_reactive_power.q4", SunSpecTypeInt16, "var", "VArMax_SF"},
+		{"WGra", "der.settings.active_power_gradient", SunSpecTypeUint16, "% WMax/sec", "WGra_SF"},
+		{"PFMinQ1", "der.settings.min_power_factor.q1", SunSpecTypeInt16, "cos()", "PFMin_SF"}, {"PFMinQ2", "der.settings.min_power_factor.q2", SunSpecTypeInt16, "cos()", "PFMin_SF"},
+		{"PFMinQ3", "der.settings.min_power_factor.q3", SunSpecTypeInt16, "cos()", "PFMin_SF"}, {"PFMinQ4", "der.settings.min_power_factor.q4", SunSpecTypeInt16, "cos()", "PFMin_SF"},
+	} {
+		points = append(points, extendedSunSpecPoint(point.name, point.field, point.typ, 1, point.unit, point.sf, false))
+	}
+	points = append(points,
+		extendedSunSpecEnum("VArAct", "der.settings.reactive_power_action", false, map[uint64]string{1: "SWITCH", 2: "MAINTAIN"}),
+		extendedSunSpecEnum("ClcTotVA", "der.settings.apparent_power_calculation", false, map[uint64]string{1: "VECTOR", 2: "ARITHMETIC"}),
+		extendedSunSpecPoint("MaxRmpRte", "der.settings.max_ramp_rate", SunSpecTypeUint16, 1, "% WGra", "MaxRmpRte_SF", false),
+		extendedSunSpecPoint("ECPNomHz", "der.settings.nominal_frequency", SunSpecTypeUint16, 1, "Hz", "ECPNomHz_SF", false),
+		extendedSunSpecEnum("ConnPh", "der.settings.connected_phase", false, map[uint64]string{1: "A", 2: "B", 3: "C"}),
+	)
+	for _, scale := range []struct {
+		name, field string
+		mandatory   bool
+	}{
+		{"WMax_SF", "der.scale.max_active_power", true}, {"VRef_SF", "der.scale.reference_voltage", true}, {"VRefOfs_SF", "der.scale.reference_voltage_offset", true},
+		{"VMinMax_SF", "der.scale.voltage_bounds", false}, {"VAMax_SF", "der.scale.max_apparent_power", false}, {"VArMax_SF", "der.scale.max_reactive_power", false},
+		{"WGra_SF", "der.scale.active_power_gradient", false}, {"PFMin_SF", "der.scale.min_power_factor", false}, {"MaxRmpRte_SF", "der.scale.max_ramp_rate", false}, {"ECPNomHz_SF", "der.scale.nominal_frequency", false},
+	} {
+		points = append(points, extendedSunSpecPoint(scale.name, scale.field, SunSpecTypeScaleFactor, 1, "", "", scale.mandatory))
+	}
+	return points
+}
+
+func statusSunSpecPoints() []sunSpecPointDefinition {
+	connection := map[uint64]string{0: "CONNECTED", 1: "AVAILABLE", 2: "OPERATING", 3: "TEST"}
+	return []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true), extendedSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecBitfield("PVConn", "der.status.pv_connection", SunSpecTypeBitfield16, true, connection),
+		extendedSunSpecBitfield("StorConn", "der.status.storage_connection", SunSpecTypeBitfield16, true, connection),
+		extendedSunSpecBitfield("ECPConn", "der.status.ecp_connection", SunSpecTypeBitfield16, true, map[uint64]string{0: "DISCONNECTED", 1: "CONNECTED"}),
+		extendedSunSpecPoint("ActWh", "der.status.active_energy", SunSpecTypeAccumulator64, 4, "Wh", "", false),
+		extendedSunSpecPoint("ActVAh", "der.status.apparent_energy", SunSpecTypeAccumulator64, 4, "VAh", "", false),
+		extendedSunSpecPoint("ActVArhQ1", "der.status.reactive_energy.q1", SunSpecTypeAccumulator64, 4, "varh", "", false),
+		extendedSunSpecPoint("ActVArhQ2", "der.status.reactive_energy.q2", SunSpecTypeAccumulator64, 4, "varh", "", false),
+		extendedSunSpecPoint("ActVArhQ3", "der.status.reactive_energy.q3", SunSpecTypeAccumulator64, 4, "varh", "", false),
+		extendedSunSpecPoint("ActVArhQ4", "der.status.reactive_energy.q4", SunSpecTypeAccumulator64, 4, "varh", "", false),
+		extendedSunSpecPoint("VArAval", "der.status.available_reactive_power", SunSpecTypeInt16, 1, "var", "VArAval_SF", false),
+		extendedSunSpecPoint("VArAval_SF", "der.scale.available_reactive_power", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("WAval", "der.status.available_active_power", SunSpecTypeUint16, 1, "var", "WAval_SF", false),
+		extendedSunSpecPoint("WAval_SF", "der.scale.available_active_power", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecBitfield("StSetLimMsk", "der.status.limit_mask", SunSpecTypeBitfield32, false, numberedSymbols("WMax", "VAMax", "VArAval", "VArMaxQ1", "VArMaxQ2", "VArMaxQ3", "VArMaxQ4", "PFMinQ1", "PFMinQ2", "PFMinQ3", "PFMinQ4")),
+		extendedSunSpecBitfield("StActCtl", "der.status.active_controls", SunSpecTypeBitfield32, false, map[uint64]string{0: "FixedW", 1: "FixedVAR", 2: "FixedPF", 3: "Volt-VAr", 4: "Freq-Watt-Param", 5: "Freq-Watt-Curve", 6: "Dyn-Reactive-Current", 7: "LVRT", 8: "HVRT", 9: "Watt-PF", 10: "Volt-Watt", 12: "Scheduled", 13: "LFRT", 14: "HFRT"}),
+		extendedSunSpecPoint("TmSrc", "der.status.time_source", SunSpecTypeString, 4, "", "", false),
+		extendedSunSpecPoint("Tms", "der.status.timestamp", SunSpecTypeUint32, 2, "Secs", "", false),
+		extendedSunSpecBitfield("RtSt", "der.status.ride_through", SunSpecTypeBitfield16, false, numberedSymbols("LVRT_ACTIVE", "HVRT_ACTIVE", "LFRT_ACTIVE", "HFRT_ACTIVE")),
+		extendedSunSpecPoint("Ris", "der.status.insulation_resistance", SunSpecTypeUint16, 1, "ohms", "Ris_SF", false),
+		extendedSunSpecPoint("Ris_SF", "der.scale.insulation_resistance", SunSpecTypeScaleFactor, 1, "", "", false),
+	}
+}
+
+func storageSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true), extendedSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecPoint("WChaMax", "storage.control.max_charge_power", SunSpecTypeUint16, 1, "W", "WChaMax_SF", true),
+		extendedSunSpecPoint("WChaGra", "storage.control.charge_gradient", SunSpecTypeUint16, 1, "% WChaMax/sec", "WChaDisChaGra_SF", true),
+		extendedSunSpecPoint("WDisChaGra", "storage.control.discharge_gradient", SunSpecTypeUint16, 1, "% WChaMax/sec", "WChaDisChaGra_SF", true),
+		extendedSunSpecBitfield("StorCtl_Mod", "storage.control.mode", SunSpecTypeBitfield16, true, map[uint64]string{0: "CHARGE", 1: "DiSCHARGE"}),
+		extendedSunSpecPoint("VAChaMax", "storage.control.max_charge_apparent_power", SunSpecTypeUint16, 1, "VA", "VAChaMax_SF", false),
+		extendedSunSpecPoint("MinRsvPct", "storage.control.minimum_reserve", SunSpecTypeUint16, 1, "% WChaMax", "MinRsvPct_SF", false),
+		extendedSunSpecPoint("ChaState", "storage.status.state_of_charge", SunSpecTypeUint16, 1, "% AhrRtg", "ChaState_SF", false),
+		extendedSunSpecPoint("StorAval", "storage.status.available_charge", SunSpecTypeUint16, 1, "AH", "StorAval_SF", false),
+		extendedSunSpecPoint("InBatV", "storage.status.internal_battery_voltage", SunSpecTypeUint16, 1, "V", "InBatV_SF", false),
+		extendedSunSpecEnum("ChaSt", "storage.status.charge_state", false, map[uint64]string{1: "OFF", 2: "EMPTY", 3: "DISCHARGING", 4: "CHARGING", 5: "FULL", 6: "HOLDING", 7: "TESTING"}),
+		extendedSunSpecPoint("OutWRte", "storage.control.discharge_rate", SunSpecTypeInt16, 1, "% WDisChaMax", "InOutWRte_SF", false),
+		extendedSunSpecPoint("InWRte", "storage.control.charge_rate", SunSpecTypeInt16, 1, " % WChaMax", "InOutWRte_SF", false),
+		extendedSunSpecPoint("InOutWRte_WinTms", "storage.control.rate_window", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("InOutWRte_RvrtTms", "storage.control.rate_revert", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("InOutWRte_RmpTms", "storage.control.rate_ramp", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecEnum("ChaGriSet", "storage.control.charge_source", false, map[uint64]string{0: "PV", 1: "GRID"}),
+		extendedSunSpecPoint("WChaMax_SF", "storage.scale.max_charge_power", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("WChaDisChaGra_SF", "storage.scale.charge_discharge_gradient", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("VAChaMax_SF", "storage.scale.max_charge_apparent_power", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("MinRsvPct_SF", "storage.scale.minimum_reserve", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("ChaState_SF", "storage.scale.state_of_charge", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("StorAval_SF", "storage.scale.available_charge", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("InBatV_SF", "storage.scale.internal_battery_voltage", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("InOutWRte_SF", "storage.scale.charge_discharge_rate", SunSpecTypeScaleFactor, 1, "", "", false),
+	}
+}
+
+func extendedSunSpecPoint(name, field string, pointType SunSpecPointType, size uint16, unit, scale string, mandatory bool) sunSpecPointDefinition {
+	return sunSpecPoint(name, field, pointType, size, unit, scale, mandatory, nil, 0)
+}
+
+func extendedSunSpecEnum(name, field string, mandatory bool, symbols map[uint64]string) sunSpecPointDefinition {
+	return sunSpecPoint(name, field, SunSpecTypeEnum16, 1, "", "", mandatory, symbols, 0)
+}
+
+func extendedSunSpecBitfield(name, field string, pointType SunSpecPointType, mandatory bool, symbols map[uint64]string) sunSpecPointDefinition {
+	return sunSpecPoint(name, field, pointType, sunSpecTypeWords(pointType), "", "", mandatory, symbols, sunSpecKnownMask(symbols))
+}
+
+func sunSpecKnownMask(symbols map[uint64]string) uint64 {
+	var mask uint64
+	for bit := range symbols {
+		if bit < 63 {
+			mask |= uint64(1) << bit
+		}
+	}
+	return mask
+}
+
+func sunSpecTypeWords(pointType SunSpecPointType) uint16 {
+	if pointType == SunSpecTypeBitfield32 {
+		return 2
+	}
+	return 1
+}
+
+func numberedSymbols(values ...string) map[uint64]string {
+	out := make(map[uint64]string, len(values))
+	for index, value := range values {
+		out[uint64(index)] = value
+	}
+	return out
+}

--- a/sunspec_models_extended_test.go
+++ b/sunspec_models_extended_test.go
@@ -1,7 +1,10 @@
 package modbusreg
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"reflect"
 	"testing"
 )
 
@@ -33,13 +36,60 @@ func TestSunSpecExtendedModelCatalogMatchesPinnedShapes(t *testing.T) {
 	}
 }
 
+func TestSunSpecExtendedGoldenMetadataMatchesCatalog(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"120", "121", "122", "124", "160_n4"} {
+		data, err := os.ReadFile("testdata/sunspec/models/v1/model_" + name + ".json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var fixture struct {
+			SourceCommit     string `json:"source_commit"`
+			ID, Length       uint16
+			PointCount       int      `json:"point_count"`
+			Mandatory        []string `json:"mandatory"`
+			ModuleCount      uint16   `json:"module_count"`
+			ModulePointCount int      `json:"module_point_count"`
+		}
+		if err := json.Unmarshal(data, &fixture); err != nil {
+			t.Fatal(err)
+		}
+		if fixture.SourceCommit != "7abdf8982d5364f8ae916deee18aac86c11be36d" {
+			t.Fatalf("fixture %s source=%s", name, fixture.SourceCommit)
+		}
+		definition, ok := registry.definition(SunSpecDecoderKey{fixture.ID, fixture.Length, testSunSpecModelsRevision})
+		if !ok || len(definition.points) != fixture.PointCount {
+			t.Fatalf("fixture %s points=%d ok=%v", name, len(definition.points), ok)
+		}
+		var mandatory []string
+		var repeated int
+		for _, point := range definition.points {
+			if point.mandatory {
+				mandatory = append(mandatory, point.name)
+			}
+			if point.repeated {
+				repeated++
+			}
+		}
+		if !reflect.DeepEqual(mandatory, fixture.Mandatory) {
+			t.Fatalf("fixture %s mandatory=%v", name, mandatory)
+		}
+		if fixture.ModuleCount > 0 && repeated != int(fixture.ModuleCount)*fixture.ModulePointCount {
+			t.Fatalf("fixture %s repeated=%d", name, repeated)
+		}
+	}
+}
+
 func TestSunSpecExtendedModelsDecodeTypedFactsAndFailClosed(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
 	if err != nil {
 		t.Fatal(err)
 	}
 	nameplate, err := registry.DecodeOccurrence(admittedOccurrence(120, 26, modelWords(t, registry, 120, 26, map[string][]uint16{
-		"DERTyp": {1}, "WRtg": {1234}, "WRtg_SF": {0xffff}, "VARtg": {1400}, "VARtg_SF": {0},
+		"DERTyp": {1}, "WRtg": {1234}, "WRtg_SF": {0x8000}, "VARtg": {1400}, "VARtg_SF": {0},
 		"VArRtgQ1": {1}, "VArRtgQ2": {1}, "VArRtgQ3": {1}, "VArRtgQ4": {1}, "VArRtg_SF": {0},
 		"ARtg": {100}, "ARtg_SF": {0}, "PFRtgQ1": {1}, "PFRtgQ2": {1}, "PFRtgQ3": {1}, "PFRtgQ4": {1}, "PFRtg_SF": {0}, "Pad": {0x8000},
 	}), 1))

--- a/sunspec_models_extended_test.go
+++ b/sunspec_models_extended_test.go
@@ -1,0 +1,72 @@
+package modbusreg
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSunSpecExtendedModelCatalogMatchesPinnedShapes(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		id, length uint16
+		want       string
+	}{
+		{120, 26, "ID:uint16:1,L:uint16:1,DERTyp:enum16:1,WRtg:uint16:1,WRtg_SF:sunssf:1,VARtg:uint16:1,VARtg_SF:sunssf:1,VArRtgQ1:int16:1,VArRtgQ2:int16:1,VArRtgQ3:int16:1,VArRtgQ4:int16:1,VArRtg_SF:sunssf:1,ARtg:uint16:1,ARtg_SF:sunssf:1,PFRtgQ1:int16:1,PFRtgQ2:int16:1,PFRtgQ3:int16:1,PFRtgQ4:int16:1,PFRtg_SF:sunssf:1,WHRtg:uint16:1,WHRtg_SF:sunssf:1,AhrRtg:uint16:1,AhrRtg_SF:sunssf:1,MaxChaRte:uint16:1,MaxChaRte_SF:sunssf:1,MaxDisChaRte:uint16:1,MaxDisChaRte_SF:sunssf:1,Pad:pad:1"},
+		{121, 30, "ID:uint16:1,L:uint16:1,WMax:uint16:1,VRef:uint16:1,VRefOfs:int16:1,VMax:uint16:1,VMin:uint16:1,VAMax:uint16:1,VArMaxQ1:int16:1,VArMaxQ2:int16:1,VArMaxQ3:int16:1,VArMaxQ4:int16:1,WGra:uint16:1,PFMinQ1:int16:1,PFMinQ2:int16:1,PFMinQ3:int16:1,PFMinQ4:int16:1,VArAct:enum16:1,ClcTotVA:enum16:1,MaxRmpRte:uint16:1,ECPNomHz:uint16:1,ConnPh:enum16:1,WMax_SF:sunssf:1,VRef_SF:sunssf:1,VRefOfs_SF:sunssf:1,VMinMax_SF:sunssf:1,VAMax_SF:sunssf:1,VArMax_SF:sunssf:1,WGra_SF:sunssf:1,PFMin_SF:sunssf:1,MaxRmpRte_SF:sunssf:1,ECPNomHz_SF:sunssf:1"},
+		{122, 44, "ID:uint16:1,L:uint16:1,PVConn:bitfield16:1,StorConn:bitfield16:1,ECPConn:bitfield16:1,ActWh:acc64:4,ActVAh:acc64:4,ActVArhQ1:acc64:4,ActVArhQ2:acc64:4,ActVArhQ3:acc64:4,ActVArhQ4:acc64:4,VArAval:int16:1,VArAval_SF:sunssf:1,WAval:uint16:1,WAval_SF:sunssf:1,StSetLimMsk:bitfield32:2,StActCtl:bitfield32:2,TmSrc:string:4,Tms:uint32:2,RtSt:bitfield16:1,Ris:uint16:1,Ris_SF:sunssf:1"},
+		{124, 24, "ID:uint16:1,L:uint16:1,WChaMax:uint16:1,WChaGra:uint16:1,WDisChaGra:uint16:1,StorCtl_Mod:bitfield16:1,VAChaMax:uint16:1,MinRsvPct:uint16:1,ChaState:uint16:1,StorAval:uint16:1,InBatV:uint16:1,ChaSt:enum16:1,OutWRte:int16:1,InWRte:int16:1,InOutWRte_WinTms:uint16:1,InOutWRte_RvrtTms:uint16:1,InOutWRte_RmpTms:uint16:1,ChaGriSet:enum16:1,WChaMax_SF:sunssf:1,WChaDisChaGra_SF:sunssf:1,VAChaMax_SF:sunssf:1,MinRsvPct_SF:sunssf:1,ChaState_SF:sunssf:1,StorAval_SF:sunssf:1,InBatV_SF:sunssf:1,InOutWRte_SF:sunssf:1"},
+	} {
+		definition, ok := registry.definition(SunSpecDecoderKey{tc.id, tc.length, testSunSpecModelsRevision})
+		if !ok {
+			t.Fatalf("model %d absent", tc.id)
+		}
+		got := make([]string, len(definition.points))
+		for index, point := range definition.points {
+			got[index] = fmt.Sprintf("%s:%s:%d", point.name, point.pointType, point.size)
+		}
+		if joined := joinSunSpecCatalog(got); joined != tc.want {
+			t.Fatalf("model %d catalog\n%s\nwant\n%s", tc.id, joined, tc.want)
+		}
+	}
+}
+
+func TestSunSpecExtendedModelsDecodeTypedFactsAndFailClosed(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nameplate, err := registry.DecodeOccurrence(admittedOccurrence(120, 26, modelWords(t, registry, 120, 26, map[string][]uint16{
+		"DERTyp": {1}, "WRtg": {1234}, "WRtg_SF": {0xffff}, "VARtg": {1400}, "VARtg_SF": {0},
+		"VArRtgQ1": {1}, "VArRtgQ2": {1}, "VArRtgQ3": {1}, "VArRtgQ4": {1}, "VArRtg_SF": {0},
+		"ARtg": {100}, "ARtg_SF": {0}, "PFRtgQ1": {1}, "PFRtgQ2": {1}, "PFRtgQ3": {1}, "PFRtgQ4": {1}, "PFRtg_SF": {0}, "Pad": {0x8000},
+	}), 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nameplate.Qualifies() {
+		t.Fatal("required value with missing scale factor qualified")
+	}
+	status, err := registry.DecodeOccurrence(admittedOccurrence(122, 44, modelWords(t, registry, 122, 44, map[string][]uint16{
+		"PVConn": {9}, "StorConn": {1}, "ECPConn": {2}, "ActWh": {0, 0, 0, 42},
+	}), 1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	energy, ok := status.Fact("der.status.active_energy")
+	if !ok {
+		t.Fatal("active energy fact absent")
+	}
+	if value, ok := energy.Value.Unsigned(); !ok || value != 42 {
+		t.Fatalf("active energy=%d/%v", value, ok)
+	}
+	connection, ok := status.Fact("der.status.pv_connection")
+	if !ok {
+		t.Fatal("PV connection fact absent")
+	}
+	if bits, unknown, ok := connection.Value.Bitfield(); !ok || bits != 9 || unknown != 0 {
+		t.Fatalf("PV connection=%x unknown=%x ok=%v", bits, unknown, ok)
+	}
+}

--- a/sunspec_models_mppt.go
+++ b/sunspec_models_mppt.go
@@ -1,0 +1,72 @@
+package modbusreg
+
+import "fmt"
+
+const maxSunSpecMPPTModules uint32 = (65535 - 8) / 20
+
+func mpptSunSpecDefinition(revision SunSpecSchemaRevision, length uint16) (sunSpecModelDefinition, error) {
+	if revision != SunSpecModelsRevisionV1 || length < 8 || (uint32(length)-8)%20 != 0 {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec Model 160 key has invalid geometry")
+	}
+	modules := (uint32(length) - 8) / 20
+	if modules > maxSunSpecMPPTModules {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec Model 160 module count exceeds addressable geometry")
+	}
+	points := mpptFixedSunSpecPoints()
+	for index := uint32(1); index <= modules; index++ {
+		for _, point := range mpptModuleSunSpecPoints() {
+			point.groupID = "module"
+			point.repeatIndex = uint16(index)
+			point.repeated = true
+			points = append(points, point)
+		}
+	}
+	definitions, err := appendSunSpecDefinition(nil, revision, 160, length, SunSpecTopologyNone, false, points)
+	if err != nil {
+		return sunSpecModelDefinition{}, err
+	}
+	definition := definitions[0]
+	definition.geometry = func(words []uint16) bool {
+		if len(words) != int(length)+2 || len(words) <= 8 || words[8] == 0xffff {
+			return false
+		}
+		return uint32(length) == 8+20*uint32(words[8])
+	}
+	return definition, nil
+}
+
+func mpptFixedSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true), extendedSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecPoint("DCA_SF", "mppt.scale.dc_current", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("DCV_SF", "mppt.scale.dc_voltage", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("DCW_SF", "mppt.scale.dc_power", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecPoint("DCWH_SF", "mppt.scale.dc_energy", SunSpecTypeScaleFactor, 1, "", "", false),
+		extendedSunSpecBitfield("Evt", "mppt.events", SunSpecTypeBitfield32, false, mpptEventSymbols()),
+		extendedSunSpecPoint("N", "mppt.module.count", SunSpecTypeCount, 1, "", "", false),
+		extendedSunSpecPoint("TmsPer", "mppt.sample_period", SunSpecTypeUint16, 1, "", "", false),
+	}
+}
+
+func mpptModuleSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "mppt.module.id", SunSpecTypeUint16, 1, "", "", false),
+		extendedSunSpecPoint("IDStr", "mppt.module.label", SunSpecTypeString, 8, "", "", false),
+		extendedSunSpecPoint("DCA", "mppt.module.dc_current", SunSpecTypeUint16, 1, "A", "DCA_SF", false),
+		extendedSunSpecPoint("DCV", "mppt.module.dc_voltage", SunSpecTypeUint16, 1, "V", "DCV_SF", false),
+		extendedSunSpecPoint("DCW", "mppt.module.dc_power", SunSpecTypeUint16, 1, "W", "DCW_SF", false),
+		extendedSunSpecPoint("DCWH", "mppt.module.dc_energy", SunSpecTypeAccumulator32, 2, "Wh", "DCWH_SF", false),
+		extendedSunSpecPoint("Tms", "mppt.module.timestamp", SunSpecTypeUint32, 2, "Secs", "", false),
+		extendedSunSpecPoint("Tmp", "mppt.module.temperature", SunSpecTypeInt16, 1, "C", "", false),
+		extendedSunSpecEnum("DCSt", "mppt.module.operating_state", false, map[uint64]string{1: "OFF", 2: "SLEEPING", 3: "STARTING", 4: "MPPT", 5: "THROTTLED", 6: "SHUTTING_DOWN", 7: "FAULT", 8: "STANDBY", 9: "TEST", 10: "RESERVED_10"}),
+		extendedSunSpecBitfield("DCEvt", "mppt.module.events", SunSpecTypeBitfield32, false, mpptEventSymbols()),
+	}
+}
+
+func mpptEventSymbols() map[uint64]string {
+	return map[uint64]string{
+		0: "GROUND_FAULT", 1: "INPUT_OVER_VOLTAGE", 2: "RESERVED_2", 3: "DC_DISCONNECT", 4: "RESERVED_4", 5: "CABINET_OPEN", 6: "MANUAL_SHUTDOWN", 7: "OVER_TEMP",
+		8: "RESERVED_8", 9: "RESERVED_9", 10: "RESERVED_10", 11: "RESERVED_11", 12: "BLOWN_FUSE", 13: "UNDER_TEMP", 14: "MEMORY_LOSS", 15: "ARC_DETECTION",
+		16: "RESERVED_16", 17: "RESERVED_17", 18: "RESERVED_18", 19: "RESERVED_19", 20: "TEST_FAILED", 21: "INPUT_UNDER_VOLTAGE", 22: "INPUT_OVER_CURRENT",
+	}
+}

--- a/sunspec_models_mppt_test.go
+++ b/sunspec_models_mppt_test.go
@@ -99,8 +99,8 @@ func TestSunSpecMPPTCountMustMatchExactLength(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if decoded.GeometryValid() || decoded.Qualifies() || !reflect.DeepEqual(decoded.RawWords(), words) {
-				t.Fatalf("geometry=%v qualifies=%v", decoded.GeometryValid(), decoded.Qualifies())
+			if decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) {
+				t.Fatalf("geometry=%v qualifies=%v facts=%d", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()))
 			}
 		})
 	}

--- a/sunspec_models_mppt_test.go
+++ b/sunspec_models_mppt_test.go
@@ -1,0 +1,107 @@
+package modbusreg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSunSpecMPPTExactKeyGeometryIsFiniteAndLazy(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []SunSpecDecoderKey
+	for _, key := range registry.DecoderKeys() {
+		if key.ModelID == 160 {
+			keys = append(keys, key)
+		}
+	}
+	if len(keys) != 3277 || keys[0].ModelLength != 8 || keys[len(keys)-1].ModelLength != 65528 {
+		t.Fatalf("MPPT key count=%d first=%#v last=%#v", len(keys), keys[0], keys[len(keys)-1])
+	}
+	for n, length := range map[uint16]uint16{0: 8, 1: 28, 4: 88, 3276: 65528} {
+		definition, ok := registry.definition(SunSpecDecoderKey{160, length, testSunSpecModelsRevision})
+		if !ok || len(definition.points) != 9+10*int(n) {
+			t.Fatalf("N=%d L=%d points=%d ok=%v", n, length, len(definition.points), ok)
+		}
+	}
+	if _, ok := registry.definition(SunSpecDecoderKey{160, 87, testSunSpecModelsRevision}); ok {
+		t.Fatal("non-geometric MPPT length resolved")
+	}
+}
+
+func TestSunSpecMPPTDecodesIndexedModulesWithSharedScale(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{160, 88, testSunSpecModelsRevision})
+	if !ok {
+		t.Fatal("model 160/88 absent")
+	}
+	words := make([]uint16, 90)
+	words[0], words[1] = 160, 88
+	for _, point := range definition.points {
+		switch {
+		case point.name == "DCA_SF":
+			words[point.offset] = 0xfffe
+		case point.name == "N":
+			words[point.offset] = 4
+		case point.repeated && point.name == "ID":
+			words[point.offset] = point.repeatIndex
+		case point.repeated && point.name == "DCA":
+			words[point.offset] = 100 + point.repeatIndex
+		case point.repeated && point.name == "DCWH":
+			words[point.offset+1] = uint16(point.repeatIndex)
+		}
+	}
+	decoded, err := registry.DecodeOccurrence(admittedOccurrence(160, 88, words, 3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("geometry=%v qualifies=%v", decoded.GeometryValid(), decoded.Qualifies())
+	}
+	var currents []SunSpecFact
+	for _, fact := range decoded.Facts() {
+		if fact.FieldID == "mppt.module.dc_current" {
+			currents = append(currents, fact)
+		}
+	}
+	if len(currents) != 4 {
+		t.Fatalf("module currents=%d", len(currents))
+	}
+	for index, fact := range currents {
+		if !fact.Repeated || fact.GroupID != "module" || fact.RepeatIndex != uint16(index+1) {
+			t.Fatalf("fact[%d]=%#v", index, fact)
+		}
+		decimal, ok := fact.Value.Decimal()
+		if !ok || decimal != (SunSpecDecimal{Coefficient: int64(101 + index), Exponent: -2}) {
+			t.Fatalf("fact[%d] decimal=%#v ok=%v", index, decimal, ok)
+		}
+	}
+	facts := decoded.Facts()
+	facts[0].GroupID = "mutated"
+	if reflect.DeepEqual(facts, decoded.Facts()) {
+		t.Fatal("repeated fact metadata was mutable")
+	}
+}
+
+func TestSunSpecMPPTCountMustMatchExactLength(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, count := range map[string]uint16{"mismatch": 3, "sentinel": 0xffff} {
+		t.Run(name, func(t *testing.T) {
+			words := modelWords(t, registry, 160, 88, map[string][]uint16{"N": {count}})
+			decoded, err := registry.DecodeOccurrence(admittedOccurrence(160, 88, words, 1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decoded.GeometryValid() || decoded.Qualifies() || !reflect.DeepEqual(decoded.RawWords(), words) {
+				t.Fatalf("geometry=%v qualifies=%v", decoded.GeometryValid(), decoded.Qualifies())
+			}
+		})
+	}
+}

--- a/sunspec_value.go
+++ b/sunspec_value.go
@@ -13,7 +13,10 @@ const (
 	SunSpecTypeUint16        SunSpecPointType = "uint16"
 	SunSpecTypeUint32        SunSpecPointType = "uint32"
 	SunSpecTypeAccumulator32 SunSpecPointType = "acc32"
+	SunSpecTypeAccumulator64 SunSpecPointType = "acc64"
+	SunSpecTypeCount         SunSpecPointType = "count"
 	SunSpecTypeEnum16        SunSpecPointType = "enum16"
+	SunSpecTypeBitfield16    SunSpecPointType = "bitfield16"
 	SunSpecTypeBitfield32    SunSpecPointType = "bitfield32"
 	SunSpecTypeString        SunSpecPointType = "string"
 	SunSpecTypeFloat32       SunSpecPointType = "float32"
@@ -87,7 +90,7 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
 		}
 		value.signed, value.hasSigned = int64(int16(words[0])), true
-	case SunSpecTypeUint16:
+	case SunSpecTypeUint16, SunSpecTypeCount:
 		if words[0] == 0xffff {
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
 		}
@@ -100,6 +103,12 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 		value.unsigned, value.hasUnsigned = raw, true
 	case SunSpecTypeAccumulator32:
 		raw := uint64(uint32(words[0])<<16 | uint32(words[1]))
+		if raw == 0 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotAccumulated)
+		}
+		value.unsigned, value.hasUnsigned = raw, true
+	case SunSpecTypeAccumulator64:
+		raw := uint64(words[0])<<48 | uint64(words[1])<<32 | uint64(words[2])<<16 | uint64(words[3])
 		if raw == 0 {
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotAccumulated)
 		}
@@ -128,6 +137,15 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
 		}
 		value.enumNumber, value.enumSymbol, value.hasEnum = uint64(words[0]), def.symbols[uint64(words[0])], true
+	case SunSpecTypeBitfield16:
+		bits := uint64(words[0])
+		if bits == math.MaxUint16 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		if bits > math.MaxInt16 {
+			return value
+		}
+		setSunSpecBitfield(&value, bits, def, 15)
 	case SunSpecTypeBitfield32:
 		bits := uint64(uint32(words[0])<<16 | uint32(words[1]))
 		if bits == math.MaxUint32 {
@@ -136,13 +154,7 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 		if bits > math.MaxInt32 {
 			return value
 		}
-		value.bits, value.unknown, value.hasBits = bits, bits&^def.knownMask, true
-		for bit := uint64(0); bit < 31; bit++ {
-			mask := uint64(1) << bit
-			if bits&mask != 0 && def.knownMask&mask != 0 && def.symbols[bit] != "" {
-				value.bitSymbols = append(value.bitSymbols, def.symbols[bit])
-			}
-		}
+		setSunSpecBitfield(&value, bits, def, 31)
 	case SunSpecTypeString:
 		return decodeSunSpecString(def, words)
 	case SunSpecTypePad:
@@ -157,6 +169,16 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 		return applySunSpecScale(value, scale)
 	}
 	return value
+}
+
+func setSunSpecBitfield(value *SunSpecValue, bits uint64, def sunSpecPointDefinition, width uint64) {
+	value.bits, value.unknown, value.hasBits = bits, bits&^def.knownMask, true
+	for bit := uint64(0); bit < width; bit++ {
+		mask := uint64(1) << bit
+		if bits&mask != 0 && def.knownMask&mask != 0 && def.symbols[bit] != "" {
+			value.bitSymbols = append(value.bitSymbols, def.symbols[bit])
+		}
+	}
 }
 
 func applySunSpecScale(value SunSpecValue, scale *SunSpecValue) SunSpecValue {

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -112,6 +112,38 @@ func TestSunSpecBitfield32DomainBoundary(t *testing.T) {
 	}
 }
 
+func TestSunSpecExtendedValueTypesRetainExactState(t *testing.T) {
+	accumulator := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeAccumulator64, 4), []uint16{0x0001, 0x0002, 0x0003, 0x0004}, nil)
+	if value, ok := accumulator.Unsigned(); accumulator.State() != SunSpecValueValid || !ok || value != 0x0001000200030004 {
+		t.Fatalf("acc64 state=%s value=%x ok=%v", accumulator.State(), value, ok)
+	}
+	notAccumulated := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeAccumulator64, 4), []uint16{0, 0, 0, 0}, nil)
+	if notAccumulated.State() != SunSpecValueNotAccumulated {
+		t.Fatalf("zero acc64 state=%s", notAccumulated.State())
+	}
+	count := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeCount, 1), []uint16{4}, nil)
+	if value, ok := count.Unsigned(); count.State() != SunSpecValueValid || !ok || value != 4 {
+		t.Fatalf("count state=%s value=%d ok=%v", count.State(), value, ok)
+	}
+	if got := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeCount, 1), []uint16{0xffff}, nil); got.State() != SunSpecValueNotImplemented {
+		t.Fatalf("count sentinel state=%s", got.State())
+	}
+	definition := sizedSunSpecPoint(SunSpecTypeBitfield16, 1)
+	definition.knownMask = 0x000f
+	valid := decodeSunSpecValue(definition, []uint16{0x4011}, nil)
+	if bits, unknown, ok := valid.Bitfield(); valid.State() != SunSpecValueValid || !ok || bits != 0x4011 || unknown != 0x4010 {
+		t.Fatalf("bitfield16 state=%s bits=%x unknown=%x ok=%v", valid.State(), bits, unknown, ok)
+	}
+	invalid := decodeSunSpecValue(definition, []uint16{0x8000}, nil)
+	if invalid.State() != SunSpecValueInvalidEncoding || !reflect.DeepEqual(invalid.RawWords(), []uint16{0x8000}) {
+		t.Fatalf("bitfield16 invalid boundary=%#v", invalid)
+	}
+	sentinel := decodeSunSpecValue(definition, []uint16{0xffff}, nil)
+	if sentinel.State() != SunSpecValueNotImplemented {
+		t.Fatalf("bitfield16 sentinel state=%s", sentinel.State())
+	}
+}
+
 func sizedSunSpecPoint(pointType SunSpecPointType, size uint16) sunSpecPointDefinition {
 	return sunSpecPointDefinition{pointType: pointType, size: size}
 }

--- a/testdata/sunspec/models/v1/catalog.json
+++ b/testdata/sunspec/models/v1/catalog.json
@@ -9,6 +9,11 @@
     {"id": 103, "length": 50, "points": 45},
     {"id": 111, "length": 60, "points": 33},
     {"id": 112, "length": 60, "points": 33},
-    {"id": 113, "length": 60, "points": 33}
+    {"id": 113, "length": 60, "points": 33},
+    {"id": 120, "length": 26, "points": 28},
+    {"id": 121, "length": 30, "points": 32},
+    {"id": 122, "length": 44, "points": 22},
+    {"id": 124, "length": 24, "points": 26},
+    {"id": 160, "length": 88, "points": 49}
   ]
 }

--- a/testdata/sunspec/models/v1/model_120.json
+++ b/testdata/sunspec/models/v1/model_120.json
@@ -1,0 +1,7 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "id": 120,
+  "length": 26,
+  "point_count": 28,
+  "mandatory": ["ID", "L", "DERTyp", "WRtg", "WRtg_SF", "VARtg", "VARtg_SF", "VArRtgQ1", "VArRtgQ2", "VArRtgQ3", "VArRtgQ4", "VArRtg_SF", "ARtg", "ARtg_SF", "PFRtgQ1", "PFRtgQ2", "PFRtgQ3", "PFRtgQ4", "PFRtg_SF"]
+}

--- a/testdata/sunspec/models/v1/model_121.json
+++ b/testdata/sunspec/models/v1/model_121.json
@@ -1,0 +1,7 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "id": 121,
+  "length": 30,
+  "point_count": 32,
+  "mandatory": ["ID", "L", "WMax", "VRef", "VRefOfs", "WMax_SF", "VRef_SF", "VRefOfs_SF"]
+}

--- a/testdata/sunspec/models/v1/model_122.json
+++ b/testdata/sunspec/models/v1/model_122.json
@@ -1,0 +1,7 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "id": 122,
+  "length": 44,
+  "point_count": 22,
+  "mandatory": ["ID", "L", "PVConn", "StorConn", "ECPConn"]
+}

--- a/testdata/sunspec/models/v1/model_124.json
+++ b/testdata/sunspec/models/v1/model_124.json
@@ -1,0 +1,7 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "id": 124,
+  "length": 24,
+  "point_count": 26,
+  "mandatory": ["ID", "L", "WChaMax", "WChaGra", "WDisChaGra", "StorCtl_Mod", "WChaMax_SF", "WChaDisChaGra_SF"]
+}

--- a/testdata/sunspec/models/v1/model_160_n4.json
+++ b/testdata/sunspec/models/v1/model_160_n4.json
@@ -1,0 +1,9 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "id": 160,
+  "length": 88,
+  "point_count": 49,
+  "mandatory": ["ID", "L"],
+  "module_count": 4,
+  "module_point_count": 10
+}


### PR DESCRIPTION
Closes #17

RED public exact HEAD: `ac4c37381fc8aa57c6b5ff06047d3d55a5450300`.
GREEN public exact HEAD: `de4af5d6694e82dee3d072d9fd31c58407bd578b`.

R2B adds the pinned SunSpec v1 model definitions and typed decoding for Models 120, 121, 122 and 124, plus finite exact-key Model 160 geometry (`L = 8 + 20*N`), lazy repeated-module definitions, repeat provenance metadata and compact golden fixtures. Invalid Model 160 count/length geometry remains raw/provenanced but emits no typed facts.

Validation on GREEN:
- `GOWORK=off go test -race -shuffle=on -count=20 -run '^(TestSunSpecValueStatesAndTypedAccess|TestSunSpecExtended|TestSunSpecMPPT)' ./...`
- `GOWORK=off ./scripts/ci_local.sh`
- terminology, scope policy + 14 mutation tests, gofmt, vet, build, full race and golangci-lint (`0 issues`) all passed.

Dependencies:
- docs gate merge `735621e57352856bb005e6678ce5a4d209ca3ff8`;
- R2A merge `26aae762d7468d305f34939f5693100f031b230c`;
- authoritative models pin `7abdf8982d5364f8ae916deee18aac86c11be36d`.

T01..T88: owner N/A, registry-only decode/type-system change; no Modbus transport, gateway, live-device or write path.
