### PR TITLE
FMV3-R3: add SunSpec capability and Fronius flavor V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ public M1-06 opaque runtime-acquisition API. M2-02 adds bounded, deterministic,
 read-only profile detection over the immutable catalog. M2-03 adds an immutable
 transport-neutral corpus for sanitized synthetic fixture replay and cross-profile
 conformance. M3-02 adds the bounded, read-only SunSpec phase-one standard-family
-profile and parser. M3-03 records the evidence-qualified `STANDARD_ONLY`
-disposition: it adds no vendor overlay, detector, product qualification, or
-live access. Vendor overlays, product qualification, and live access remain
-outside this milestone.
+profile and parser. M3-03 records its historical evidence-qualified
+`STANDARD_ONLY` disposition. The generic SunSpec R1-R3 wave now adds the
+bounded model chain and decoder registry, standard Models
+1/101-103/111-113/120-122/124/160, the encoding-neutral three-phase monitoring
+capability, and one exact experimental Fronius observed flavor. That flavor is
+post-capability classification only: it adds no product qualification,
+acquisition activation, support statement, live result, or write authority.
 
 ## One Registry, Multiple Vendors
 
@@ -47,7 +50,8 @@ This repository owns:
   detection;
 - strict bounded synthetic fixture corpus serialization, replay, mutation
   classification, and deterministic conformance reports; and
-- evidence-gated vendor overlay declarations for future milestones.
+- evidence-gated, versioned vendor flavors that cannot override standard model
+  semantics or create acquisition authority.
 
 This repository does not own:
 
@@ -114,8 +118,8 @@ Work remains one issue and one pull request at a time, with squash merge,
 proportionate test-first evidence, applicable public documentation/evidence,
 and blocker-driven review of the current head.
 
-The current execution cycle stops after M3-03 and before all gateway work in
-M4-01. Crossing that boundary requires a separate operator request.
+Gateway composition, registry dispatch, and live qualification remain separate
+milestones outside this repository.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
 

