### PR TITLE
FMV3-M4-04 R4: add Model 123 and Fronius flavor v1.1

### DIFF
--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -158,12 +158,25 @@ func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (
 			scale = &value
 		}
 		value := decodeSunSpecValue(point, words[point.offset:point.offset+point.size], scale)
-		if point.mandatory && value.State() != SunSpecValueValid {
+		if point.mandatory && !mandatorySunSpecValueQualifies(value) {
 			model.qualifies = false
 		}
 		model.facts = append(model.facts, SunSpecFact{FieldID: point.fieldID, PointName: point.name, Unit: point.unit, Required: point.required, GroupID: point.groupID, RepeatIndex: point.repeatIndex, Repeated: point.repeated, Value: value})
 	}
 	return model, nil
+}
+
+func mandatorySunSpecValueQualifies(value SunSpecValue) bool {
+	if value.State() != SunSpecValueValid {
+		return false
+	}
+	if _, symbol, ok := value.Enum(); ok {
+		return symbol != ""
+	}
+	if _, unknown, ok := value.Bitfield(); ok {
+		return unknown == 0
+	}
+	return true
 }
 
 func (r SunSpecDecoderRegistry) DecodeChain(snapshot SunSpecChainSnapshot) (SunSpecDecodedChain, error) {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -47,7 +47,8 @@ func TestSunSpecDecoderRegistryUsesExactImmutableKeys(t *testing.T) {
 		{101, 50, testSunSpecModelsRevision}, {102, 50, testSunSpecModelsRevision}, {103, 50, testSunSpecModelsRevision},
 		{111, 60, testSunSpecModelsRevision}, {112, 60, testSunSpecModelsRevision}, {113, 60, testSunSpecModelsRevision},
 		{120, 26, testSunSpecModelsRevision}, {121, 30, testSunSpecModelsRevision},
-		{122, 44, testSunSpecModelsRevision}, {124, 24, testSunSpecModelsRevision},
+		{122, 44, testSunSpecModelsRevision}, {123, 24, testSunSpecModelsRevision},
+		{124, 24, testSunSpecModelsRevision},
 	}
 	sort.Slice(want, func(i, j int) bool {
 		if want[i].ModelID != want[j].ModelID {

--- a/sunspec_fronius.go
+++ b/sunspec_fronius.go
@@ -2,7 +2,10 @@ package modbusreg
 
 import "slices"
 
-const SunSpecFroniusObservedFlavorID = "sunspec.flavor.fronius.gen24.float.observed@1.0.0"
+const (
+	SunSpecFroniusObservedFlavorID    = "sunspec.flavor.fronius.gen24.float.observed@1.0.0"
+	SunSpecFroniusObservedFlavorV11ID = "sunspec.flavor.fronius.gen24.float.observed@1.1.0"
+)
 
 type SunSpecFroniusFlavorReason string
 
@@ -16,6 +19,7 @@ const (
 )
 
 type SunSpecFroniusFlavorDecision struct {
+	flavorID   string
 	matched    bool
 	reason     SunSpecFroniusFlavorReason
 	capability SunSpecCapabilityDecision
@@ -25,7 +29,7 @@ type SunSpecFroniusFlavorDecision struct {
 
 func (d SunSpecFroniusFlavorDecision) Matched() bool                      { return d.matched }
 func (d SunSpecFroniusFlavorDecision) Reason() SunSpecFroniusFlavorReason { return d.reason }
-func (d SunSpecFroniusFlavorDecision) FlavorID() string                   { return SunSpecFroniusObservedFlavorID }
+func (d SunSpecFroniusFlavorDecision) FlavorID() string                   { return d.flavorID }
 func (d SunSpecFroniusFlavorDecision) Capability() SunSpecCapabilityDecision {
 	return cloneSunSpecCapabilityDecision(d.capability)
 }
@@ -47,10 +51,75 @@ var froniusObservedChainV1 = []SunSpecWireKey{
 	{ModelID: sunSpecEndModel, ModelLength: 0},
 }
 
+var froniusObservedChainV11 = []SunSpecWireKey{
+	{ModelID: 1, ModelLength: 65},
+	{ModelID: 113, ModelLength: 60},
+	{ModelID: 120, ModelLength: 26},
+	{ModelID: 121, ModelLength: 30},
+	{ModelID: 122, ModelLength: 44},
+	{ModelID: 123, ModelLength: 24},
+	{ModelID: 160, ModelLength: 88},
+	{ModelID: 124, ModelLength: 24},
+	{ModelID: sunSpecEndModel, ModelLength: 0},
+}
+
+type sunSpecFroniusFlavorDefinition struct {
+	id    string
+	chain []SunSpecWireKey
+}
+
+type SunSpecFroniusFlavorSelectionReason string
+
+const (
+	SunSpecFroniusFlavorSelectionReasonNoMatch        SunSpecFroniusFlavorSelectionReason = "NO_MATCH"
+	SunSpecFroniusFlavorSelectionReasonAmbiguousMatch SunSpecFroniusFlavorSelectionReason = "AMBIGUOUS_MATCH"
+	SunSpecFroniusFlavorSelectionReasonMatched        SunSpecFroniusFlavorSelectionReason = "MATCHED"
+)
+
+type SunSpecFroniusFlavorSelection struct {
+	matched     bool
+	reason      SunSpecFroniusFlavorSelectionReason
+	decision    *SunSpecFroniusFlavorDecision
+	evaluations []SunSpecFroniusFlavorDecision
+}
+
+func (s SunSpecFroniusFlavorSelection) Matched() bool { return s.matched }
+func (s SunSpecFroniusFlavorSelection) Reason() SunSpecFroniusFlavorSelectionReason {
+	return s.reason
+}
+func (s SunSpecFroniusFlavorSelection) Decision() (SunSpecFroniusFlavorDecision, bool) {
+	if s.decision == nil {
+		return SunSpecFroniusFlavorDecision{}, false
+	}
+	return cloneSunSpecFroniusFlavorDecision(*s.decision), true
+}
+func (s SunSpecFroniusFlavorSelection) Evaluations() []SunSpecFroniusFlavorDecision {
+	return cloneSunSpecFroniusFlavorDecisions(s.evaluations)
+}
+
 func (r SunSpecDecoderRegistry) EvaluateFroniusObservedFlavor(snapshot SunSpecChainSnapshot) SunSpecFroniusFlavorDecision {
+	return r.evaluateFroniusObservedFlavor(snapshot, sunSpecFroniusFlavorDefinition{
+		id: SunSpecFroniusObservedFlavorID, chain: froniusObservedChainV1,
+	})
+}
+
+func (r SunSpecDecoderRegistry) EvaluateFroniusObservedFlavorV11(snapshot SunSpecChainSnapshot) SunSpecFroniusFlavorDecision {
+	return r.evaluateFroniusObservedFlavor(snapshot, sunSpecFroniusFlavorDefinition{
+		id: SunSpecFroniusObservedFlavorV11ID, chain: froniusObservedChainV11,
+	})
+}
+
+func (r SunSpecDecoderRegistry) SelectFroniusObservedFlavor(snapshot SunSpecChainSnapshot) SunSpecFroniusFlavorSelection {
+	return selectSunSpecFroniusFlavor([]SunSpecFroniusFlavorDecision{
+		r.EvaluateFroniusObservedFlavor(snapshot),
+		r.EvaluateFroniusObservedFlavorV11(snapshot),
+	})
+}
+
+func (r SunSpecDecoderRegistry) evaluateFroniusObservedFlavor(snapshot SunSpecChainSnapshot, definition sunSpecFroniusFlavorDefinition) SunSpecFroniusFlavorDecision {
 	capability := r.EvaluateThreePhaseMonitoring(snapshot)
 	rejected := func(reason SunSpecFroniusFlavorReason) SunSpecFroniusFlavorDecision {
-		return SunSpecFroniusFlavorDecision{reason: reason, capability: capability}
+		return SunSpecFroniusFlavorDecision{flavorID: definition.id, reason: reason, capability: capability}
 	}
 	if capability.Reason() == SunSpecCapabilityReasonAmbiguousSource {
 		return rejected(SunSpecFroniusFlavorReasonAmbiguousSource)
@@ -76,16 +145,56 @@ func (r SunSpecDecoderRegistry) EvaluateFroniusObservedFlavor(snapshot SunSpecCh
 		return rejected(SunSpecFroniusFlavorReasonFirmwareMismatch)
 	}
 	chain, valid := sunSpecSnapshotWireChain(snapshot)
-	if !valid || !slices.Equal(chain, froniusObservedChainV1) {
+	if !valid || !slices.Equal(chain, definition.chain) {
 		return rejected(SunSpecFroniusFlavorReasonChainMismatch)
 	}
 	return SunSpecFroniusFlavorDecision{
+		flavorID:   definition.id,
 		matched:    true,
 		reason:     SunSpecFroniusFlavorReasonMatched,
 		capability: capability,
 		chain:      chain,
 		views:      snapshot.SourceViews(),
 	}
+}
+
+func selectSunSpecFroniusFlavor(evaluations []SunSpecFroniusFlavorDecision) SunSpecFroniusFlavorSelection {
+	selection := SunSpecFroniusFlavorSelection{
+		reason:      SunSpecFroniusFlavorSelectionReasonNoMatch,
+		evaluations: cloneSunSpecFroniusFlavorDecisions(evaluations),
+	}
+	for index := range evaluations {
+		if !evaluations[index].Matched() {
+			continue
+		}
+		if selection.decision != nil {
+			selection.decision = nil
+			selection.reason = SunSpecFroniusFlavorSelectionReasonAmbiguousMatch
+			return selection
+		}
+		decision := cloneSunSpecFroniusFlavorDecision(evaluations[index])
+		selection.decision = &decision
+	}
+	if selection.decision != nil {
+		selection.matched = true
+		selection.reason = SunSpecFroniusFlavorSelectionReasonMatched
+	}
+	return selection
+}
+
+func cloneSunSpecFroniusFlavorDecision(decision SunSpecFroniusFlavorDecision) SunSpecFroniusFlavorDecision {
+	decision.capability = cloneSunSpecCapabilityDecision(decision.capability)
+	decision.chain = append([]SunSpecWireKey(nil), decision.chain...)
+	decision.views = cloneSunSpecLogicalViewSnapshots(decision.views)
+	return decision
+}
+
+func cloneSunSpecFroniusFlavorDecisions(decisions []SunSpecFroniusFlavorDecision) []SunSpecFroniusFlavorDecision {
+	out := make([]SunSpecFroniusFlavorDecision, len(decisions))
+	for index := range decisions {
+		out[index] = cloneSunSpecFroniusFlavorDecision(decisions[index])
+	}
+	return out
 }
 
 func sunSpecTextFact(model SunSpecDecodedModel, fieldID string) (string, bool) {

--- a/sunspec_fronius.go
+++ b/sunspec_fronius.go
@@ -29,7 +29,12 @@ type SunSpecFroniusFlavorDecision struct {
 
 func (d SunSpecFroniusFlavorDecision) Matched() bool                      { return d.matched }
 func (d SunSpecFroniusFlavorDecision) Reason() SunSpecFroniusFlavorReason { return d.reason }
-func (d SunSpecFroniusFlavorDecision) FlavorID() string                   { return d.flavorID }
+func (d SunSpecFroniusFlavorDecision) FlavorID() string {
+	if d.flavorID == "" {
+		return SunSpecFroniusObservedFlavorID
+	}
+	return d.flavorID
+}
 func (d SunSpecFroniusFlavorDecision) Capability() SunSpecCapabilityDecision {
 	return cloneSunSpecCapabilityDecision(d.capability)
 }

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -182,6 +182,99 @@ func TestFroniusObservedFlavorFixtureIsExactAndNonActionable(t *testing.T) {
 	}
 }
 
+func TestFroniusObservedFlavorV11MatchesOnlyTheModel123Chain(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	v1Snapshot := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	v11Snapshot := froniusObservedSnapshotV11(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+
+	v1 := registry.EvaluateFroniusObservedFlavor(v11Snapshot)
+	if v1.Matched() || v1.Reason() != SunSpecFroniusFlavorReasonChainMismatch || v1.FlavorID() != SunSpecFroniusObservedFlavorID {
+		t.Fatalf("V1 on V1.1 chain matched=%t reason=%q id=%q", v1.Matched(), v1.Reason(), v1.FlavorID())
+	}
+	v11OnV1 := registry.EvaluateFroniusObservedFlavorV11(v1Snapshot)
+	if v11OnV1.Matched() || v11OnV1.Reason() != SunSpecFroniusFlavorReasonChainMismatch || v11OnV1.FlavorID() != SunSpecFroniusObservedFlavorV11ID {
+		t.Fatalf("V1.1 on V1 chain matched=%t reason=%q id=%q", v11OnV1.Matched(), v11OnV1.Reason(), v11OnV1.FlavorID())
+	}
+	v11 := registry.EvaluateFroniusObservedFlavorV11(v11Snapshot)
+	if !v11.Matched() || v11.Reason() != SunSpecFroniusFlavorReasonMatched || v11.FlavorID() != SunSpecFroniusObservedFlavorV11ID {
+		t.Fatalf("V1.1 matched=%t reason=%q id=%q", v11.Matched(), v11.Reason(), v11.FlavorID())
+	}
+	if !v11.Capability().Admitted() || len(v11.Chain()) != 9 || len(v11.SourceViews()) != len(v11Snapshot.SourceViews()) {
+		t.Fatalf("V1.1 capability=%t chain=%v views=%d", v11.Capability().Admitted(), v11.Chain(), len(v11.SourceViews()))
+	}
+}
+
+func TestFroniusObservedFlavorSelectorRequiresExactlyOneMatch(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	for name, snapshot := range map[string]SunSpecChainSnapshot{
+		"v1":   froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1"),
+		"v1.1": froniusObservedSnapshotV11(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			selection := registry.SelectFroniusObservedFlavor(snapshot)
+			if !selection.Matched() || selection.Reason() != SunSpecFroniusFlavorSelectionReasonMatched {
+				t.Fatalf("selection matched=%t reason=%q", selection.Matched(), selection.Reason())
+			}
+			decision, ok := selection.Decision()
+			if !ok || !decision.Matched() {
+				t.Fatalf("selected decision=%#v ok=%v", decision, ok)
+			}
+			wantID := SunSpecFroniusObservedFlavorID
+			if name == "v1.1" {
+				wantID = SunSpecFroniusObservedFlavorV11ID
+			}
+			if decision.FlavorID() != wantID || len(selection.Evaluations()) != 2 {
+				t.Fatalf("selected id=%q evaluations=%d", decision.FlavorID(), len(selection.Evaluations()))
+			}
+		})
+	}
+
+	noMatch := registry.SelectFroniusObservedFlavor(froniusObservedSnapshotV11(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-2"))
+	if noMatch.Matched() || noMatch.Reason() != SunSpecFroniusFlavorSelectionReasonNoMatch {
+		t.Fatalf("no-match matched=%t reason=%q", noMatch.Matched(), noMatch.Reason())
+	}
+	if _, ok := noMatch.Decision(); ok {
+		t.Fatal("no-match selection exposed a decision")
+	}
+
+	matched := registry.EvaluateFroniusObservedFlavor(froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1"))
+	ambiguous := selectSunSpecFroniusFlavor([]SunSpecFroniusFlavorDecision{matched, matched})
+	if ambiguous.Matched() || ambiguous.Reason() != SunSpecFroniusFlavorSelectionReasonAmbiguousMatch {
+		t.Fatalf("ambiguous matched=%t reason=%q", ambiguous.Matched(), ambiguous.Reason())
+	}
+}
+
+func TestFroniusObservedFlavorV11FixtureIsExactAndNonActionable(t *testing.T) {
+	raw, err := os.ReadFile("testdata/sunspec/chains/fronius_gen24_float_v1_1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		Schema       string           `json:"schema"`
+		FlavorID     string           `json:"flavor_id"`
+		Manufacturer string           `json:"manufacturer"`
+		Model        string           `json:"model"`
+		Firmware     string           `json:"firmware"`
+		Chain        []SunSpecWireKey `json:"chain"`
+		Observation  struct {
+			Function  string `json:"function"`
+			UnitID    uint16 `json:"unit_id"`
+			PDUOffset uint16 `json:"pdu_offset"`
+			Authority string `json:"authority"`
+		} `json:"sanitized_observation"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	wantChain := []SunSpecWireKey{{1, 65}, {113, 60}, {120, 26}, {121, 30}, {122, 44}, {123, 24}, {160, 88}, {124, 24}, {0xffff, 0}}
+	if fixture.Schema != "helianthus-sunspec-fronius-observed-flavor/v1.1" || fixture.FlavorID != SunSpecFroniusObservedFlavorV11ID || fixture.Manufacturer != "Fronius" || fixture.Model != "Symo GEN24 10.0" || fixture.Firmware != "1.41.11-1" || !reflect.DeepEqual(fixture.Chain, wantChain) {
+		t.Fatalf("fixture=%+v", fixture)
+	}
+	if fixture.Observation.Function != "FC03" || fixture.Observation.UnitID != 1 || fixture.Observation.PDUOffset != 40000 || fixture.Observation.Authority != "non_actionable_provenance_only" {
+		t.Fatalf("observation=%+v", fixture.Observation)
+	}
+}
+
 func froniusObservedSnapshot(t *testing.T, registry SunSpecDecoderRegistry, manufacturer, model, firmware string) SunSpecChainSnapshot {
 	t.Helper()
 	occurrences := []SunSpecOccurrence{
@@ -192,6 +285,21 @@ func froniusObservedSnapshot(t *testing.T, registry SunSpecDecoderRegistry, manu
 		admittedOccurrence(122, 44, modelWords(t, registry, 122, 44, nil), 5),
 		admittedOccurrence(160, 88, modelWords(t, registry, 160, 88, map[string][]uint16{"N": {4}}), 6),
 		admittedOccurrence(124, 24, modelWords(t, registry, 124, 24, nil), 7),
+	}
+	return snapshotFromOccurrences(occurrences...)
+}
+
+func froniusObservedSnapshotV11(t *testing.T, registry SunSpecDecoderRegistry, manufacturer, model, firmware string) SunSpecChainSnapshot {
+	t.Helper()
+	occurrences := []SunSpecOccurrence{
+		commonOccurrence(t, registry, manufacturer, model, firmware, 1),
+		inverterOccurrence(t, registry, 113, nil, 2),
+		admittedOccurrence(120, 26, modelWords(t, registry, 120, 26, nil), 3),
+		admittedOccurrence(121, 30, modelWords(t, registry, 121, 30, nil), 4),
+		admittedOccurrence(122, 44, modelWords(t, registry, 122, 44, nil), 5),
+		admittedOccurrence(123, 24, modelWords(t, registry, 123, 24, validModel123Values()), 6),
+		admittedOccurrence(160, 88, modelWords(t, registry, 160, 88, map[string][]uint16{"N": {4}}), 7),
+		admittedOccurrence(124, 24, modelWords(t, registry, 124, 24, nil), 8),
 	}
 	return snapshotFromOccurrences(occurrences...)
 }

--- a/sunspec_fronius_test.go
+++ b/sunspec_fronius_test.go
@@ -24,6 +24,13 @@ func TestFroniusObservedFlavorMatchesOnlyExactEvidenceTuple(t *testing.T) {
 	}
 }
 
+func TestFroniusFlavorDecisionZeroValuePreservesV1Identity(t *testing.T) {
+	var decision SunSpecFroniusFlavorDecision
+	if decision.FlavorID() != SunSpecFroniusObservedFlavorID {
+		t.Fatalf("zero-value flavor id=%q want=%q", decision.FlavorID(), SunSpecFroniusObservedFlavorID)
+	}
+}
+
 func TestFroniusObservedFlavorAcceptsCompletedPublicChainSnapshot(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	fixture := froniusObservedSnapshot(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -75,6 +75,7 @@ func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecM
 		{120, 26, nameplateSunSpecPoints()},
 		{121, 30, settingsSunSpecPoints()},
 		{122, 44, statusSunSpecPoints()},
+		{123, 24, immediateControlsSunSpecPoints()},
 		{124, 24, storageSunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)

--- a/sunspec_models_controls.go
+++ b/sunspec_models_controls.go
@@ -1,0 +1,32 @@
+package modbusreg
+
+func immediateControlsSunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		extendedSunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", true),
+		extendedSunSpecPoint("Conn_WinTms", "der.control.connection.window_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("Conn_RvrtTms", "der.control.connection.revert_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecEnum("Conn", "der.control.connection.command", true, map[uint64]string{0: "DISCONNECT", 1: "CONNECT"}),
+		extendedSunSpecPoint("WMaxLimPct", "der.control.active_power_limit.percent", SunSpecTypeUint16, 1, "% WMax", "WMaxLimPct_SF", true),
+		extendedSunSpecPoint("WMaxLimPct_WinTms", "der.control.active_power_limit.window_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("WMaxLimPct_RvrtTms", "der.control.active_power_limit.revert_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("WMaxLimPct_RmpTms", "der.control.active_power_limit.ramp_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecEnum("WMaxLim_Ena", "der.control.active_power_limit.enabled", true, map[uint64]string{0: "DISABLED", 1: "ENABLED"}),
+		extendedSunSpecPoint("OutPFSet", "der.control.power_factor.setpoint", SunSpecTypeInt16, 1, "cos()", "OutPFSet_SF", true),
+		extendedSunSpecPoint("OutPFSet_WinTms", "der.control.power_factor.window_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("OutPFSet_RvrtTms", "der.control.power_factor.revert_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("OutPFSet_RmpTms", "der.control.power_factor.ramp_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecEnum("OutPFSet_Ena", "der.control.power_factor.enabled", true, map[uint64]string{0: "DISABLED", 1: "ENABLED"}),
+		extendedSunSpecPoint("VArWMaxPct", "der.control.reactive_power.percent_wmax", SunSpecTypeInt16, 1, "% WMax", "VArPct_SF", false),
+		extendedSunSpecPoint("VArMaxPct", "der.control.reactive_power.percent_var_max", SunSpecTypeInt16, 1, "% VArMax", "VArPct_SF", false),
+		extendedSunSpecPoint("VArAvalPct", "der.control.reactive_power.percent_var_available", SunSpecTypeInt16, 1, "% VArAval", "VArPct_SF", false),
+		extendedSunSpecPoint("VArPct_WinTms", "der.control.reactive_power.window_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("VArPct_RvrtTms", "der.control.reactive_power.revert_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecPoint("VArPct_RmpTms", "der.control.reactive_power.ramp_seconds", SunSpecTypeUint16, 1, "Secs", "", false),
+		extendedSunSpecEnum("VArPct_Mod", "der.control.reactive_power.mode", false, map[uint64]string{0: "NONE", 1: "WMax", 2: "VArMax", 3: "VArAval"}),
+		extendedSunSpecEnum("VArPct_Ena", "der.control.reactive_power.enabled", true, map[uint64]string{0: "DISABLED", 1: "ENABLED"}),
+		extendedSunSpecPoint("WMaxLimPct_SF", "der.control.scale.active_power_limit", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("OutPFSet_SF", "der.control.scale.power_factor", SunSpecTypeScaleFactor, 1, "", "", true),
+		extendedSunSpecPoint("VArPct_SF", "der.control.scale.reactive_power", SunSpecTypeScaleFactor, 1, "", "", false),
+	}
+}

--- a/sunspec_models_controls_test.go
+++ b/sunspec_models_controls_test.go
@@ -1,0 +1,131 @@
+package modbusreg
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestSunSpecModel123CatalogMatchesPinnedImmediateControls(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	key := SunSpecDecoderKey{ModelID: 123, ModelLength: 24, SchemaRevision: testSunSpecModelsRevision}
+	definition, ok := registry.definition(key)
+	if !ok {
+		t.Fatal("standard Model 123/L24 decoder key absent")
+	}
+	if _, wrongLength := registry.definition(SunSpecDecoderKey{ModelID: 123, ModelLength: 23, SchemaRevision: testSunSpecModelsRevision}); wrongLength {
+		t.Fatal("Model 123 admitted by ID without exact length")
+	}
+
+	want := "ID:uint16:1,L:uint16:1,Conn_WinTms:uint16:1,Conn_RvrtTms:uint16:1,Conn:enum16:1,WMaxLimPct:uint16:1,WMaxLimPct_WinTms:uint16:1,WMaxLimPct_RvrtTms:uint16:1,WMaxLimPct_RmpTms:uint16:1,WMaxLim_Ena:enum16:1,OutPFSet:int16:1,OutPFSet_WinTms:uint16:1,OutPFSet_RvrtTms:uint16:1,OutPFSet_RmpTms:uint16:1,OutPFSet_Ena:enum16:1,VArWMaxPct:int16:1,VArMaxPct:int16:1,VArAvalPct:int16:1,VArPct_WinTms:uint16:1,VArPct_RvrtTms:uint16:1,VArPct_RmpTms:uint16:1,VArPct_Mod:enum16:1,VArPct_Ena:enum16:1,WMaxLimPct_SF:sunssf:1,OutPFSet_SF:sunssf:1,VArPct_SF:sunssf:1"
+	got := make([]string, len(definition.points))
+	var extent uint16
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d", point.name, point.pointType, point.size)
+		if point.offset != extent {
+			t.Fatalf("point %s offset=%d want=%d", point.name, point.offset, extent)
+		}
+		extent += point.size
+	}
+	if joined := joinSunSpecCatalog(got); joined != want {
+		t.Fatalf("Model 123 catalog\n%s\nwant\n%s", joined, want)
+	}
+	if extent != 26 {
+		t.Fatalf("Model 123 extent=%d want=26 header+payload words", extent)
+	}
+}
+
+func TestSunSpecModel123DecodesReadOnlyTypedFacts(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	words := modelWords(t, registry, 123, 24, validModel123Values())
+	occurrence := admittedOccurrence(123, 24, words, 6)
+	occurrence.spans = []SunSpecSourceSpan{{LogicalViewID: 77, PDUOffset: 4, WordCount: 26}}
+	decoded, err := registry.DecodeOccurrence(occurrence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.Qualifies() || decoded.Key() != (SunSpecDecoderKey{123, 24, testSunSpecModelsRevision}) || decoded.Topology() != SunSpecTopologyNone {
+		t.Fatalf("decoded qualifies=%t key=%#v topology=%q", decoded.Qualifies(), decoded.Key(), decoded.Topology())
+	}
+	if !reflect.DeepEqual(decoded.RawWords(), words) || !reflect.DeepEqual(decoded.SourceSpans(), occurrence.SourceSpans()) {
+		t.Fatal("Model 123 raw words or provenance were not retained")
+	}
+
+	connection := mustSunSpecFact(t, decoded, "der.control.connection.command")
+	if number, symbol, ok := connection.Value.Enum(); !ok || number != 1 || symbol != "CONNECT" {
+		t.Fatalf("connection=%d/%q/%v", number, symbol, ok)
+	}
+	activeLimit := mustSunSpecFact(t, decoded, "der.control.active_power_limit.percent")
+	if decimal, ok := activeLimit.Value.Decimal(); !ok || decimal != (SunSpecDecimal{Coefficient: 500, Exponent: -1}) {
+		t.Fatalf("active limit=%#v/%v", decimal, ok)
+	}
+	powerFactor := mustSunSpecFact(t, decoded, "der.control.power_factor.setpoint")
+	if decimal, ok := powerFactor.Value.Decimal(); !ok || decimal != (SunSpecDecimal{Coefficient: 950, Exponent: -3}) {
+		t.Fatalf("power factor=%#v/%v", decimal, ok)
+	}
+	mode := mustSunSpecFact(t, decoded, "der.control.reactive_power.mode")
+	if number, symbol, ok := mode.Value.Enum(); !ok || number != 3 || symbol != "VAR_AVAIL" {
+		t.Fatalf("reactive mode=%d/%q/%v", number, symbol, ok)
+	}
+}
+
+func TestSunSpecModel123MandatoryUnknownAndSentinelFailClosed(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	tests := map[string]struct {
+		point string
+		words []uint16
+		state SunSpecValueState
+	}{
+		"unknown connection enum": {point: "Conn", words: []uint16{9}, state: SunSpecValueValid},
+		"missing active limit":    {point: "WMaxLimPct", words: []uint16{0xffff}, state: SunSpecValueNotImplemented},
+		"missing scale factor":    {point: "OutPFSet_SF", words: []uint16{0x8000}, state: SunSpecValueNotImplemented},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			values := validModel123Values()
+			values[tc.point] = tc.words
+			words := modelWords(t, registry, 123, 24, values)
+			decoded, err := registry.DecodeOccurrence(admittedOccurrence(123, 24, words, 1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decoded.Qualifies() {
+				t.Fatal("invalid mandatory Model 123 value qualified")
+			}
+			var pointFact SunSpecFact
+			for _, fact := range decoded.Facts() {
+				if fact.PointName == tc.point {
+					pointFact = fact
+					break
+				}
+			}
+			if pointFact.PointName == "" || pointFact.Value.State() != tc.state || !reflect.DeepEqual(pointFact.Value.RawWords(), tc.words) {
+				t.Fatalf("point=%q state=%q raw=%v", pointFact.PointName, pointFact.Value.State(), pointFact.Value.RawWords())
+			}
+		})
+	}
+}
+
+func validModel123Values() map[string][]uint16 {
+	return map[string][]uint16{
+		"Conn":          {1},
+		"WMaxLimPct":    {500},
+		"WMaxLim_Ena":   {1},
+		"OutPFSet":      {950},
+		"OutPFSet_Ena":  {1},
+		"VArPct_Mod":    {3},
+		"VArPct_Ena":    {0},
+		"WMaxLimPct_SF": {0xffff},
+		"OutPFSet_SF":   {0xfffd},
+		"VArPct_SF":     {0xffff},
+	}
+}
+
+func mustSunSpecFact(t *testing.T, model SunSpecDecodedModel, fieldID string) SunSpecFact {
+	t.Helper()
+	fact, ok := model.Fact(fieldID)
+	if !ok {
+		t.Fatalf("fact %q absent", fieldID)
+	}
+	return fact
+}

--- a/sunspec_models_controls_test.go
+++ b/sunspec_models_controls_test.go
@@ -1,7 +1,9 @@
 package modbusreg
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -35,6 +37,40 @@ func TestSunSpecModel123CatalogMatchesPinnedImmediateControls(t *testing.T) {
 	}
 }
 
+func TestSunSpecModel123GoldenMetadataMatchesCatalog(t *testing.T) {
+	data, err := os.ReadFile("testdata/sunspec/models/v1/model_123.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		SourceCommit string   `json:"source_commit"`
+		ID           uint16   `json:"id"`
+		Length       uint16   `json:"length"`
+		PointCount   int      `json:"point_count"`
+		Mandatory    []string `json:"mandatory"`
+	}
+	if err := json.Unmarshal(data, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	if fixture.SourceCommit != "7abdf8982d5364f8ae916deee18aac86c11be36d" || fixture.ID != 123 || fixture.Length != 24 {
+		t.Fatalf("unpinned Model 123 fixture: %#v", fixture)
+	}
+	registry := mustStandardSunSpecRegistry(t)
+	definition, ok := registry.definition(SunSpecDecoderKey{fixture.ID, fixture.Length, testSunSpecModelsRevision})
+	if !ok || len(definition.points) != fixture.PointCount {
+		t.Fatalf("Model 123 points=%d ok=%v", len(definition.points), ok)
+	}
+	var mandatory []string
+	for _, point := range definition.points {
+		if point.mandatory {
+			mandatory = append(mandatory, point.name)
+		}
+	}
+	if !reflect.DeepEqual(mandatory, fixture.Mandatory) {
+		t.Fatalf("Model 123 mandatory=%v want=%v", mandatory, fixture.Mandatory)
+	}
+}
+
 func TestSunSpecModel123DecodesReadOnlyTypedFacts(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	words := modelWords(t, registry, 123, 24, validModel123Values())
@@ -64,7 +100,7 @@ func TestSunSpecModel123DecodesReadOnlyTypedFacts(t *testing.T) {
 		t.Fatalf("power factor=%#v/%v", decimal, ok)
 	}
 	mode := mustSunSpecFact(t, decoded, "der.control.reactive_power.mode")
-	if number, symbol, ok := mode.Value.Enum(); !ok || number != 3 || symbol != "VAR_AVAIL" {
+	if number, symbol, ok := mode.Value.Enum(); !ok || number != 3 || symbol != "VArAval" {
 		t.Fatalf("reactive mode=%d/%q/%v", number, symbol, ok)
 	}
 }

--- a/sunspec_models_controls_test.go
+++ b/sunspec_models_controls_test.go
@@ -71,6 +71,30 @@ func TestSunSpecModel123GoldenMetadataMatchesCatalog(t *testing.T) {
 	}
 }
 
+func TestSunSpecModel123EnumSymbolsMatchPinnedCatalog(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	definition, ok := registry.definition(SunSpecDecoderKey{123, 24, testSunSpecModelsRevision})
+	if !ok {
+		t.Fatal("Model 123 definition absent")
+	}
+	want := map[string]map[uint64]string{
+		"Conn":         {0: "DISCONNECT", 1: "CONNECT"},
+		"WMaxLim_Ena":  {0: "DISABLED", 1: "ENABLED"},
+		"OutPFSet_Ena": {0: "DISABLED", 1: "ENABLED"},
+		"VArPct_Mod":   {0: "NONE", 1: "WMax", 2: "VArMax", 3: "VArAval"},
+		"VArPct_Ena":   {0: "DISABLED", 1: "ENABLED"},
+	}
+	got := make(map[string]map[uint64]string)
+	for _, point := range definition.points {
+		if point.pointType == SunSpecTypeEnum16 {
+			got[point.name] = cloneSunSpecSymbols(point.symbols)
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 123 enum symbols=%v want=%v", got, want)
+	}
+}
+
 func TestSunSpecModel123DecodesReadOnlyTypedFacts(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	words := modelWords(t, registry, 123, 24, validModel123Values())

--- a/testdata/sunspec/chains/fronius_gen24_float_v1_1.json
+++ b/testdata/sunspec/chains/fronius_gen24_float_v1_1.json
@@ -1,0 +1,24 @@
+{
+  "schema": "helianthus-sunspec-fronius-observed-flavor/v1.1",
+  "flavor_id": "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+  "manufacturer": "Fronius",
+  "model": "Symo GEN24 10.0",
+  "firmware": "1.41.11-1",
+  "chain": [
+    {"ModelID": 1, "ModelLength": 65},
+    {"ModelID": 113, "ModelLength": 60},
+    {"ModelID": 120, "ModelLength": 26},
+    {"ModelID": 121, "ModelLength": 30},
+    {"ModelID": 122, "ModelLength": 44},
+    {"ModelID": 123, "ModelLength": 24},
+    {"ModelID": 160, "ModelLength": 88},
+    {"ModelID": 124, "ModelLength": 24},
+    {"ModelID": 65535, "ModelLength": 0}
+  ],
+  "sanitized_observation": {
+    "function": "FC03",
+    "unit_id": 1,
+    "pdu_offset": 40000,
+    "authority": "non_actionable_provenance_only"
+  }
+}

--- a/testdata/sunspec/models/v1/catalog.json
+++ b/testdata/sunspec/models/v1/catalog.json
@@ -13,6 +13,7 @@
     {"id": 120, "length": 26, "points": 28},
     {"id": 121, "length": 30, "points": 32},
     {"id": 122, "length": 44, "points": 22},
+    {"id": 123, "length": 24, "points": 26},
     {"id": 124, "length": 24, "points": 26},
     {"id": 160, "length": 88, "points": 49}
   ]

--- a/testdata/sunspec/models/v1/model_123.json
+++ b/testdata/sunspec/models/v1/model_123.json
@@ -1,0 +1,18 @@
+{
+  "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d",
+  "id": 123,
+  "length": 24,
+  "point_count": 26,
+  "mandatory": [
+    "ID",
+    "L",
+    "Conn",
+    "WMaxLimPct",
+    "WMaxLim_Ena",
+    "OutPFSet",
+    "OutPFSet_Ena",
+    "VArPct_Ena",
+    "WMaxLimPct_SF",
+    "OutPFSet_SF"
+  ]
+}


### PR DESCRIPTION
Closes #21

## Scope
- standard SunSpec Model 123/L24 exact-key read-only decoder
- mandatory enum/bitfield semantic fail-closed with raw retention
- immutable Fronius flavor 1.0.0 plus exact flavor 1.1.0
- registry-owned exact-one flavor selection
- pinned Model 123 and Fronius V1.1 fixtures

## TDD
- R4A RED cfed72e5f98ab2a4d57b2f30c653f56f93e9e5f3: Model 123/L24 absent
- R4A GREEN 4d0b05523d18d7090a5260cabcb759d28e93aeb3
- R4B RED c7d2912238506d539da31ac3fbb0f422728e1fd8: V1.1 and selector API absent
- R4B GREEN 6ebb2562d2005ee507ac5274020f5b4bfd2d8ad9

## Validation
- focused Model 123 race tests PASS
- focused Fronius flavor race tests PASS
- full go test -race -count=1 ./... PASS
- full scripts/ci_local.sh PASS
- scope policy 14 tests PASS
- gofmt, vet, build, golangci-lint 2.11.4 PASS with 0 issues
- T01..T88 N/A: no transport or wire-path change

## Dependencies and safety
- docs gate b70063ff8f803f32768059290f2b02f84e1d542d
- FC03/read-only ownership; no write API or Modbus transport
- no gateway, publication, live-device, or private-binding change
- old V1 evaluator and fixture remain unchanged