--- a/sunspec_capability.go
+++ b/sunspec_capability.go
@@ -114,6 +114,9 @@ func (r SunSpecDecoderRegistry) EvaluateThreePhaseMonitoring(snapshot SunSpecCha
 	}
 	exactSources := make([]SunSpecOccurrence, 0, 2)
 	for _, occurrence := range snapshot.Occurrences() {
+		if !validRetainedSunSpecGeometry(occurrence) {
+			return rejected(SunSpecCapabilityReasonInvalidChain)
+		}
 		if occurrence.WireKey == (SunSpecWireKey{ModelID: 103, ModelLength: 50}) || occurrence.WireKey == (SunSpecWireKey{ModelID: 113, ModelLength: 60}) {
 			exactSources = append(exactSources, occurrence)
 		}
@@ -186,6 +189,17 @@ func (r SunSpecDecoderRegistry) EvaluateThreePhaseMonitoring(snapshot SunSpecCha
 		facts:    canonical,
 		views:    snapshot.SourceViews(),
 	}
+}
+
+func validRetainedSunSpecGeometry(occurrence SunSpecOccurrence) bool {
+	if occurrence.ModelID() != 160 {
+		return true
+	}
+	words := occurrence.Words()
+	if len(words) != int(occurrence.ModelLength())+2 || len(words) <= 8 || words[8] == 0xffff {
+		return false
+	}
+	return uint32(occurrence.ModelLength()) == 8+20*uint32(words[8])
 }
 
 func canonicalSunSpecValue(value SunSpecValue) (SunSpecCanonicalValue, bool) {

--- a/sunspec_capability.go
+++ b/sunspec_capability.go
@@ -1,0 +1,270 @@
+package modbusreg
+
+import (
+	"strconv"
+	"strings"
+)
+
+const SunSpecThreePhaseMonitoringCapabilityID = "sunspec.inverter.three_phase.monitoring@1.0.0"
+
+type SunSpecCapabilityReason string
+
+const (
+	SunSpecCapabilityReasonAdmitted            SunSpecCapabilityReason = "ADMITTED"
+	SunSpecCapabilityReasonInvalidChain        SunSpecCapabilityReason = "INVALID_CHAIN"
+	SunSpecCapabilityReasonSourceAbsent        SunSpecCapabilityReason = "SOURCE_ABSENT"
+	SunSpecCapabilityReasonAmbiguousSource     SunSpecCapabilityReason = "AMBIGUOUS_SOURCE"
+	SunSpecCapabilityReasonSourceUnsupported   SunSpecCapabilityReason = "SOURCE_UNSUPPORTED"
+	SunSpecCapabilityReasonInvalidRequiredFact SunSpecCapabilityReason = "INVALID_REQUIRED_FACT"
+)
+
+type SunSpecCanonicalValueKind string
+
+const (
+	SunSpecCanonicalNumber   SunSpecCanonicalValueKind = "number"
+	SunSpecCanonicalEnum     SunSpecCanonicalValueKind = "enum"
+	SunSpecCanonicalBitfield SunSpecCanonicalValueKind = "bitfield"
+)
+
+type SunSpecCanonicalValue struct {
+	kind       SunSpecCanonicalValueKind
+	number     string
+	enumNumber uint64
+	enumSymbol string
+	bits       uint64
+	bitSymbols []string
+}
+
+func (v SunSpecCanonicalValue) Kind() SunSpecCanonicalValueKind { return v.kind }
+func (v SunSpecCanonicalValue) Number() (string, bool) {
+	return v.number, v.kind == SunSpecCanonicalNumber
+}
+func (v SunSpecCanonicalValue) Enum() (uint64, string, bool) {
+	return v.enumNumber, v.enumSymbol, v.kind == SunSpecCanonicalEnum
+}
+func (v SunSpecCanonicalValue) Bitfield() (uint64, []string, bool) {
+	return v.bits, append([]string(nil), v.bitSymbols...), v.kind == SunSpecCanonicalBitfield
+}
+
+type SunSpecCapabilityFact struct {
+	fieldID     string
+	unit        string
+	value       SunSpecCanonicalValue
+	sourceValue SunSpecValue
+}
+
+func (f SunSpecCapabilityFact) FieldID() string { return f.fieldID }
+func (f SunSpecCapabilityFact) Unit() string    { return f.unit }
+func (f SunSpecCapabilityFact) Value() SunSpecCanonicalValue {
+	return cloneSunSpecCanonicalValue(f.value)
+}
+func (f SunSpecCapabilityFact) SourceValue() SunSpecValue {
+	return cloneSunSpecValue(f.sourceValue)
+}
+
+type SunSpecCapabilityDecision struct {
+	admitted bool
+	reason   SunSpecCapabilityReason
+	source   *SunSpecOccurrence
+	facts    []SunSpecCapabilityFact
+	views    []LogicalViewSnapshot
+}
+
+func (d SunSpecCapabilityDecision) Admitted() bool                  { return d.admitted }
+func (d SunSpecCapabilityDecision) Reason() SunSpecCapabilityReason { return d.reason }
+func (d SunSpecCapabilityDecision) ProfileID() string               { return SunSpecThreePhaseMonitoringCapabilityID }
+func (d SunSpecCapabilityDecision) SourceOccurrence() (SunSpecOccurrence, bool) {
+	if d.source == nil {
+		return SunSpecOccurrence{}, false
+	}
+	return cloneOccurrence(*d.source), true
+}
+func (d SunSpecCapabilityDecision) Facts() []SunSpecCapabilityFact {
+	return cloneSunSpecCapabilityFacts(d.facts)
+}
+func (d SunSpecCapabilityDecision) SourceViews() []LogicalViewSnapshot {
+	return cloneSunSpecLogicalViewSnapshots(d.views)
+}
+
+type sunSpecCapabilityField struct{ id, sourceUnit, unit string }
+
+var threePhaseMonitoringFields = []sunSpecCapabilityField{
+	{"inverter.ac.current.total", "A", "A"},
+	{"inverter.ac.current.phase_a", "A", "A"},
+	{"inverter.ac.current.phase_b", "A", "A"},
+	{"inverter.ac.current.phase_c", "A", "A"},
+	{"inverter.ac.voltage.phase_a", "V", "V"},
+	{"inverter.ac.voltage.phase_b", "V", "V"},
+	{"inverter.ac.voltage.phase_c", "V", "V"},
+	{"inverter.ac.power.active", "W", "W"},
+	{"inverter.ac.frequency", "Hz", "Hz"},
+	{"inverter.ac.energy_lifetime", "Wh", "Wh"},
+	{"inverter.temperature.cabinet", "C", "C"},
+	{"inverter.operating_state", "", "none"},
+	{"inverter.events.1", "", "none"},
+	{"inverter.events.2", "", "none"},
+}
+
+func (r SunSpecDecoderRegistry) EvaluateThreePhaseMonitoring(snapshot SunSpecChainSnapshot) SunSpecCapabilityDecision {
+	rejected := func(reason SunSpecCapabilityReason) SunSpecCapabilityDecision {
+		return SunSpecCapabilityDecision{reason: reason}
+	}
+	if _, ok := sunSpecSnapshotWireChain(snapshot); !ok {
+		return rejected(SunSpecCapabilityReasonInvalidChain)
+	}
+	exactSources := make([]SunSpecOccurrence, 0, 2)
+	for _, occurrence := range snapshot.Occurrences() {
+		if occurrence.WireKey == (SunSpecWireKey{ModelID: 103, ModelLength: 50}) || occurrence.WireKey == (SunSpecWireKey{ModelID: 113, ModelLength: 60}) {
+			exactSources = append(exactSources, occurrence)
+		}
+	}
+	decoded, err := r.DecodeChain(snapshot)
+	if err != nil {
+		return rejected(SunSpecCapabilityReasonInvalidChain)
+	}
+	if len(exactSources) > 1 {
+		return rejected(SunSpecCapabilityReasonAmbiguousSource)
+	}
+	if len(exactSources) == 0 {
+		return rejected(SunSpecCapabilityReasonSourceAbsent)
+	}
+	exactSource := exactSources[0]
+	key, admitted := exactSource.DecoderKey()
+	if !admitted || exactSource.Disposition != SunSpecChainDispositionAdmitted || key.SchemaRevision != r.revision {
+		return rejected(SunSpecCapabilityReasonSourceUnsupported)
+	}
+	var model SunSpecDecodedModel
+	found := false
+	for _, candidate := range decoded.Models() {
+		if candidate.Ordinal() == exactSource.Ordinal && candidate.Key() == key {
+			model, found = candidate, true
+			break
+		}
+	}
+	if !found || model.Topology() != SunSpecTopologyThreePhase {
+		return rejected(SunSpecCapabilityReasonSourceUnsupported)
+	}
+	factsByID := make(map[string][]SunSpecFact, len(threePhaseMonitoringFields))
+	for _, fact := range model.Facts() {
+		factsByID[fact.FieldID] = append(factsByID[fact.FieldID], fact)
+	}
+	canonical := make([]SunSpecCapabilityFact, 0, len(threePhaseMonitoringFields))
+	for _, required := range threePhaseMonitoringFields {
+		matches := factsByID[required.id]
+		if len(matches) != 1 || matches[0].Unit != required.sourceUnit || !matches[0].Required {
+			return rejected(SunSpecCapabilityReasonInvalidRequiredFact)
+		}
+		value, ok := canonicalSunSpecValue(matches[0].Value)
+		if !ok {
+			return rejected(SunSpecCapabilityReasonInvalidRequiredFact)
+		}
+		canonical = append(canonical, SunSpecCapabilityFact{
+			fieldID: required.id, unit: required.unit, value: value,
+			sourceValue: cloneSunSpecValue(matches[0].Value),
+		})
+	}
+	var source *SunSpecOccurrence
+	for _, occurrence := range snapshot.Occurrences() {
+		if occurrence.Ordinal == model.Ordinal() && occurrence.WireKey == (SunSpecWireKey{ModelID: model.Key().ModelID, ModelLength: model.Key().ModelLength}) {
+			copy := cloneOccurrence(occurrence)
+			source = &copy
+			break
+		}
+	}
+	if source == nil {
+		return rejected(SunSpecCapabilityReasonInvalidChain)
+	}
+	return SunSpecCapabilityDecision{
+		admitted: true,
+		reason:   SunSpecCapabilityReasonAdmitted,
+		source:   source,
+		facts:    canonical,
+		views:    snapshot.SourceViews(),
+	}
+}
+
+func canonicalSunSpecValue(value SunSpecValue) (SunSpecCanonicalValue, bool) {
+	if value.State() != SunSpecValueValid {
+		return SunSpecCanonicalValue{}, false
+	}
+	if decimal, ok := value.Decimal(); ok {
+		return SunSpecCanonicalValue{kind: SunSpecCanonicalNumber, number: formatSunSpecDecimal(decimal)}, true
+	}
+	if number, ok := value.Float32(); ok {
+		formatted := strconv.FormatFloat(float64(number), 'f', -1, 32)
+		if formatted == "-0" {
+			formatted = "0"
+		}
+		return SunSpecCanonicalValue{kind: SunSpecCanonicalNumber, number: formatted}, true
+	}
+	if number, symbol, ok := value.Enum(); ok {
+		if symbol == "" {
+			return SunSpecCanonicalValue{}, false
+		}
+		return SunSpecCanonicalValue{kind: SunSpecCanonicalEnum, enumNumber: number, enumSymbol: symbol}, true
+	}
+	if bits, unknown, ok := value.Bitfield(); ok {
+		if unknown != 0 {
+			return SunSpecCanonicalValue{}, false
+		}
+		symbols := value.BitfieldSymbols()
+		return SunSpecCanonicalValue{kind: SunSpecCanonicalBitfield, bits: bits, bitSymbols: symbols}, true
+	}
+	return SunSpecCanonicalValue{}, false
+}
+
+func formatSunSpecDecimal(decimal SunSpecDecimal) string {
+	if decimal.Coefficient == 0 {
+		return "0"
+	}
+	negative := decimal.Coefficient < 0
+	digits := strconv.FormatInt(decimal.Coefficient, 10)
+	if negative {
+		digits = digits[1:]
+	}
+	if decimal.Exponent >= 0 {
+		digits += strings.Repeat("0", int(decimal.Exponent))
+	} else {
+		point := len(digits) + int(decimal.Exponent)
+		if point <= 0 {
+			digits = "0." + strings.Repeat("0", -point) + digits
+		} else {
+			digits = digits[:point] + "." + digits[point:]
+		}
+		digits = strings.TrimRight(strings.TrimRight(digits, "0"), ".")
+	}
+	if negative {
+		return "-" + digits
+	}
+	return digits
+}
+
+func cloneSunSpecCanonicalValue(value SunSpecCanonicalValue) SunSpecCanonicalValue {
+	value.bitSymbols = append([]string(nil), value.bitSymbols...)
+	return value
+}
+
+func cloneSunSpecCapabilityFacts(facts []SunSpecCapabilityFact) []SunSpecCapabilityFact {
+	out := make([]SunSpecCapabilityFact, len(facts))
+	for index, fact := range facts {
+		fact.value = cloneSunSpecCanonicalValue(fact.value)
+		fact.sourceValue = cloneSunSpecValue(fact.sourceValue)
+		out[index] = fact
+	}
+	return out
+}
+
+func cloneSunSpecValue(value SunSpecValue) SunSpecValue {
+	value.raw = append([]uint16(nil), value.raw...)
+	value.bitSymbols = append([]string(nil), value.bitSymbols...)
+	return value
+}
+
+func cloneSunSpecLogicalViewSnapshots(views []LogicalViewSnapshot) []LogicalViewSnapshot {
+	out := make([]LogicalViewSnapshot, len(views))
+	for index, view := range views {
+		record := view.Record()
+		out[index] = LogicalViewSnapshot{record: cloneSunSpecLogicalViewRecord(record), valid: true}
+	}
+	return out
+}

--- a/sunspec_capability.go
+++ b/sunspec_capability.go
@@ -122,6 +122,11 @@ func (r SunSpecDecoderRegistry) EvaluateThreePhaseMonitoring(snapshot SunSpecCha
 	if err != nil {
 		return rejected(SunSpecCapabilityReasonInvalidChain)
 	}
+	for _, candidate := range decoded.Models() {
+		if !candidate.GeometryValid() || (candidate.Key().ModelID == 1 && !candidate.Qualifies()) {
+			return rejected(SunSpecCapabilityReasonInvalidChain)
+		}
+	}
 	if len(exactSources) > 1 {
 		return rejected(SunSpecCapabilityReasonAmbiguousSource)
 	}

--- a/sunspec_capability_test.go
+++ b/sunspec_capability_test.go
@@ -1,6 +1,7 @@
 package modbusreg
 
 import (
+	"math"
 	"reflect"
 	"testing"
 )
@@ -42,6 +43,102 @@ func TestThreePhaseMonitoringFailsClosedOnSourceAmbiguity(t *testing.T) {
 			decision := registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(occurrences...))
 			if decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonAmbiguousSource || len(decision.Facts()) != 0 {
 				t.Fatalf("decision admitted=%t reason=%q facts=%d", decision.Admitted(), decision.Reason(), len(decision.Facts()))
+			}
+		})
+	}
+}
+
+func TestThreePhaseMonitoringRejectsMissingSourceAndInvalidCommon(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	common := commonOccurrence(t, registry, "Maker", "Model", "1.0", 1)
+	if decision := registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(common)); decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonSourceAbsent {
+		t.Fatalf("missing source admitted=%t reason=%q", decision.Admitted(), decision.Reason())
+	}
+	if decision := registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(inverterOccurrence(t, registry, 113, nil, 1))); decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonInvalidChain {
+		t.Fatalf("missing common admitted=%t reason=%q", decision.Admitted(), decision.Reason())
+	}
+}
+
+func TestThreePhaseMonitoringDistinguishesUnsupportedExactSource(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	common := commonOccurrence(t, registry, "Maker", "Model", "1.0", 1)
+	unsupported := inverterOccurrence(t, registry, 113, nil, 2)
+	unsupported.Disposition = SunSpecChainDispositionUnknownModel
+	unsupported.decoderKey = nil
+	decision := registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(common, unsupported))
+	if decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonSourceUnsupported {
+		t.Fatalf("unsupported admitted=%t reason=%q", decision.Admitted(), decision.Reason())
+	}
+
+	wrongLength := SunSpecOccurrence{
+		Ordinal: 2, WireKey: SunSpecWireKey{ModelID: 103, ModelLength: 49},
+		SchemaRevision: testSunSpecModelsRevision, Disposition: SunSpecChainDispositionUnsupportedLength,
+		words: append([]uint16{103, 49}, make([]uint16, 49)...),
+	}
+	valid := inverterOccurrence(t, registry, 113, nil, 3)
+	decision = registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(common, wrongLength, valid))
+	if !decision.Admitted() {
+		t.Fatalf("wrong-length lookalike blocked exact source: %q", decision.Reason())
+	}
+
+	unsupported.Ordinal = 2
+	valid.Ordinal = 3
+	decision = registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(common, unsupported, valid))
+	if decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonAmbiguousSource {
+		t.Fatalf("unsupported exact source was ignored: admitted=%t reason=%q", decision.Admitted(), decision.Reason())
+	}
+}
+
+func TestCanonicalSunSpecNumbersUseClosedPlainDecimalGrammar(t *testing.T) {
+	tests := []struct {
+		decimal SunSpecDecimal
+		want    string
+	}{
+		{SunSpecDecimal{Coefficient: 0, Exponent: -4}, "0"},
+		{SunSpecDecimal{Coefficient: 12, Exponent: -1}, "1.2"},
+		{SunSpecDecimal{Coefficient: 120, Exponent: -2}, "1.2"},
+		{SunSpecDecimal{Coefficient: -5, Exponent: 0}, "-5"},
+		{SunSpecDecimal{Coefficient: 1, Exponent: -3}, "0.001"},
+		{SunSpecDecimal{Coefficient: -10, Exponent: 2}, "-1000"},
+	}
+	for _, tc := range tests {
+		if got := formatSunSpecDecimal(tc.decimal); got != tc.want {
+			t.Fatalf("formatSunSpecDecimal(%+v)=%q want=%q", tc.decimal, got, tc.want)
+		}
+	}
+	value, ok := canonicalSunSpecValue(SunSpecValue{
+		pointType: SunSpecTypeFloat32,
+		state:     SunSpecValueValid,
+		float32:   math.Float32frombits(0x80000000),
+		hasFloat:  true,
+	})
+	if number, numberOK := value.Number(); !ok || !numberOK || number != "0" {
+		t.Fatalf("negative zero canonical=%q value_ok=%t number_ok=%t", number, ok, numberOK)
+	}
+}
+
+func TestThreePhaseMonitoringRequiresVerifiedTerminalOffsetsAndSpans(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	valid := capabilitySnapshot(t, registry, 113, nil)
+	missingTerminal := cloneSnapshotForTest(valid)
+	missingTerminal.raw = missingTerminal.raw[:len(missingTerminal.raw)-2]
+	badOffset := cloneSnapshotForTest(valid)
+	badOffset.occurrences[1].HeaderOffset++
+	badSpan := cloneSnapshotForTest(valid)
+	badSpan.occurrences[1].spans[0].WordCount--
+	rawContradiction := cloneSnapshotForTest(valid)
+	rawContradiction.raw[2] = 2
+
+	for name, snapshot := range map[string]SunSpecChainSnapshot{
+		"missing terminal":  missingTerminal,
+		"bad offset":        badOffset,
+		"bad span":          badSpan,
+		"raw contradiction": rawContradiction,
+	} {
+		t.Run(name, func(t *testing.T) {
+			decision := registry.EvaluateThreePhaseMonitoring(snapshot)
+			if decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonInvalidChain {
+				t.Fatalf("admitted=%t reason=%q", decision.Admitted(), decision.Reason())
 			}
 		})
 	}
@@ -95,6 +192,12 @@ func TestThreePhaseMonitoringNormalizesEquivalent103And113Values(t *testing.T) {
 			t.Fatalf("%s integer=%q/%t floating=%q/%t", field, leftNumber, leftOK, rightNumber, rightOK)
 		}
 	}
+	for _, field := range []string{"inverter.operating_state", "inverter.events.1", "inverter.events.2"} {
+		fact, ok := capabilityFactByID(floating.Facts(), field)
+		if !ok || fact.Unit() != "none" {
+			t.Fatalf("%s unit=%q present=%t", field, fact.Unit(), ok)
+		}
+	}
 }
 
 func TestThreePhaseMonitoringDecisionIsDefensiveAndRetainsEvidence(t *testing.T) {
@@ -105,6 +208,12 @@ func TestThreePhaseMonitoringDecisionIsDefensiveAndRetainsEvidence(t *testing.T)
 	facts[0] = SunSpecCapabilityFact{}
 	if decision.Facts()[0].FieldID() == "" {
 		t.Fatal("facts mutated through accessor")
+	}
+	original := decision.Facts()[0].SourceValue()
+	words := original.RawWords()
+	words[0] = 0
+	if decision.Facts()[0].SourceValue().RawWords()[0] == 0 {
+		t.Fatal("original typed value mutated through accessor")
 	}
 	source, ok := decision.SourceOccurrence()
 	if !ok {

--- a/sunspec_capability_test.go
+++ b/sunspec_capability_test.go
@@ -1,0 +1,140 @@
+package modbusreg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestThreePhaseMonitoringAdmitsExactlyOneCompleteSource(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	for _, modelID := range []uint16{103, 113} {
+		t.Run(string(rune(modelID)), func(t *testing.T) {
+			snapshot := capabilitySnapshot(t, registry, modelID, nil)
+			decision := registry.EvaluateThreePhaseMonitoring(snapshot)
+			if !decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonAdmitted || decision.ProfileID() != SunSpecThreePhaseMonitoringCapabilityID {
+				t.Fatalf("decision admitted=%t reason=%q profile=%q", decision.Admitted(), decision.Reason(), decision.ProfileID())
+			}
+			facts := decision.Facts()
+			if len(facts) != 14 {
+				t.Fatalf("facts=%d", len(facts))
+			}
+			if source, ok := decision.SourceOccurrence(); !ok || source.ModelID() != modelID || source.ModelLength() != map[bool]uint16{true: 60, false: 50}[modelID == 113] {
+				t.Fatalf("source=%#v present=%t", source, ok)
+			}
+			if len(decision.SourceViews()) != len(snapshot.SourceViews()) {
+				t.Fatalf("source views=%d want=%d", len(decision.SourceViews()), len(snapshot.SourceViews()))
+			}
+		})
+	}
+}
+
+func TestThreePhaseMonitoringFailsClosedOnSourceAmbiguity(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	common := commonOccurrence(t, registry, "Maker", "Model", "1.0", 1)
+	integer := inverterOccurrence(t, registry, 103, nil, 2)
+	floating := inverterOccurrence(t, registry, 113, nil, 3)
+
+	for name, occurrences := range map[string][]SunSpecOccurrence{
+		"duplicate": {common, integer, inverterOccurrence(t, registry, 103, nil, 3)},
+		"both":      {common, integer, floating},
+	} {
+		t.Run(name, func(t *testing.T) {
+			decision := registry.EvaluateThreePhaseMonitoring(snapshotFromOccurrences(occurrences...))
+			if decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonAmbiguousSource || len(decision.Facts()) != 0 {
+				t.Fatalf("decision admitted=%t reason=%q facts=%d", decision.Admitted(), decision.Reason(), len(decision.Facts()))
+			}
+		})
+	}
+}
+
+func TestThreePhaseMonitoringRejectsInvalidRequiredFacts(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	tests := map[string]map[string][]uint16{
+		"sentinel":           {"A": {0x7fc0, 0}},
+		"nonfinite":          {"A": {0x7f80, 0}},
+		"unknown enum":       {"St": {99}},
+		"unknown event bits": {"Evt1": {0x0001, 0}},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			decision := registry.EvaluateThreePhaseMonitoring(capabilitySnapshot(t, registry, 113, values))
+			if decision.Admitted() || decision.Reason() != SunSpecCapabilityReasonInvalidRequiredFact || len(decision.Facts()) != 0 {
+				t.Fatalf("decision admitted=%t reason=%q facts=%d", decision.Admitted(), decision.Reason(), len(decision.Facts()))
+			}
+		})
+	}
+}
+
+func TestThreePhaseMonitoringNormalizesEquivalent103And113Values(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	integer := registry.EvaluateThreePhaseMonitoring(capabilitySnapshot(t, registry, 103, map[string][]uint16{
+		"A": {125}, "AphA": {125}, "AphB": {125}, "AphC": {125}, "A_SF": {0xfffe},
+		"PhVphA": {2300}, "PhVphB": {2300}, "PhVphC": {2300}, "V_SF": {0xffff},
+		"W": {125}, "W_SF": {0xfffe}, "Hz": {5000}, "Hz_SF": {0xfffe},
+		"WH": {0, 125}, "WH_SF": {0xfffe}, "TmpCab": {250}, "Tmp_SF": {0xffff},
+		"St": {4}, "Evt1": {0, 1}, "Evt2": {0, 0},
+	}))
+	floating := registry.EvaluateThreePhaseMonitoring(capabilitySnapshot(t, registry, 113, map[string][]uint16{
+		"A": float32Words(1.25), "AphA": float32Words(1.25), "AphB": float32Words(1.25), "AphC": float32Words(1.25),
+		"PhVphA": float32Words(230), "PhVphB": float32Words(230), "PhVphC": float32Words(230),
+		"W": float32Words(1.25), "Hz": float32Words(50), "WH": float32Words(1.25), "TmpCab": float32Words(25),
+		"St": {4}, "Evt1": {0, 1}, "Evt2": {0, 0},
+	}))
+	if !integer.Admitted() || !floating.Admitted() {
+		t.Fatalf("integer=%q floating=%q", integer.Reason(), floating.Reason())
+	}
+	if !reflect.DeepEqual(capabilityFactShape(integer.Facts()), capabilityFactShape(floating.Facts())) {
+		t.Fatalf("103=%v\n113=%v", capabilityFactShape(integer.Facts()), capabilityFactShape(floating.Facts()))
+	}
+	for _, field := range []string{"inverter.ac.current.total", "inverter.ac.voltage.phase_a", "inverter.ac.power.active", "inverter.ac.frequency", "inverter.ac.energy_lifetime", "inverter.temperature.cabinet"} {
+		left, lok := capabilityFactByID(integer.Facts(), field)
+		right, rok := capabilityFactByID(floating.Facts(), field)
+		leftNumber, leftOK := left.Value().Number()
+		rightNumber, rightOK := right.Value().Number()
+		if !lok || !rok || !leftOK || !rightOK || leftNumber != rightNumber {
+			t.Fatalf("%s integer=%q/%t floating=%q/%t", field, leftNumber, leftOK, rightNumber, rightOK)
+		}
+	}
+}
+
+func TestThreePhaseMonitoringDecisionIsDefensiveAndRetainsEvidence(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	snapshot := capabilitySnapshot(t, registry, 113, nil)
+	decision := registry.EvaluateThreePhaseMonitoring(snapshot)
+	facts := decision.Facts()
+	facts[0] = SunSpecCapabilityFact{}
+	if decision.Facts()[0].FieldID() == "" {
+		t.Fatal("facts mutated through accessor")
+	}
+	source, ok := decision.SourceOccurrence()
+	if !ok {
+		t.Fatal("source absent")
+	}
+	raw := source.Words()
+	raw[0] = 0
+	again, _ := decision.SourceOccurrence()
+	if again.Words()[0] != 113 {
+		t.Fatal("source raw evidence mutated")
+	}
+	views := decision.SourceViews()
+	if len(views) == 0 {
+		t.Fatal("source provenance absent")
+	}
+}
+
+func capabilityFactShape(facts []SunSpecCapabilityFact) []string {
+	out := make([]string, len(facts))
+	for index, fact := range facts {
+		out[index] = fact.FieldID() + "|" + fact.Unit() + "|" + string(fact.Value().Kind())
+	}
+	return out
+}
+
+func capabilityFactByID(facts []SunSpecCapabilityFact, fieldID string) (SunSpecCapabilityFact, bool) {
+	for _, fact := range facts {
+		if fact.FieldID() == fieldID {
+			return fact, true
+		}
+	}
+	return SunSpecCapabilityFact{}, false
+}

--- a/sunspec_fronius.go
+++ b/sunspec_fronius.go
@@ -1,0 +1,172 @@
+package modbusreg
+
+import "slices"
+
+const SunSpecFroniusObservedFlavorID = "sunspec.flavor.fronius.gen24.float.observed@1.0.0"
+
+type SunSpecFroniusFlavorReason string
+
+const (
+	SunSpecFroniusFlavorReasonCapabilityNotAdmitted  SunSpecFroniusFlavorReason = "CAPABILITY_NOT_ADMITTED"
+	SunSpecFroniusFlavorReasonCommonIdentityMismatch SunSpecFroniusFlavorReason = "COMMON_IDENTITY_MISMATCH"
+	SunSpecFroniusFlavorReasonFirmwareMismatch       SunSpecFroniusFlavorReason = "FIRMWARE_MISMATCH"
+	SunSpecFroniusFlavorReasonChainMismatch          SunSpecFroniusFlavorReason = "CHAIN_MISMATCH"
+	SunSpecFroniusFlavorReasonAmbiguousSource        SunSpecFroniusFlavorReason = "AMBIGUOUS_SOURCE"
+	SunSpecFroniusFlavorReasonMatched                SunSpecFroniusFlavorReason = "MATCHED"
+)
+
+type SunSpecFroniusFlavorDecision struct {
+	matched    bool
+	reason     SunSpecFroniusFlavorReason
+	capability SunSpecCapabilityDecision
+	chain      []SunSpecWireKey
+	views      []LogicalViewSnapshot
+}
+
+func (d SunSpecFroniusFlavorDecision) Matched() bool                      { return d.matched }
+func (d SunSpecFroniusFlavorDecision) Reason() SunSpecFroniusFlavorReason { return d.reason }
+func (d SunSpecFroniusFlavorDecision) FlavorID() string                   { return SunSpecFroniusObservedFlavorID }
+func (d SunSpecFroniusFlavorDecision) Capability() SunSpecCapabilityDecision {
+	return cloneSunSpecCapabilityDecision(d.capability)
+}
+func (d SunSpecFroniusFlavorDecision) Chain() []SunSpecWireKey {
+	return append([]SunSpecWireKey(nil), d.chain...)
+}
+func (d SunSpecFroniusFlavorDecision) SourceViews() []LogicalViewSnapshot {
+	return cloneSunSpecLogicalViewSnapshots(d.views)
+}
+
+var froniusObservedChainV1 = []SunSpecWireKey{
+	{ModelID: 1, ModelLength: 65},
+	{ModelID: 113, ModelLength: 60},
+	{ModelID: 120, ModelLength: 26},
+	{ModelID: 121, ModelLength: 30},
+	{ModelID: 122, ModelLength: 44},
+	{ModelID: 160, ModelLength: 88},
+	{ModelID: 124, ModelLength: 24},
+	{ModelID: sunSpecEndModel, ModelLength: 0},
+}
+
+func (r SunSpecDecoderRegistry) EvaluateFroniusObservedFlavor(snapshot SunSpecChainSnapshot) SunSpecFroniusFlavorDecision {
+	capability := r.EvaluateThreePhaseMonitoring(snapshot)
+	rejected := func(reason SunSpecFroniusFlavorReason) SunSpecFroniusFlavorDecision {
+		return SunSpecFroniusFlavorDecision{reason: reason, capability: capability}
+	}
+	if capability.Reason() == SunSpecCapabilityReasonAmbiguousSource {
+		return rejected(SunSpecFroniusFlavorReasonAmbiguousSource)
+	}
+	if !capability.Admitted() {
+		return rejected(SunSpecFroniusFlavorReasonCapabilityNotAdmitted)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) == 0 {
+		return rejected(SunSpecFroniusFlavorReasonChainMismatch)
+	}
+	common, err := r.DecodeOccurrence(occurrences[0])
+	if err != nil {
+		return rejected(SunSpecFroniusFlavorReasonCommonIdentityMismatch)
+	}
+	manufacturer, manufacturerOK := sunSpecTextFact(common, "device.manufacturer")
+	model, modelOK := sunSpecTextFact(common, "device.model")
+	if !manufacturerOK || !modelOK || manufacturer != "Fronius" || model != "Symo GEN24 10.0" {
+		return rejected(SunSpecFroniusFlavorReasonCommonIdentityMismatch)
+	}
+	firmware, firmwareOK := sunSpecTextFact(common, "device.version")
+	if !firmwareOK || firmware != "1.41.11-1" {
+		return rejected(SunSpecFroniusFlavorReasonFirmwareMismatch)
+	}
+	chain, valid := sunSpecSnapshotWireChain(snapshot)
+	if !valid || !slices.Equal(chain, froniusObservedChainV1) {
+		return rejected(SunSpecFroniusFlavorReasonChainMismatch)
+	}
+	return SunSpecFroniusFlavorDecision{
+		matched:    true,
+		reason:     SunSpecFroniusFlavorReasonMatched,
+		capability: capability,
+		chain:      chain,
+		views:      snapshot.SourceViews(),
+	}
+}
+
+func sunSpecTextFact(model SunSpecDecodedModel, fieldID string) (string, bool) {
+	fact, ok := model.Fact(fieldID)
+	if !ok || fact.Value.State() != SunSpecValueValid {
+		return "", false
+	}
+	return fact.Value.Text()
+}
+
+func sunSpecSnapshotWireChain(snapshot SunSpecChainSnapshot) ([]SunSpecWireKey, bool) {
+	raw := snapshot.RawWords()
+	if len(raw) < 4 || raw[0] != sunSpecSignatureFirst || raw[1] != sunSpecSignatureSecond {
+		return nil, false
+	}
+	occurrences := snapshot.Occurrences()
+	views := snapshot.SourceViews()
+	viewByID := make(map[uint64]LogicalViewRecord, len(views))
+	for _, view := range views {
+		record := view.Record()
+		if record.LogicalViewID == 0 {
+			return nil, false
+		}
+		if _, duplicate := viewByID[record.LogicalViewID]; duplicate {
+			return nil, false
+		}
+		viewByID[record.LogicalViewID] = record
+	}
+	keys := make([]SunSpecWireKey, 0, len(occurrences)+1)
+	offset := 2
+	var nextHeader uint32
+	for index, occurrence := range occurrences {
+		if occurrence.Ordinal != uint32(index+1) || offset+2 > len(raw) {
+			return nil, false
+		}
+		key := SunSpecWireKey{ModelID: raw[offset], ModelLength: raw[offset+1]}
+		end := offset + 2 + int(key.ModelLength)
+		if key.ModelID == sunSpecEndModel || key.ModelLength == 0 || end > len(raw) || key != occurrence.WireKey || !slices.Equal(raw[offset:end], occurrence.Words()) {
+			return nil, false
+		}
+		if index == 0 {
+			if occurrence.HeaderOffset < 2 {
+				return nil, false
+			}
+			nextHeader = uint32(occurrence.HeaderOffset)
+		}
+		if uint32(occurrence.HeaderOffset) != nextHeader || uint32(occurrence.PayloadOffset) != nextHeader+2 {
+			return nil, false
+		}
+		wordCursor := 0
+		for _, span := range occurrence.SourceSpans() {
+			record, ok := viewByID[span.LogicalViewID]
+			spanEnd := wordCursor + int(span.WordCount)
+			if !ok || span.WordCount == 0 || spanEnd > len(occurrence.words) || span.PDUOffset != record.SliceOffset || span.WordCount != record.SliceWordCount || len(record.Words) != int(span.WordCount) || !slices.Equal(record.Words, occurrence.words[wordCursor:spanEnd]) {
+				return nil, false
+			}
+			wordCursor = spanEnd
+		}
+		if wordCursor != len(occurrence.words) {
+			return nil, false
+		}
+		keys = append(keys, key)
+		offset = end
+		nextHeader += uint32(len(occurrence.words))
+		if nextHeader > 65535 {
+			return nil, false
+		}
+	}
+	if offset+2 != len(raw) || raw[offset] != sunSpecEndModel || raw[offset+1] != 0 {
+		return nil, false
+	}
+	return append(keys, SunSpecWireKey{ModelID: sunSpecEndModel, ModelLength: 0}), true
+}
+
+func cloneSunSpecCapabilityDecision(decision SunSpecCapabilityDecision) SunSpecCapabilityDecision {
+	out := decision
+	if decision.source != nil {
+		source := cloneOccurrence(*decision.source)
+		out.source = &source
+	}
+	out.facts = cloneSunSpecCapabilityFacts(decision.facts)
+	out.views = cloneSunSpecLogicalViewSnapshots(decision.views)
+	return out
+}

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -1,0 +1,108 @@
+package modbusreg
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestFroniusObservedFlavorMatchesOnlyExactEvidenceTuple(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	snapshot := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	decision := registry.EvaluateFroniusObservedFlavor(snapshot)
+	if !decision.Matched() || decision.Reason() != SunSpecFroniusFlavorReasonMatched || decision.FlavorID() != SunSpecFroniusObservedFlavorID {
+		t.Fatalf("matched=%t reason=%q flavor=%q", decision.Matched(), decision.Reason(), decision.FlavorID())
+	}
+	if !decision.Capability().Admitted() || len(decision.Chain()) != 8 || len(decision.SourceViews()) != len(snapshot.SourceViews()) {
+		t.Fatalf("capability=%t chain=%v views=%d", decision.Capability().Admitted(), decision.Chain(), len(decision.SourceViews()))
+	}
+	chain := decision.Chain()
+	chain[0] = SunSpecWireKey{}
+	if decision.Chain()[0] != (SunSpecWireKey{ModelID: 1, ModelLength: 65}) {
+		t.Fatal("flavor chain mutated through accessor")
+	}
+}
+
+func TestFroniusObservedFlavorReasonsAreClosedAndFailClosed(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	identity := froniusObservedSnapshot(t, registry, "fronius", "Symo GEN24 10.0", "1.41.11-1")
+	firmware := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-2")
+	chain := valid
+	chain.occurrences[2], chain.occurrences[3] = chain.occurrences[3], chain.occurrences[2]
+	chain.raw = rawWordsForOccurrences(chain.occurrences)
+	invalidCapability := valid
+	invalidCapability.occurrences[1] = inverterOccurrence(t, registry, 113, map[string][]uint16{"St": {99}}, 2)
+	invalidCapability.raw = rawWordsForOccurrences(invalidCapability.occurrences)
+	ambiguous := valid
+	ambiguous.occurrences = append(ambiguous.occurrences[:2], append([]SunSpecOccurrence{inverterOccurrence(t, registry, 103, nil, 3)}, ambiguous.occurrences[2:]...)...)
+	for index := range ambiguous.occurrences {
+		ambiguous.occurrences[index].Ordinal = uint32(index + 1)
+	}
+	ambiguous.raw = rawWordsForOccurrences(ambiguous.occurrences)
+
+	tests := map[string]struct {
+		snapshot SunSpecChainSnapshot
+		reason   SunSpecFroniusFlavorReason
+	}{
+		"identity":   {identity, SunSpecFroniusFlavorReasonCommonIdentityMismatch},
+		"firmware":   {firmware, SunSpecFroniusFlavorReasonFirmwareMismatch},
+		"chain":      {chain, SunSpecFroniusFlavorReasonChainMismatch},
+		"capability": {invalidCapability, SunSpecFroniusFlavorReasonCapabilityNotAdmitted},
+		"ambiguous":  {ambiguous, SunSpecFroniusFlavorReasonAmbiguousSource},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			decision := registry.EvaluateFroniusObservedFlavor(tc.snapshot)
+			if decision.Matched() || decision.Reason() != tc.reason {
+				t.Fatalf("matched=%t reason=%q want=%q", decision.Matched(), decision.Reason(), tc.reason)
+			}
+		})
+	}
+}
+
+func TestFroniusObservedFlavorFixtureIsExactAndNonActionable(t *testing.T) {
+	raw, err := os.ReadFile("testdata/sunspec/chains/fronius_gen24_float_v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		Schema       string           `json:"schema"`
+		FlavorID     string           `json:"flavor_id"`
+		Manufacturer string           `json:"manufacturer"`
+		Model        string           `json:"model"`
+		Firmware     string           `json:"firmware"`
+		Chain        []SunSpecWireKey `json:"chain"`
+		Observation  struct {
+			Function  string `json:"function"`
+			UnitID    uint16 `json:"unit_id"`
+			PDUOffset uint16 `json:"pdu_offset"`
+			Authority string `json:"authority"`
+		} `json:"sanitized_observation"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	wantChain := []SunSpecWireKey{{1, 65}, {113, 60}, {120, 26}, {121, 30}, {122, 44}, {160, 88}, {124, 24}, {0xffff, 0}}
+	if fixture.Schema != "helianthus-sunspec-fronius-observed-flavor/v1" || fixture.FlavorID != SunSpecFroniusObservedFlavorID || fixture.Manufacturer != "Fronius" || fixture.Model != "Symo GEN24 10.0" || fixture.Firmware != "1.41.11-1" || !reflect.DeepEqual(fixture.Chain, wantChain) {
+		t.Fatalf("fixture=%+v", fixture)
+	}
+	if fixture.Observation.Function != "FC03" || fixture.Observation.UnitID != 1 || fixture.Observation.PDUOffset != 40000 || fixture.Observation.Authority != "non_actionable_provenance_only" {
+		t.Fatalf("observation=%+v", fixture.Observation)
+	}
+}
+
+func froniusObservedSnapshot(t *testing.T, registry SunSpecDecoderRegistry, manufacturer, model, firmware string) SunSpecChainSnapshot {
+	t.Helper()
+	occurrences := []SunSpecOccurrence{
+		commonOccurrence(t, registry, manufacturer, model, firmware, 1),
+		inverterOccurrence(t, registry, 113, nil, 2),
+		admittedOccurrence(120, 26, modelWords(t, registry, 120, 26, nil), 3),
+		admittedOccurrence(121, 30, modelWords(t, registry, 121, 30, nil), 4),
+		admittedOccurrence(122, 44, modelWords(t, registry, 122, 44, nil), 5),
+		admittedOccurrence(160, 88, modelWords(t, registry, 160, 88, map[string][]uint16{"N": {4}}), 6),
+		admittedOccurrence(124, 24, modelWords(t, registry, 124, 24, nil), 7),
+	}
+	return snapshotFromOccurrences(occurrences...)
+}

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -24,6 +24,19 @@ func TestFroniusObservedFlavorMatchesOnlyExactEvidenceTuple(t *testing.T) {
 	}
 }
 
+func TestFroniusObservedFlavorAcceptsCompletedPublicChainSnapshot(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	fixture := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	snapshot := completedChainSnapshot(t, registry, fixture.Occurrences()...)
+	decision := registry.EvaluateFroniusObservedFlavor(snapshot)
+	if !decision.Matched() || !decision.Capability().Admitted() {
+		t.Fatalf("matched=%t flavor_reason=%q capability_reason=%q", decision.Matched(), decision.Reason(), decision.Capability().Reason())
+	}
+	if len(snapshot.SourceViews()) <= len(snapshot.Occurrences()) {
+		t.Fatalf("production snapshot did not retain split signature/header/payload/terminal views: views=%d occurrences=%d", len(snapshot.SourceViews()), len(snapshot.Occurrences()))
+	}
+}
+
 func TestFroniusObservedFlavorReasonsAreClosedAndFailClosed(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -63,6 +63,32 @@ func TestCapabilityAndFlavorRejectInvalidCommonAndAdmittedGeometry(t *testing.T)
 	}
 }
 
+func TestCapabilityAndFlavorRejectRetainedUnadmittedModel160Geometry(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	fixture := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	occurrences := fixture.Occurrences()
+	occurrences[5] = admittedOccurrence(160, 88, modelWords(t, registry, 160, 88, map[string][]uint16{"N": {3}}), 6)
+	keys := registry.DecoderKeys()
+	withoutExactMPPT := keys[:0]
+	for _, key := range keys {
+		if key.ModelID != 160 || key.ModelLength != 88 {
+			withoutExactMPPT = append(withoutExactMPPT, key)
+		}
+	}
+	snapshot := completedChainSnapshotWithKeys(t, withoutExactMPPT, occurrences...)
+	if model160 := snapshot.ByModelID(160); len(model160) != 1 || model160[0].Disposition != SunSpecChainDispositionUnsupportedLength {
+		t.Fatalf("retained Model 160=%#v", model160)
+	}
+	capability := registry.EvaluateThreePhaseMonitoring(snapshot)
+	if capability.Admitted() || capability.Reason() != SunSpecCapabilityReasonInvalidChain {
+		t.Fatalf("capability admitted=%t reason=%q", capability.Admitted(), capability.Reason())
+	}
+	flavor := registry.EvaluateFroniusObservedFlavor(snapshot)
+	if flavor.Matched() || flavor.Reason() != SunSpecFroniusFlavorReasonCapabilityNotAdmitted {
+		t.Fatalf("flavor matched=%t reason=%q", flavor.Matched(), flavor.Reason())
+	}
+}
+
 func TestFroniusObservedFlavorReasonsAreClosedAndFailClosed(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -37,6 +37,32 @@ func TestFroniusObservedFlavorAcceptsCompletedPublicChainSnapshot(t *testing.T) 
 	}
 }
 
+func TestCapabilityAndFlavorRejectInvalidCommonAndAdmittedGeometry(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	invalidCommon := valid.Occurrences()
+	invalidCommon[0] = commonOccurrence(t, registry, "", "Symo GEN24 10.0", "1.41.11-1", 1)
+	invalidGeometry := valid.Occurrences()
+	invalidGeometry[5] = admittedOccurrence(160, 88, modelWords(t, registry, 160, 88, map[string][]uint16{"N": {3}}), 6)
+
+	for name, occurrences := range map[string][]SunSpecOccurrence{
+		"invalid mandatory Common":   invalidCommon,
+		"invalid Model 160 geometry": invalidGeometry,
+	} {
+		t.Run(name, func(t *testing.T) {
+			snapshot := completedChainSnapshot(t, registry, occurrences...)
+			capability := registry.EvaluateThreePhaseMonitoring(snapshot)
+			if capability.Admitted() || capability.Reason() != SunSpecCapabilityReasonInvalidChain {
+				t.Fatalf("capability admitted=%t reason=%q", capability.Admitted(), capability.Reason())
+			}
+			flavor := registry.EvaluateFroniusObservedFlavor(snapshot)
+			if flavor.Matched() || flavor.Reason() != SunSpecFroniusFlavorReasonCapabilityNotAdmitted {
+				t.Fatalf("flavor matched=%t reason=%q", flavor.Matched(), flavor.Reason())
+			}
+		})
+	}
+}
+
 func TestFroniusObservedFlavorReasonsAreClosedAndFailClosed(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -29,18 +29,21 @@ func TestFroniusObservedFlavorReasonsAreClosedAndFailClosed(t *testing.T) {
 	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
 	identity := froniusObservedSnapshot(t, registry, "fronius", "Symo GEN24 10.0", "1.41.11-1")
 	firmware := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-2")
-	chain := valid
-	chain.occurrences[2], chain.occurrences[3] = chain.occurrences[3], chain.occurrences[2]
-	chain.raw = rawWordsForOccurrences(chain.occurrences)
-	invalidCapability := valid
-	invalidCapability.occurrences[1] = inverterOccurrence(t, registry, 113, map[string][]uint16{"St": {99}}, 2)
-	invalidCapability.raw = rawWordsForOccurrences(invalidCapability.occurrences)
-	ambiguous := valid
-	ambiguous.occurrences = append(ambiguous.occurrences[:2], append([]SunSpecOccurrence{inverterOccurrence(t, registry, 103, nil, 3)}, ambiguous.occurrences[2:]...)...)
-	for index := range ambiguous.occurrences {
-		ambiguous.occurrences[index].Ordinal = uint32(index + 1)
+	chainOccurrences := valid.Occurrences()
+	chainOccurrences[2], chainOccurrences[3] = chainOccurrences[3], chainOccurrences[2]
+	for index := range chainOccurrences {
+		chainOccurrences[index].Ordinal = uint32(index + 1)
 	}
-	ambiguous.raw = rawWordsForOccurrences(ambiguous.occurrences)
+	chain := snapshotFromOccurrences(chainOccurrences...)
+	invalidCapability := cloneSnapshotForTest(valid)
+	invalidCapability.occurrences[1] = inverterOccurrence(t, registry, 113, map[string][]uint16{"St": {99}}, 2)
+	invalidCapability = snapshotFromOccurrences(invalidCapability.occurrences...)
+	ambiguousOccurrences := valid.Occurrences()
+	ambiguousOccurrences = append(ambiguousOccurrences[:2], append([]SunSpecOccurrence{inverterOccurrence(t, registry, 103, nil, 3)}, ambiguousOccurrences[2:]...)...)
+	for index := range ambiguousOccurrences {
+		ambiguousOccurrences[index].Ordinal = uint32(index + 1)
+	}
+	ambiguous := snapshotFromOccurrences(ambiguousOccurrences...)
 
 	tests := map[string]struct {
 		snapshot SunSpecChainSnapshot
@@ -57,6 +60,27 @@ func TestFroniusObservedFlavorReasonsAreClosedAndFailClosed(t *testing.T) {
 			decision := registry.EvaluateFroniusObservedFlavor(tc.snapshot)
 			if decision.Matched() || decision.Reason() != tc.reason {
 				t.Fatalf("matched=%t reason=%q want=%q", decision.Matched(), decision.Reason(), tc.reason)
+			}
+		})
+	}
+}
+
+func TestFroniusObservedFlavorMapsMalformedSnapshotToCapabilityFailure(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	valid := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	missingTerminal := cloneSnapshotForTest(valid)
+	missingTerminal.raw = missingTerminal.raw[:len(missingTerminal.raw)-2]
+	trailing := cloneSnapshotForTest(valid)
+	trailing.raw = append(trailing.raw, 0)
+
+	for name, snapshot := range map[string]SunSpecChainSnapshot{
+		"missing terminal": missingTerminal,
+		"trailing words":   trailing,
+	} {
+		t.Run(name, func(t *testing.T) {
+			decision := registry.EvaluateFroniusObservedFlavor(snapshot)
+			if decision.Matched() || decision.Reason() != SunSpecFroniusFlavorReasonCapabilityNotAdmitted {
+				t.Fatalf("matched=%t reason=%q", decision.Matched(), decision.Reason())
 			}
 		})
 	}

--- a/sunspec_r3_test_helpers_test.go
+++ b/sunspec_r3_test_helpers_test.go
@@ -57,13 +57,43 @@ func capabilitySnapshot(t *testing.T, registry SunSpecDecoderRegistry, modelID u
 }
 
 func snapshotFromOccurrences(occurrences ...SunSpecOccurrence) SunSpecChainSnapshot {
+	cloned := make([]SunSpecOccurrence, len(occurrences))
+	sources := make([]LogicalViewRecord, len(occurrences))
+	header := uint16(40002)
+	for index, occurrence := range occurrences {
+		occurrence = cloneOccurrence(occurrence)
+		occurrence.HeaderOffset = header
+		occurrence.PayloadOffset = header + 2
+		logicalViewID := uint64(index + 1)
+		occurrence.spans = []SunSpecSourceSpan{{LogicalViewID: logicalViewID, PDUOffset: 0, WordCount: uint16(len(occurrence.words))}}
+		cloned[index] = occurrence
+		sources[index] = LogicalViewRecord{
+			LogicalViewID: logicalViewID, WireResponseID: uint64(index + 101), PhysicalRequestID: uint64(index + 201),
+			Endpoint: "fixture-endpoint", ConnectionID: 4, Transport: TransportTCP, TransportGeneration: 5, UnitID: 1,
+			RequestedFunction: FunctionReadHoldingRegisters, ReceivedFunction: FunctionReadHoldingRegisters, Table: HoldingRegisters,
+			PhysicalOffset: header, PhysicalWordCount: uint16(len(occurrence.words)), AuthorizationScope: "fixture-read-only",
+			PollGeneration: 6, DeadlineIdentity: uint64(index + 301), LogicalOffset: header,
+			LogicalWordCount: uint16(len(occurrence.words)), SliceWordCount: uint16(len(occurrence.words)),
+			Words: occurrence.Words(), WireResponseBytes: []byte{0, byte(index + 1)},
+		}
+		header += uint16(len(occurrence.words))
+	}
 	return SunSpecChainSnapshot{
-		occurrences: occurrences,
-		raw:         rawWordsForOccurrences(occurrences),
-		sources: []LogicalViewRecord{{
-			LogicalViewID: 1, WireResponseID: 2, PhysicalRequestID: 3, ConnectionID: 4,
-			TransportGeneration: 5, PollGeneration: 6, Words: []uint16{1}, WireResponseBytes: []byte{0, 1},
-		}},
+		occurrences: cloned,
+		raw:         rawWordsForOccurrences(cloned),
+		sources:     sources,
+	}
+}
+
+func cloneSnapshotForTest(snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {
+	sources := make([]LogicalViewRecord, len(snapshot.sources))
+	for index, source := range snapshot.sources {
+		sources[index] = cloneSunSpecLogicalViewRecord(source)
+	}
+	return SunSpecChainSnapshot{
+		occurrences: snapshot.Occurrences(),
+		raw:         snapshot.RawWords(),
+		sources:     sources,
 	}
 }
 

--- a/sunspec_r3_test_helpers_test.go
+++ b/sunspec_r3_test_helpers_test.go
@@ -1,0 +1,81 @@
+package modbusreg
+
+import (
+	"math"
+	"testing"
+)
+
+func mustStandardSunSpecRegistry(t *testing.T) SunSpecDecoderRegistry {
+	t.Helper()
+	registry, err := NewStandardSunSpecDecoderRegistry(testSunSpecModelsRevision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registry
+}
+
+func commonOccurrence(t *testing.T, registry SunSpecDecoderRegistry, manufacturer, model, firmware string, ordinal uint32) SunSpecOccurrence {
+	t.Helper()
+	return admittedOccurrence(1, 65, modelWords(t, registry, 1, 65, map[string][]uint16{
+		"Mn": stringWords(manufacturer, 16), "Md": stringWords(model, 16), "Vr": stringWords(firmware, 8), "SN": stringWords("sanitized", 16),
+	}), ordinal)
+}
+
+func inverterOccurrence(t *testing.T, registry SunSpecDecoderRegistry, modelID uint16, override map[string][]uint16, ordinal uint32) SunSpecOccurrence {
+	t.Helper()
+	length := uint16(50)
+	values := map[string][]uint16{
+		"A": {1}, "AphA": {1}, "AphB": {1}, "AphC": {1}, "A_SF": {0},
+		"PhVphA": {1}, "PhVphB": {1}, "PhVphC": {1}, "V_SF": {0},
+		"W": {1}, "W_SF": {0}, "Hz": {1}, "Hz_SF": {0}, "WH": {0, 1}, "WH_SF": {0},
+		"TmpCab": {1}, "Tmp_SF": {0}, "St": {4}, "Evt1": {0, 0}, "Evt2": {0, 0},
+	}
+	if modelID == 113 {
+		length = 60
+		for _, name := range []string{"A", "AphA", "AphB", "AphC", "PhVphA", "PhVphB", "PhVphC", "W", "Hz", "WH", "TmpCab"} {
+			values[name] = float32Words(1)
+		}
+		delete(values, "A_SF")
+		delete(values, "V_SF")
+		delete(values, "W_SF")
+		delete(values, "Hz_SF")
+		delete(values, "WH_SF")
+		delete(values, "Tmp_SF")
+	}
+	for name, value := range override {
+		values[name] = value
+	}
+	return admittedOccurrence(modelID, length, modelWords(t, registry, modelID, length, values), ordinal)
+}
+
+func capabilitySnapshot(t *testing.T, registry SunSpecDecoderRegistry, modelID uint16, override map[string][]uint16) SunSpecChainSnapshot {
+	t.Helper()
+	return snapshotFromOccurrences(
+		commonOccurrence(t, registry, "Maker", "Model", "1.0", 1),
+		inverterOccurrence(t, registry, modelID, override, 2),
+	)
+}
+
+func snapshotFromOccurrences(occurrences ...SunSpecOccurrence) SunSpecChainSnapshot {
+	return SunSpecChainSnapshot{
+		occurrences: occurrences,
+		raw:         rawWordsForOccurrences(occurrences),
+		sources: []LogicalViewRecord{{
+			LogicalViewID: 1, WireResponseID: 2, PhysicalRequestID: 3, ConnectionID: 4,
+			TransportGeneration: 5, PollGeneration: 6, Words: []uint16{1}, WireResponseBytes: []byte{0, 1},
+		}},
+	}
+}
+
+func rawWordsForOccurrences(occurrences []SunSpecOccurrence) []uint16 {
+	raw := []uint16{sunSpecSignatureFirst, sunSpecSignatureSecond}
+	for _, occurrence := range occurrences {
+		raw = append(raw, occurrence.Words()...)
+	}
+	return append(raw, sunSpecEndModel, 0)
+}
+
+func float32Words(value float32) []uint16 {
+	bits := math.Float32bits(value)
+	return []uint16{uint16(bits >> 16), uint16(bits)}
+}

--- a/sunspec_r3_test_helpers_test.go
+++ b/sunspec_r3_test_helpers_test.go
@@ -99,6 +99,11 @@ func cloneSnapshotForTest(snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {
 
 func completedChainSnapshot(t *testing.T, registry SunSpecDecoderRegistry, occurrences ...SunSpecOccurrence) SunSpecChainSnapshot {
 	t.Helper()
+	return completedChainSnapshotWithKeys(t, registry.DecoderKeys(), occurrences...)
+}
+
+func completedChainSnapshotWithKeys(t *testing.T, decoderKeys []SunSpecDecoderKey, occurrences ...SunSpecOccurrence) SunSpecChainSnapshot {
+	t.Helper()
 	const base = uint16(40000)
 	raw := rawWordsForOccurrences(occurrences)
 	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
@@ -108,7 +113,7 @@ func completedChainSnapshot(t *testing.T, registry SunSpecDecoderRegistry, occur
 			MaxTotalWords:  uint32(len(raw)),
 			MaxOccurrences: uint32(len(occurrences)),
 		},
-		DecoderKeys: registry.DecoderKeys(),
+		DecoderKeys: decoderKeys,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/sunspec_r3_test_helpers_test.go
+++ b/sunspec_r3_test_helpers_test.go
@@ -97,6 +97,48 @@ func cloneSnapshotForTest(snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {
 	}
 }
 
+func completedChainSnapshot(t *testing.T, registry SunSpecDecoderRegistry, occurrences ...SunSpecOccurrence) SunSpecChainSnapshot {
+	t.Helper()
+	const base = uint16(40000)
+	raw := rawWordsForOccurrences(occurrences)
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: testSunSpecModelsRevision,
+		BaseCandidates: []uint16{base},
+		Limits: SunSpecChainLimits{
+			MaxTotalWords:  uint32(len(raw)),
+			MaxOccurrences: uint32(len(occurrences)),
+		},
+		DecoderKeys: registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	logicalViewID := uint64(1000)
+	for step := 0; step < len(raw); step++ {
+		requests := chain.NextRequests()
+		if len(requests) != 1 {
+			t.Fatalf("pending requests=%d", len(requests))
+		}
+		request := requests[0]
+		start := int(uint32(request.Address()) - uint32(base))
+		end := start + int(request.WordCount())
+		if start < 0 || end > len(raw) {
+			t.Fatalf("request [%d,%d) exceeds raw words %d", start, end, len(raw))
+		}
+		snapshot, err := chain.AdmitReplay(request, chainView(t, request, logicalViewID, raw[start:end], "fixture"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		logicalViewID++
+		if len(snapshot.RawWords()) != 0 {
+			return snapshot
+		}
+	}
+	t.Fatal("SunSpec chain did not reach its terminal snapshot")
+	return SunSpecChainSnapshot{}
+}
+
 func rawWordsForOccurrences(occurrences []SunSpecOccurrence) []uint16 {
 	raw := []uint16{sunSpecSignatureFirst, sunSpecSignatureSecond}
 	for _, occurrence := range occurrences {

--- a/testdata/sunspec/chains/fronius_gen24_float_v1.json
+++ b/testdata/sunspec/chains/fronius_gen24_float_v1.json
@@ -1,0 +1,23 @@
+{
+  "schema": "helianthus-sunspec-fronius-observed-flavor/v1",
+  "flavor_id": "sunspec.flavor.fronius.gen24.float.observed@1.0.0",
+  "manufacturer": "Fronius",
+  "model": "Symo GEN24 10.0",
+  "firmware": "1.41.11-1",
+  "chain": [
+    {"ModelID": 1, "ModelLength": 65},
+    {"ModelID": 113, "ModelLength": 60},
+    {"ModelID": 120, "ModelLength": 26},
+    {"ModelID": 121, "ModelLength": 30},
+    {"ModelID": 122, "ModelLength": 44},
+    {"ModelID": 160, "ModelLength": 88},
+    {"ModelID": 124, "ModelLength": 24},
+    {"ModelID": 65535, "ModelLength": 0}
+  ],
+  "sanitized_observation": {
+    "function": "FC03",
+    "unit_id": 1,
+    "pdu_offset": 40000,
+    "authority": "non_actionable_provenance_only"
+  }
+}


### PR DESCRIPTION
Closes #19

Docs gates:
- `helianthus-docs-ebus@6caca7b355a2310a24d38da36c88cbb4e5f7ada3`
- R3 addendum `helianthus-docs-ebus@b0d04cb75d17b485deafc298387da7728749b557`

RED public exact HEAD: `748f00f3bc72616b1ee2b4425cc93a51d5f3c243`.
GREEN public exact HEAD: `1dd0d346502a4ebeca2f09a6fa323ed7e0116220`.

Review remediation:
- P2 RED: `1b63a2097a413842ec4c1e7c358ce5d772ff79bf` proves invalid mandatory Common and Model 160 geometry were admitted.
- P2 GREEN: `f7fb0c139954d999cc99c7e362228bba7c067001` rejects invalid mandatory Common and admitted Model 160 geometry.
- Follow-up P2 RED: `c6b231843aa7ff4a787dccd17e43bb8877b7eca6` proves an invalid 160 occurrence could bypass geometry when its exact decoder key was omitted.
- Follow-up P2 GREEN: `1dd0d346502a4ebeca2f09a6fa323ed7e0116220` validates retained Model 160 geometry independently of disposition; both paths return `INVALID_CHAIN`, with flavor `CAPABILITY_NOT_ADMITTED`.

Scope:
- encoding-neutral `sunspec.inverter.three_phase.monitoring@1.0.0`;
- exact one-source 103/L50 or 113/L60 admission with 14 required facts;
- exact evidence-bounded Fronius observed flavor;
- raw/source provenance retained; no gateway/acquisition/live/write authority.

TDD:
- RED: `GOWORK=off go test ./...` failed to compile only because the new capability/flavor API and closed reasons did not yet exist.
- GREEN: focused race, full `go test`, vet and `GOWORK=off ./scripts/ci_local.sh` pass; scope mutation tests 14/14 and golangci-lint 0 issues.

Transport gate: N/A. This change consumes completed SunSpec chain snapshots and adds registry semantics only; it does not change Modbus framing, transport, acquisition, or live-device behavior.


