### PR TITLE
FMV3-M4-04 R6A: retain canonical SunSpec qualification observation

### DIFF
--- a/sunspec_qualification_observation.go
+++ b/sunspec_qualification_observation.go
@@ -3,6 +3,7 @@ package modbusreg
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 const sunSpecQualificationObservationSchema = "helianthus-sunspec-qualification-observation/v1"
@@ -159,7 +160,28 @@ func cloneSunSpecQualificationSnapshot(snapshot SunSpecChainSnapshot) SunSpecCha
 }
 
 func (observation SunSpecQualificationObservation) MarshalJSON() ([]byte, error) {
-	occurrences := observation.Occurrences()
+	snapshot, identity, err := validateSunSpecQualificationSnapshot(observation.snapshot)
+	if err != nil {
+		return nil, fmt.Errorf("SunSpec qualification observation cannot serialize invalid retained snapshot: %w", err)
+	}
+	chain, terminal := sunSpecSnapshotWireChain(snapshot)
+	if !terminal || !reflect.DeepEqual(observation.chain, chain) {
+		return nil, fmt.Errorf("SunSpec qualification observation cannot serialize inconsistent chain")
+	}
+	expectedSampleID := fmt.Sprintf("sunspec-%d-%d", identity.pollGeneration, identity.deadlineIdentity)
+	if observation.sampleID == "" || observation.sampleID != expectedSampleID || observation.identity != identity {
+		return nil, fmt.Errorf("SunSpec qualification observation cannot serialize inconsistent sample identity")
+	}
+	capability := observation.Capability()
+	if !capability.Admitted() || capability.Reason() != SunSpecCapabilityReasonAdmitted || capability.ProfileID() != SunSpecThreePhaseMonitoringCapabilityID {
+		return nil, fmt.Errorf("SunSpec qualification observation cannot serialize non-admitted capability")
+	}
+	flavor := observation.Flavor()
+	if !flavor.Matched() || flavor.Reason() != SunSpecFroniusFlavorReasonMatched || !supportedSunSpecQualificationFlavorID(flavor.FlavorID()) || !reflect.DeepEqual(flavor.Chain(), chain) || !reflect.DeepEqual(flavor.SourceViews(), snapshot.SourceViews()) {
+		return nil, fmt.Errorf("SunSpec qualification observation cannot serialize inconsistent flavor")
+	}
+
+	occurrences := snapshot.Occurrences()
 	encodedOccurrences := make([]sunSpecQualificationOccurrenceJSON, len(occurrences))
 	for index, occurrence := range occurrences {
 		key, hasKey := occurrence.DecoderKey()
@@ -178,36 +200,44 @@ func (observation SunSpecQualificationObservation) MarshalJSON() ([]byte, error)
 			encodedOccurrences[index].DecoderKey = &keyCopy
 		}
 	}
-	views := observation.SourceViews()
+	views := snapshot.SourceViews()
 	encodedViews := make([]sunSpecQualificationLogicalViewJSON, len(views))
 	for index, view := range views {
 		encodedViews[index] = newSunSpecQualificationLogicalViewJSON(view.Record())
 	}
 	return json.Marshal(sunSpecQualificationObservationJSON{
-		Schema:       sunSpecQualificationObservationSchema,
-		CapabilityID: observation.Capability().ProfileID(),
-		FlavorID:     observation.Flavor().FlavorID(),
-		SampleID:     observation.SampleID(),
+		Schema:           sunSpecQualificationObservationSchema,
+		CapabilityID:     capability.ProfileID(),
+		CapabilityReason: capability.Reason(),
+		FlavorID:         flavor.FlavorID(),
+		FlavorReason:     flavor.Reason(),
+		SampleID:         observation.SampleID(),
 		SampleIdentity: sunSpecQualificationSampleIdentityJSON{
-			PollGeneration: observation.identity.pollGeneration, DeadlineIdentity: observation.identity.deadlineIdentity,
+			PollGeneration: identity.pollGeneration, DeadlineIdentity: identity.deadlineIdentity,
 		},
-		Chain:       observation.Chain(),
-		RawWords:    observation.RawWords(),
+		Chain:       append([]SunSpecWireKey(nil), chain...),
+		RawWords:    snapshot.RawWords(),
 		Occurrences: encodedOccurrences,
 		SourceViews: encodedViews,
 	})
 }
 
+func supportedSunSpecQualificationFlavorID(flavorID string) bool {
+	return flavorID == SunSpecFroniusObservedFlavorID || flavorID == SunSpecFroniusObservedFlavorV11ID
+}
+
 type sunSpecQualificationObservationJSON struct {
-	Schema         string                                 `json:"schema"`
-	CapabilityID   string                                 `json:"capability_id"`
-	FlavorID       string                                 `json:"flavor_id"`
-	SampleID       string                                 `json:"sample_id"`
-	SampleIdentity sunSpecQualificationSampleIdentityJSON `json:"sample_identity"`
-	Chain          []SunSpecWireKey                       `json:"chain"`
-	RawWords       []uint16                               `json:"raw_words"`
-	Occurrences    []sunSpecQualificationOccurrenceJSON   `json:"occurrences"`
-	SourceViews    []sunSpecQualificationLogicalViewJSON  `json:"source_views"`
+	Schema           string                                 `json:"schema"`
+	CapabilityID     string                                 `json:"capability_id"`
+	CapabilityReason SunSpecCapabilityReason                `json:"capability_reason"`
+	FlavorID         string                                 `json:"flavor_id"`
+	FlavorReason     SunSpecFroniusFlavorReason             `json:"flavor_reason"`
+	SampleID         string                                 `json:"sample_id"`
+	SampleIdentity   sunSpecQualificationSampleIdentityJSON `json:"sample_identity"`
+	Chain            []SunSpecWireKey                       `json:"chain"`
+	RawWords         []uint16                               `json:"raw_words"`
+	Occurrences      []sunSpecQualificationOccurrenceJSON   `json:"occurrences"`
+	SourceViews      []sunSpecQualificationLogicalViewJSON  `json:"source_views"`
 }
 
 type sunSpecQualificationSampleIdentityJSON struct {

--- a/sunspec_qualification_observation.go
+++ b/sunspec_qualification_observation.go
@@ -1,0 +1,265 @@
+package modbusreg
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const sunSpecQualificationObservationSchema = "helianthus-sunspec-qualification-observation/v1"
+
+// SunSpecQualificationSampleIdentity is the capture identity shared by every
+// retained source view of one qualification observation.
+type SunSpecQualificationSampleIdentity struct {
+	pollGeneration   uint64
+	deadlineIdentity uint64
+}
+
+func (identity SunSpecQualificationSampleIdentity) PollGeneration() uint64 {
+	return identity.pollGeneration
+}
+
+func (identity SunSpecQualificationSampleIdentity) DeadlineIdentity() uint64 {
+	return identity.deadlineIdentity
+}
+
+// SunSpecQualificationReplay is an immutable detached replay image.
+type SunSpecQualificationReplay struct{ snapshot SunSpecChainSnapshot }
+
+func (replay SunSpecQualificationReplay) RawWords() []uint16 {
+	return replay.snapshot.RawWords()
+}
+
+func (replay SunSpecQualificationReplay) Occurrences() []SunSpecOccurrence {
+	return replay.snapshot.Occurrences()
+}
+
+func (replay SunSpecQualificationReplay) SourceViews() []LogicalViewSnapshot {
+	return replay.snapshot.SourceViews()
+}
+
+// SunSpecQualificationObservation is the registry-owned, transport-neutral
+// evidence record for one terminal-qualified SunSpec capture.
+type SunSpecQualificationObservation struct {
+	capability SunSpecCapabilityDecision
+	flavor     SunSpecFroniusFlavorDecision
+	chain      []SunSpecWireKey
+	sampleID   string
+	identity   SunSpecQualificationSampleIdentity
+	snapshot   SunSpecChainSnapshot
+}
+
+// NewSunSpecQualificationObservation derives qualification only from the
+// supplied registry and complete source-backed snapshot. It never accepts a
+// caller verdict, flavor selection, or sample identity.
+func NewSunSpecQualificationObservation(registry SunSpecDecoderRegistry, input SunSpecChainSnapshot) (SunSpecQualificationObservation, error) {
+	snapshot, identity, err := validateSunSpecQualificationSnapshot(input)
+	if err != nil {
+		return SunSpecQualificationObservation{}, err
+	}
+	chain, valid := sunSpecSnapshotWireChain(snapshot)
+	if !valid {
+		return SunSpecQualificationObservation{}, fmt.Errorf("SunSpec qualification chain is not terminal verified")
+	}
+	capability := registry.EvaluateThreePhaseMonitoring(snapshot)
+	if !capability.Admitted() || capability.Reason() != SunSpecCapabilityReasonAdmitted {
+		return SunSpecQualificationObservation{}, fmt.Errorf("SunSpec qualification capability is not admitted")
+	}
+	selection := registry.SelectFroniusObservedFlavor(snapshot)
+	if !selection.Matched() || selection.Reason() != SunSpecFroniusFlavorSelectionReasonMatched {
+		return SunSpecQualificationObservation{}, fmt.Errorf("SunSpec qualification flavor is not uniquely matched")
+	}
+	flavor, ok := selection.Decision()
+	if !ok || !flavor.Matched() || flavor.Reason() != SunSpecFroniusFlavorReasonMatched {
+		return SunSpecQualificationObservation{}, fmt.Errorf("SunSpec qualification flavor decision is invalid")
+	}
+	return SunSpecQualificationObservation{
+		capability: cloneSunSpecCapabilityDecision(capability),
+		flavor:     cloneSunSpecFroniusFlavorDecision(flavor),
+		chain:      append([]SunSpecWireKey(nil), chain...),
+		sampleID:   fmt.Sprintf("sunspec-%d-%d", identity.pollGeneration, identity.deadlineIdentity),
+		identity:   identity,
+		snapshot:   cloneSunSpecQualificationSnapshot(snapshot),
+	}, nil
+}
+
+func (observation SunSpecQualificationObservation) Capability() SunSpecCapabilityDecision {
+	return cloneSunSpecCapabilityDecision(observation.capability)
+}
+
+func (observation SunSpecQualificationObservation) Flavor() SunSpecFroniusFlavorDecision {
+	return cloneSunSpecFroniusFlavorDecision(observation.flavor)
+}
+
+func (observation SunSpecQualificationObservation) Chain() []SunSpecWireKey {
+	return append([]SunSpecWireKey(nil), observation.chain...)
+}
+
+func (observation SunSpecQualificationObservation) SampleID() string { return observation.sampleID }
+
+func (observation SunSpecQualificationObservation) SampleIdentity() SunSpecQualificationSampleIdentity {
+	return observation.identity
+}
+
+func (observation SunSpecQualificationObservation) RawWords() []uint16 {
+	return observation.snapshot.RawWords()
+}
+
+func (observation SunSpecQualificationObservation) Occurrences() []SunSpecOccurrence {
+	return observation.snapshot.Occurrences()
+}
+
+func (observation SunSpecQualificationObservation) SourceViews() []LogicalViewSnapshot {
+	return observation.snapshot.SourceViews()
+}
+
+func (observation SunSpecQualificationObservation) Replay() (SunSpecQualificationReplay, error) {
+	if _, _, err := validateSunSpecQualificationSnapshot(observation.snapshot); err != nil {
+		return SunSpecQualificationReplay{}, err
+	}
+	return SunSpecQualificationReplay{snapshot: cloneSunSpecQualificationSnapshot(observation.snapshot)}, nil
+}
+
+func validateSunSpecQualificationSnapshot(input SunSpecChainSnapshot) (SunSpecChainSnapshot, SunSpecQualificationSampleIdentity, error) {
+	if len(input.raw) < 4 || len(input.raw) > MaxSunSpecPhaseOneChainWords || len(input.occurrences) == 0 || len(input.occurrences) > MaxSunSpecPhaseOneChainWords/2 || len(input.sources) == 0 || len(input.sources) > MaxSunSpecPhaseOneChainWords {
+		return SunSpecChainSnapshot{}, SunSpecQualificationSampleIdentity{}, fmt.Errorf("SunSpec qualification bounds are invalid")
+	}
+	sources := make([]LogicalViewRecord, len(input.sources))
+	first := input.sources[0]
+	if first.PollGeneration == 0 || first.DeadlineIdentity == 0 {
+		return SunSpecChainSnapshot{}, SunSpecQualificationSampleIdentity{}, fmt.Errorf("SunSpec qualification sample identity is invalid")
+	}
+	for index, source := range input.sources {
+		validated, err := NewLogicalViewSnapshot(source)
+		if err != nil {
+			return SunSpecChainSnapshot{}, SunSpecQualificationSampleIdentity{}, fmt.Errorf("SunSpec qualification source view %d: %w", index, err)
+		}
+		record := validated.Record()
+		if !sameSunSpecProvenance(first, record) || record.PollGeneration == 0 || record.DeadlineIdentity == 0 {
+			return SunSpecChainSnapshot{}, SunSpecQualificationSampleIdentity{}, fmt.Errorf("SunSpec qualification source provenance is mixed")
+		}
+		sources[index] = record
+	}
+	snapshot := SunSpecChainSnapshot{
+		raw:         append([]uint16(nil), input.raw...),
+		occurrences: input.Occurrences(),
+		sources:     sources,
+	}
+	if _, valid := sunSpecSnapshotWireChain(snapshot); !valid {
+		return SunSpecChainSnapshot{}, SunSpecQualificationSampleIdentity{}, fmt.Errorf("SunSpec qualification retained chain is invalid")
+	}
+	return snapshot, SunSpecQualificationSampleIdentity{pollGeneration: first.PollGeneration, deadlineIdentity: first.DeadlineIdentity}, nil
+}
+
+func cloneSunSpecQualificationSnapshot(snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {
+	cloned := SunSpecChainSnapshot{raw: snapshot.RawWords(), occurrences: snapshot.Occurrences()}
+	for _, source := range snapshot.SourceViews() {
+		cloned.sources = append(cloned.sources, source.Record())
+	}
+	return cloned
+}
+
+func (observation SunSpecQualificationObservation) MarshalJSON() ([]byte, error) {
+	occurrences := observation.Occurrences()
+	encodedOccurrences := make([]sunSpecQualificationOccurrenceJSON, len(occurrences))
+	for index, occurrence := range occurrences {
+		key, hasKey := occurrence.DecoderKey()
+		encodedOccurrences[index] = sunSpecQualificationOccurrenceJSON{
+			Ordinal:        occurrence.Ordinal,
+			WireKey:        occurrence.WireKey,
+			SchemaRevision: occurrence.SchemaRevision,
+			HeaderOffset:   occurrence.HeaderOffset,
+			PayloadOffset:  occurrence.PayloadOffset,
+			Disposition:    occurrence.Disposition,
+			Words:          occurrence.Words(),
+			SourceSpans:    occurrence.SourceSpans(),
+		}
+		if hasKey {
+			keyCopy := key
+			encodedOccurrences[index].DecoderKey = &keyCopy
+		}
+	}
+	views := observation.SourceViews()
+	encodedViews := make([]sunSpecQualificationLogicalViewJSON, len(views))
+	for index, view := range views {
+		encodedViews[index] = newSunSpecQualificationLogicalViewJSON(view.Record())
+	}
+	return json.Marshal(sunSpecQualificationObservationJSON{
+		Schema:       sunSpecQualificationObservationSchema,
+		CapabilityID: observation.Capability().ProfileID(),
+		FlavorID:     observation.Flavor().FlavorID(),
+		SampleID:     observation.SampleID(),
+		SampleIdentity: sunSpecQualificationSampleIdentityJSON{
+			PollGeneration: observation.identity.pollGeneration, DeadlineIdentity: observation.identity.deadlineIdentity,
+		},
+		Chain:       observation.Chain(),
+		RawWords:    observation.RawWords(),
+		Occurrences: encodedOccurrences,
+		SourceViews: encodedViews,
+	})
+}
+
+type sunSpecQualificationObservationJSON struct {
+	Schema         string                                 `json:"schema"`
+	CapabilityID   string                                 `json:"capability_id"`
+	FlavorID       string                                 `json:"flavor_id"`
+	SampleID       string                                 `json:"sample_id"`
+	SampleIdentity sunSpecQualificationSampleIdentityJSON `json:"sample_identity"`
+	Chain          []SunSpecWireKey                       `json:"chain"`
+	RawWords       []uint16                               `json:"raw_words"`
+	Occurrences    []sunSpecQualificationOccurrenceJSON   `json:"occurrences"`
+	SourceViews    []sunSpecQualificationLogicalViewJSON  `json:"source_views"`
+}
+
+type sunSpecQualificationSampleIdentityJSON struct {
+	PollGeneration   uint64 `json:"poll_generation"`
+	DeadlineIdentity uint64 `json:"deadline_identity"`
+}
+
+type sunSpecQualificationOccurrenceJSON struct {
+	Ordinal        uint32                  `json:"ordinal"`
+	WireKey        SunSpecWireKey          `json:"wire_key"`
+	SchemaRevision SunSpecSchemaRevision   `json:"schema_revision"`
+	HeaderOffset   uint16                  `json:"header_offset"`
+	PayloadOffset  uint16                  `json:"payload_offset"`
+	Disposition    SunSpecChainDisposition `json:"disposition"`
+	DecoderKey     *SunSpecDecoderKey      `json:"decoder_key,omitempty"`
+	Words          []uint16                `json:"words"`
+	SourceSpans    []SunSpecSourceSpan     `json:"source_spans"`
+}
+
+type sunSpecQualificationLogicalViewJSON struct {
+	LogicalViewID       uint64          `json:"logical_view_id"`
+	WireResponseID      uint64          `json:"wire_response_id"`
+	PhysicalRequestID   uint64          `json:"physical_request_id"`
+	Endpoint            string          `json:"endpoint"`
+	ConnectionID        uint64          `json:"connection_id"`
+	Transport           TransportFamily `json:"transport"`
+	TransportGeneration uint64          `json:"transport_generation"`
+	UnitID              byte            `json:"unit_id"`
+	RequestedFunction   FunctionCode    `json:"requested_function"`
+	ReceivedFunction    FunctionCode    `json:"received_function"`
+	Table               LogicalTable    `json:"table"`
+	PhysicalOffset      uint16          `json:"physical_offset"`
+	PhysicalWordCount   uint16          `json:"physical_word_count"`
+	AuthorizationScope  string          `json:"authorization_scope"`
+	PollGeneration      uint64          `json:"poll_generation"`
+	DeadlineIdentity    uint64          `json:"deadline_identity"`
+	LogicalOffset       uint16          `json:"logical_offset"`
+	LogicalWordCount    uint16          `json:"logical_word_count"`
+	SliceOffset         uint16          `json:"slice_offset"`
+	SliceWordCount      uint16          `json:"slice_word_count"`
+	Words               []uint16        `json:"words"`
+	WireResponseBytes   []byte          `json:"wire_response_bytes"`
+}
+
+func newSunSpecQualificationLogicalViewJSON(record LogicalViewRecord) sunSpecQualificationLogicalViewJSON {
+	return sunSpecQualificationLogicalViewJSON{
+		LogicalViewID: record.LogicalViewID, WireResponseID: record.WireResponseID, PhysicalRequestID: record.PhysicalRequestID,
+		Endpoint: record.Endpoint, ConnectionID: record.ConnectionID, Transport: record.Transport, TransportGeneration: record.TransportGeneration,
+		UnitID: record.UnitID, RequestedFunction: record.RequestedFunction, ReceivedFunction: record.ReceivedFunction, Table: record.Table,
+		PhysicalOffset: record.PhysicalOffset, PhysicalWordCount: record.PhysicalWordCount, AuthorizationScope: record.AuthorizationScope,
+		PollGeneration: record.PollGeneration, DeadlineIdentity: record.DeadlineIdentity, LogicalOffset: record.LogicalOffset,
+		LogicalWordCount: record.LogicalWordCount, SliceOffset: record.SliceOffset, SliceWordCount: record.SliceWordCount,
+		Words: append([]uint16(nil), record.Words...), WireResponseBytes: append([]byte(nil), record.WireResponseBytes...),
+	}
+}

--- a/sunspec_qualification_observation_test.go
+++ b/sunspec_qualification_observation_test.go
@@ -34,6 +34,9 @@ func TestSunSpecQualificationObservationDerivesAndRetainsExactV11Evidence(t *tes
 	if identity.PollGeneration() != 6 || identity.DeadlineIdentity() != 700 {
 		t.Fatalf("sample identity=%#v", identity)
 	}
+	if observation.SampleID() != "sunspec-6-700" {
+		t.Fatalf("sample id=%q", observation.SampleID())
+	}
 	occurrences, views := observation.Occurrences(), observation.SourceViews()
 	if len(occurrences) != 8 || len(views) != len(snapshot.SourceViews()) {
 		t.Fatalf("occurrences=%d views=%d", len(occurrences), len(views))
@@ -85,8 +88,33 @@ func TestSunSpecQualificationObservationJSONGoldenAndBoundedReplay(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Equal(first, fixture) {
-		t.Fatalf("qualification JSON differs from golden\n got: %s\nwant: %s", first, fixture)
+	var want qualificationObservationManifest
+	if err := json.Unmarshal(fixture, &want); err != nil {
+		t.Fatalf("unmarshal metadata manifest: %v", err)
+	}
+	var got serializedQualificationObservation
+	if err := json.Unmarshal(first, &got); err != nil {
+		t.Fatalf("unmarshal qualification JSON: %v", err)
+	}
+	if got.Schema != want.Schema || got.CapabilityID != want.CapabilityID || got.FlavorID != want.FlavorID || got.SampleID != want.SampleID || got.SampleIdentity != want.SampleIdentity || !reflect.DeepEqual(got.Chain, want.Chain) {
+		t.Fatalf("serialized metadata=%+v want=%+v", got.qualificationMetadata(), want)
+	}
+	if !reflect.DeepEqual(got.RawWords, observation.RawWords()) || len(got.Occurrences) != 8 || len(got.SourceViews) != len(observation.SourceViews()) {
+		t.Fatalf("serialized evidence raw=%d occurrences=%d source_views=%d", len(got.RawWords), len(got.Occurrences), len(got.SourceViews))
+	}
+	for index, occurrence := range got.Occurrences {
+		if len(occurrence.Words) == 0 || len(occurrence.SourceSpans) == 0 || occurrence.DecoderKey == nil {
+			t.Fatalf("serialized occurrence %d lost words, spans, or decoder key: %#v", index, occurrence)
+		}
+	}
+	model123 := got.Occurrences[5]
+	if model123.WireKey != (SunSpecWireKey{ModelID: 123, ModelLength: 24}) || model123.DecoderKey == nil || *model123.DecoderKey != (SunSpecDecoderKey{ModelID: 123, ModelLength: 24, SchemaRevision: testSunSpecModelsRevision}) {
+		t.Fatalf("serialized model 123=%#v", model123)
+	}
+	for index, view := range got.SourceViews {
+		if view.Transport == "" || len(view.WireResponseBytes) == 0 || view.PollGeneration != 6 || view.DeadlineIdentity != 700 {
+			t.Fatalf("serialized source view %d lost wire or transport provenance: %#v", index, view)
+		}
 	}
 
 	replay, err := observation.Replay()
@@ -155,11 +183,51 @@ func TestSunSpecQualificationObservationFailsClosed(t *testing.T) {
 
 func qualificationSnapshot(t *testing.T, registry SunSpecDecoderRegistry) SunSpecChainSnapshot {
 	t.Helper()
-	snapshot := cloneSnapshotForTest(froniusObservedSnapshotV11(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1"))
+	v11 := froniusObservedSnapshotV11(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1")
+	snapshot := completedChainSnapshot(t, registry, v11.Occurrences()...)
 	for index := range snapshot.sources {
 		snapshot.sources[index].DeadlineIdentity = 700
 	}
 	return snapshot
+}
+
+type qualificationObservationManifest struct {
+	Schema         string            `json:"schema"`
+	CapabilityID   string            `json:"capability_id"`
+	FlavorID       string            `json:"flavor_id"`
+	SampleID       string            `json:"sample_id"`
+	SampleIdentity sampleIdentityDTO `json:"sample_identity"`
+	Chain          []SunSpecWireKey  `json:"chain"`
+}
+
+type sampleIdentityDTO struct {
+	PollGeneration   uint64 `json:"poll_generation"`
+	DeadlineIdentity uint64 `json:"deadline_identity"`
+}
+
+type serializedQualificationObservation struct {
+	qualificationObservationManifest
+	RawWords    []uint16                      `json:"raw_words"`
+	Occurrences []serializedSunSpecOccurrence `json:"occurrences"`
+	SourceViews []serializedLogicalView       `json:"source_views"`
+}
+
+func (value serializedQualificationObservation) qualificationMetadata() qualificationObservationManifest {
+	return value.qualificationObservationManifest
+}
+
+type serializedSunSpecOccurrence struct {
+	WireKey     SunSpecWireKey      `json:"wire_key"`
+	DecoderKey  *SunSpecDecoderKey  `json:"decoder_key"`
+	Words       []uint16            `json:"words"`
+	SourceSpans []SunSpecSourceSpan `json:"source_spans"`
+}
+
+type serializedLogicalView struct {
+	Transport         string `json:"transport"`
+	WireResponseBytes []byte `json:"wire_response_bytes"`
+	PollGeneration    uint64 `json:"poll_generation"`
+	DeadlineIdentity  uint64 `json:"deadline_identity"`
 }
 
 func qualificationRebuildSnapshot(t *testing.T, registry SunSpecDecoderRegistry, snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {

--- a/sunspec_qualification_observation_test.go
+++ b/sunspec_qualification_observation_test.go
@@ -1,0 +1,177 @@
+package modbusreg
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// The qualification record is deliberately constructed from only a registry and
+// a completed capture.  In particular, neither a caller verdict nor a
+// caller-selected flavor is an input to the owner record.
+func TestSunSpecQualificationObservationDerivesAndRetainsExactV11Evidence(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	snapshot := qualificationSnapshot(t, registry)
+
+	observation, err := NewSunSpecQualificationObservation(registry, snapshot)
+	if err != nil {
+		t.Fatalf("NewSunSpecQualificationObservation: %v", err)
+	}
+	if !observation.Capability().Admitted() || observation.Capability().Reason() != SunSpecCapabilityReasonAdmitted {
+		t.Fatalf("capability=%#v", observation.Capability())
+	}
+	if !observation.Flavor().Matched() || observation.Flavor().FlavorID() != SunSpecFroniusObservedFlavorV11ID {
+		t.Fatalf("flavor=%#v", observation.Flavor())
+	}
+	wantChain := []SunSpecWireKey{{1, 65}, {113, 60}, {120, 26}, {121, 30}, {122, 44}, {123, 24}, {160, 88}, {124, 24}, {sunSpecEndModel, 0}}
+	if got := observation.Chain(); !reflect.DeepEqual(got, wantChain) {
+		t.Fatalf("chain=%#v want=%#v", got, wantChain)
+	}
+
+	identity := observation.SampleIdentity()
+	if identity.PollGeneration() != 6 || identity.DeadlineIdentity() != 700 {
+		t.Fatalf("sample identity=%#v", identity)
+	}
+	occurrences, views := observation.Occurrences(), observation.SourceViews()
+	if len(occurrences) != 8 || len(views) != len(snapshot.SourceViews()) {
+		t.Fatalf("occurrences=%d views=%d", len(occurrences), len(views))
+	}
+	for index, view := range views {
+		record := view.Record()
+		if record.PollGeneration != identity.PollGeneration() || record.DeadlineIdentity != identity.DeadlineIdentity() {
+			t.Fatalf("source view %d has detached identity: %#v", index, record)
+		}
+	}
+	model123 := occurrences[5]
+	if model123.WireKey != (SunSpecWireKey{ModelID: 123, ModelLength: 24}) || model123.Disposition != SunSpecChainDispositionAdmitted {
+		t.Fatalf("model 123=%#v", model123)
+	}
+	key, ok := model123.DecoderKey()
+	if !ok || key != (SunSpecDecoderKey{ModelID: 123, ModelLength: 24, SchemaRevision: testSunSpecModelsRevision}) || len(model123.SourceSpans()) == 0 || len(model123.Words()) != 26 {
+		t.Fatalf("model 123 key=%#v ok=%t spans=%#v raw=%#v", key, ok, model123.SourceSpans(), model123.Words())
+	}
+	if raw := observation.RawWords(); !reflect.DeepEqual(raw, snapshot.RawWords()) {
+		t.Fatalf("raw words were not retained: got=%d want=%d", len(raw), len(snapshot.RawWords()))
+	}
+
+	// All getter results must remain detached from the immutable qualification.
+	chain, raw := observation.Chain(), observation.RawWords()
+	chain[0], raw[0] = SunSpecWireKey{}, 0
+	occurrences[5].words[0] = 0
+	record := views[0].Record()
+	record.Words[0] = 0
+	if observation.Chain()[0] != (SunSpecWireKey{ModelID: 1, ModelLength: 65}) || observation.RawWords()[0] != sunSpecSignatureFirst || observation.Occurrences()[5].Words()[0] != 123 || observation.SourceViews()[0].Record().Words[0] == 0 {
+		t.Fatal("qualification getters leaked caller mutation")
+	}
+}
+
+func TestSunSpecQualificationObservationJSONGoldenAndBoundedReplay(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	observation, err := NewSunSpecQualificationObservation(registry, qualificationSnapshot(t, registry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := json.Marshal(observation)
+	if err != nil {
+		t.Fatalf("MarshalJSON(first): %v", err)
+	}
+	second, err := json.Marshal(observation)
+	if err != nil || !bytes.Equal(first, second) {
+		t.Fatalf("qualification JSON is not deterministic: %v", err)
+	}
+	fixture, err := os.ReadFile("testdata/sunspec/qualification/fronius_gen24_float_v1_1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, fixture) {
+		t.Fatalf("qualification JSON differs from golden\n got: %s\nwant: %s", first, fixture)
+	}
+
+	replay, err := observation.Replay()
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if !reflect.DeepEqual(replay.RawWords(), observation.RawWords()) || !reflect.DeepEqual(replay.Occurrences(), observation.Occurrences()) || !reflect.DeepEqual(replay.SourceViews(), observation.SourceViews()) {
+		t.Fatal("bounded ordered replay lost retained evidence")
+	}
+	replayed := replay.RawWords()
+	replayed[0] = 0
+	if observation.RawWords()[0] != sunSpecSignatureFirst {
+		t.Fatal("replay retained caller-owned raw storage")
+	}
+}
+
+func TestSunSpecQualificationObservationFailsClosed(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	valid := qualificationSnapshot(t, registry)
+
+	noMatch := cloneSnapshotForTest(valid)
+	noMatch.occurrences[0] = commonOccurrence(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-2", 1)
+	noMatch = qualificationRebuildSnapshot(t, registry, noMatch)
+
+	unknown := cloneSnapshotForTest(valid)
+	unknown.occurrences = append(unknown.occurrences, SunSpecOccurrence{Ordinal: 9, WireKey: SunSpecWireKey{ModelID: 999, ModelLength: 1}, SchemaRevision: testSunSpecModelsRevision, HeaderOffset: 40000, PayloadOffset: 40002, Disposition: SunSpecChainDispositionUnknownModel, words: []uint16{999, 1, 7}, spans: []SunSpecSourceSpan{{LogicalViewID: 999, PDUOffset: 0, WordCount: 3}}})
+	unknown = qualificationRebuildSnapshot(t, registry, unknown)
+
+	unsupported := cloneSnapshotForTest(valid)
+	unsupportedWords := make([]uint16, 27)
+	unsupportedWords[0], unsupportedWords[1] = 123, 25
+	unsupported.occurrences[5] = admittedOccurrence(123, 25, unsupportedWords, 6)
+	unsupported.occurrences[5].Disposition = SunSpecChainDispositionUnsupportedLength
+	unsupported = qualificationRebuildSnapshot(t, registry, unsupported)
+
+	ambiguous := cloneSnapshotForTest(valid)
+	// The selector itself must remain fail-closed if future registry definitions overlap.
+	if selected := selectSunSpecFroniusFlavor([]SunSpecFroniusFlavorDecision{registry.EvaluateFroniusObservedFlavorV11(valid), registry.EvaluateFroniusObservedFlavorV11(valid)}); selected.Matched() || selected.Reason() != SunSpecFroniusFlavorSelectionReasonAmbiguousMatch {
+		t.Fatalf("ambiguous flavor selection=%#v", selected)
+	}
+	ambiguous.sources[1].DeadlineIdentity++
+
+	nonterminal := cloneSnapshotForTest(valid)
+	nonterminal.raw = nonterminal.raw[:len(nonterminal.raw)-2]
+	malformedIdentity := cloneSnapshotForTest(valid)
+	malformedIdentity.sources[0].PollGeneration = 0
+	mixedProvenance := cloneSnapshotForTest(valid)
+	mixedProvenance.sources[1].Transport = TransportRTU
+
+	for name, snapshot := range map[string]SunSpecChainSnapshot{
+		"no match":           noMatch,
+		"unknown occurrence": unknown,
+		"unsupported":        unsupported,
+		"ambiguous identity": ambiguous,
+		"nonterminal":        nonterminal,
+		"malformed identity": malformedIdentity,
+		"mixed provenance":   mixedProvenance,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewSunSpecQualificationObservation(registry, snapshot); err == nil {
+				t.Fatal("invalid qualification input unexpectedly admitted")
+			}
+		})
+	}
+}
+
+func qualificationSnapshot(t *testing.T, registry SunSpecDecoderRegistry) SunSpecChainSnapshot {
+	t.Helper()
+	snapshot := cloneSnapshotForTest(froniusObservedSnapshotV11(t, registry, "Fronius", "Symo GEN24 10.0", "1.41.11-1"))
+	for index := range snapshot.sources {
+		snapshot.sources[index].DeadlineIdentity = 700
+	}
+	return snapshot
+}
+
+func qualificationRebuildSnapshot(t *testing.T, registry SunSpecDecoderRegistry, snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {
+	t.Helper()
+	return qualificationSnapshotWithOccurrences(t, registry, snapshot.Occurrences())
+}
+
+func qualificationSnapshotWithOccurrences(t *testing.T, registry SunSpecDecoderRegistry, occurrences []SunSpecOccurrence) SunSpecChainSnapshot {
+	t.Helper()
+	snapshot := completedChainSnapshot(t, registry, occurrences...)
+	for index := range snapshot.sources {
+		snapshot.sources[index].DeadlineIdentity = 700
+	}
+	return snapshot
+}

--- a/sunspec_qualification_observation_test.go
+++ b/sunspec_qualification_observation_test.go
@@ -96,24 +96,30 @@ func TestSunSpecQualificationObservationJSONGoldenAndBoundedReplay(t *testing.T)
 	if err := json.Unmarshal(first, &got); err != nil {
 		t.Fatalf("unmarshal qualification JSON: %v", err)
 	}
-	if got.Schema != want.Schema || got.CapabilityID != want.CapabilityID || got.FlavorID != want.FlavorID || got.SampleID != want.SampleID || got.SampleIdentity != want.SampleIdentity || !reflect.DeepEqual(got.Chain, want.Chain) {
+	if got.Schema != want.Schema || got.CapabilityID != want.CapabilityID || got.CapabilityReason != want.CapabilityReason || got.FlavorID != want.FlavorID || got.FlavorReason != want.FlavorReason || got.SampleID != want.SampleID || got.SampleIdentity != want.SampleIdentity || !reflect.DeepEqual(got.Chain, want.Chain) {
 		t.Fatalf("serialized metadata=%+v want=%+v", got.qualificationMetadata(), want)
+	}
+	if got.CapabilityReason != SunSpecCapabilityReasonAdmitted || got.FlavorReason != SunSpecFroniusFlavorReasonMatched {
+		t.Fatalf("serialized reasons capability=%q flavor=%q", got.CapabilityReason, got.FlavorReason)
 	}
 	if !reflect.DeepEqual(got.RawWords, observation.RawWords()) || len(got.Occurrences) != 8 || len(got.SourceViews) != len(observation.SourceViews()) {
 		t.Fatalf("serialized evidence raw=%d occurrences=%d source_views=%d", len(got.RawWords), len(got.Occurrences), len(got.SourceViews))
 	}
-	for index, occurrence := range got.Occurrences {
-		if len(occurrence.Words) == 0 || len(occurrence.SourceSpans) == 0 || occurrence.DecoderKey == nil {
-			t.Fatalf("serialized occurrence %d lost words, spans, or decoder key: %#v", index, occurrence)
+	for index, gotOccurrence := range got.Occurrences {
+		wantOccurrence := observation.Occurrences()[index]
+		wantDecoderKey, wantHasDecoderKey := wantOccurrence.DecoderKey()
+		if gotOccurrence.Ordinal != wantOccurrence.Ordinal || gotOccurrence.WireKey != wantOccurrence.WireKey || gotOccurrence.SchemaRevision != wantOccurrence.SchemaRevision || gotOccurrence.HeaderOffset != wantOccurrence.HeaderOffset || gotOccurrence.PayloadOffset != wantOccurrence.PayloadOffset || gotOccurrence.Disposition != wantOccurrence.Disposition || !reflect.DeepEqual(gotOccurrence.Words, wantOccurrence.Words()) || !reflect.DeepEqual(gotOccurrence.SourceSpans, wantOccurrence.SourceSpans()) || (gotOccurrence.DecoderKey != nil) != wantHasDecoderKey || wantHasDecoderKey && *gotOccurrence.DecoderKey != wantDecoderKey {
+			t.Fatalf("serialized occurrence %d=%#v does not retain source=%#v", index, gotOccurrence, wantOccurrence)
 		}
 	}
 	model123 := got.Occurrences[5]
 	if model123.WireKey != (SunSpecWireKey{ModelID: 123, ModelLength: 24}) || model123.DecoderKey == nil || *model123.DecoderKey != (SunSpecDecoderKey{ModelID: 123, ModelLength: 24, SchemaRevision: testSunSpecModelsRevision}) {
 		t.Fatalf("serialized model 123=%#v", model123)
 	}
-	for index, view := range got.SourceViews {
-		if view.Transport == "" || len(view.WireResponseBytes) == 0 || view.PollGeneration != 6 || view.DeadlineIdentity != 700 {
-			t.Fatalf("serialized source view %d lost wire or transport provenance: %#v", index, view)
+	for index, gotView := range got.SourceViews {
+		wantView := observation.SourceViews()[index].Record()
+		if gotView.LogicalViewID != wantView.LogicalViewID || gotView.WireResponseID != wantView.WireResponseID || gotView.PhysicalRequestID != wantView.PhysicalRequestID || gotView.Endpoint != wantView.Endpoint || gotView.ConnectionID != wantView.ConnectionID || gotView.Transport != wantView.Transport || gotView.TransportGeneration != wantView.TransportGeneration || gotView.UnitID != wantView.UnitID || gotView.RequestedFunction != wantView.RequestedFunction || gotView.ReceivedFunction != wantView.ReceivedFunction || gotView.Table != wantView.Table || gotView.PhysicalOffset != wantView.PhysicalOffset || gotView.PhysicalWordCount != wantView.PhysicalWordCount || gotView.AuthorizationScope != wantView.AuthorizationScope || gotView.PollGeneration != wantView.PollGeneration || gotView.DeadlineIdentity != wantView.DeadlineIdentity || gotView.LogicalOffset != wantView.LogicalOffset || gotView.LogicalWordCount != wantView.LogicalWordCount || gotView.SliceOffset != wantView.SliceOffset || gotView.SliceWordCount != wantView.SliceWordCount || !reflect.DeepEqual(gotView.Words, wantView.Words) || !reflect.DeepEqual(gotView.WireResponseBytes, wantView.WireResponseBytes) {
+			t.Fatalf("serialized source view %d=%#v does not retain source=%#v", index, gotView, wantView)
 		}
 	}
 
@@ -128,6 +134,12 @@ func TestSunSpecQualificationObservationJSONGoldenAndBoundedReplay(t *testing.T)
 	replayed[0] = 0
 	if observation.RawWords()[0] != sunSpecSignatureFirst {
 		t.Fatal("replay retained caller-owned raw storage")
+	}
+}
+
+func TestSunSpecQualificationObservationJSONRejectsZeroValue(t *testing.T) {
+	if _, err := json.Marshal(SunSpecQualificationObservation{}); err == nil {
+		t.Fatal("zero qualification observation unexpectedly marshaled")
 	}
 }
 
@@ -192,12 +204,14 @@ func qualificationSnapshot(t *testing.T, registry SunSpecDecoderRegistry) SunSpe
 }
 
 type qualificationObservationManifest struct {
-	Schema         string            `json:"schema"`
-	CapabilityID   string            `json:"capability_id"`
-	FlavorID       string            `json:"flavor_id"`
-	SampleID       string            `json:"sample_id"`
-	SampleIdentity sampleIdentityDTO `json:"sample_identity"`
-	Chain          []SunSpecWireKey  `json:"chain"`
+	Schema           string                     `json:"schema"`
+	CapabilityID     string                     `json:"capability_id"`
+	CapabilityReason SunSpecCapabilityReason    `json:"capability_reason"`
+	FlavorID         string                     `json:"flavor_id"`
+	FlavorReason     SunSpecFroniusFlavorReason `json:"flavor_reason"`
+	SampleID         string                     `json:"sample_id"`
+	SampleIdentity   sampleIdentityDTO          `json:"sample_identity"`
+	Chain            []SunSpecWireKey           `json:"chain"`
 }
 
 type sampleIdentityDTO struct {
@@ -217,17 +231,40 @@ func (value serializedQualificationObservation) qualificationMetadata() qualific
 }
 
 type serializedSunSpecOccurrence struct {
-	WireKey     SunSpecWireKey      `json:"wire_key"`
-	DecoderKey  *SunSpecDecoderKey  `json:"decoder_key"`
-	Words       []uint16            `json:"words"`
-	SourceSpans []SunSpecSourceSpan `json:"source_spans"`
+	Ordinal        uint32                  `json:"ordinal"`
+	WireKey        SunSpecWireKey          `json:"wire_key"`
+	SchemaRevision SunSpecSchemaRevision   `json:"schema_revision"`
+	HeaderOffset   uint16                  `json:"header_offset"`
+	PayloadOffset  uint16                  `json:"payload_offset"`
+	Disposition    SunSpecChainDisposition `json:"disposition"`
+	DecoderKey     *SunSpecDecoderKey      `json:"decoder_key"`
+	Words          []uint16                `json:"words"`
+	SourceSpans    []SunSpecSourceSpan     `json:"source_spans"`
 }
 
 type serializedLogicalView struct {
-	Transport         string `json:"transport"`
-	WireResponseBytes []byte `json:"wire_response_bytes"`
-	PollGeneration    uint64 `json:"poll_generation"`
-	DeadlineIdentity  uint64 `json:"deadline_identity"`
+	LogicalViewID       uint64          `json:"logical_view_id"`
+	WireResponseID      uint64          `json:"wire_response_id"`
+	PhysicalRequestID   uint64          `json:"physical_request_id"`
+	Endpoint            string          `json:"endpoint"`
+	ConnectionID        uint64          `json:"connection_id"`
+	Transport           TransportFamily `json:"transport"`
+	TransportGeneration uint64          `json:"transport_generation"`
+	UnitID              byte            `json:"unit_id"`
+	RequestedFunction   FunctionCode    `json:"requested_function"`
+	ReceivedFunction    FunctionCode    `json:"received_function"`
+	Table               LogicalTable    `json:"table"`
+	PhysicalOffset      uint16          `json:"physical_offset"`
+	PhysicalWordCount   uint16          `json:"physical_word_count"`
+	AuthorizationScope  string          `json:"authorization_scope"`
+	PollGeneration      uint64          `json:"poll_generation"`
+	DeadlineIdentity    uint64          `json:"deadline_identity"`
+	LogicalOffset       uint16          `json:"logical_offset"`
+	LogicalWordCount    uint16          `json:"logical_word_count"`
+	SliceOffset         uint16          `json:"slice_offset"`
+	SliceWordCount      uint16          `json:"slice_word_count"`
+	Words               []uint16        `json:"words"`
+	WireResponseBytes   []byte          `json:"wire_response_bytes"`
 }
 
 func qualificationRebuildSnapshot(t *testing.T, registry SunSpecDecoderRegistry, snapshot SunSpecChainSnapshot) SunSpecChainSnapshot {

--- a/testdata/sunspec/qualification/fronius_gen24_float_v1_1.json
+++ b/testdata/sunspec/qualification/fronius_gen24_float_v1_1.json
@@ -2,12 +2,17 @@
   "schema": "helianthus-sunspec-qualification-observation/v1",
   "capability_id": "sunspec.inverter.three_phase.monitoring@1.0.0",
   "flavor_id": "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+  "sample_id": "sunspec-6-700",
   "sample_identity": {"poll_generation": 6, "deadline_identity": 700},
-  "requirements": {
-    "terminal_verified": true,
-    "ordered_bounded_replay": true,
-    "occurrences": ["all", "including_unknown_and_unsupported"],
-    "provenance": ["logical_views", "wire_evidence", "transport"],
-    "retained_model": {"model_id": 123, "model_length": 24}
-  }
+  "chain": [
+    {"ModelID": 1, "ModelLength": 65},
+    {"ModelID": 113, "ModelLength": 60},
+    {"ModelID": 120, "ModelLength": 26},
+    {"ModelID": 121, "ModelLength": 30},
+    {"ModelID": 122, "ModelLength": 44},
+    {"ModelID": 123, "ModelLength": 24},
+    {"ModelID": 160, "ModelLength": 88},
+    {"ModelID": 124, "ModelLength": 24},
+    {"ModelID": 65535, "ModelLength": 0}
+  ]
 }

--- a/testdata/sunspec/qualification/fronius_gen24_float_v1_1.json
+++ b/testdata/sunspec/qualification/fronius_gen24_float_v1_1.json
@@ -1,7 +1,9 @@
 {
   "schema": "helianthus-sunspec-qualification-observation/v1",
   "capability_id": "sunspec.inverter.three_phase.monitoring@1.0.0",
+  "capability_reason": "ADMITTED",
   "flavor_id": "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+  "flavor_reason": "MATCHED",
   "sample_id": "sunspec-6-700",
   "sample_identity": {"poll_generation": 6, "deadline_identity": 700},
   "chain": [

--- a/testdata/sunspec/qualification/fronius_gen24_float_v1_1.json
+++ b/testdata/sunspec/qualification/fronius_gen24_float_v1_1.json
@@ -1,0 +1,13 @@
+{
+  "schema": "helianthus-sunspec-qualification-observation/v1",
+  "capability_id": "sunspec.inverter.three_phase.monitoring@1.0.0",
+  "flavor_id": "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+  "sample_identity": {"poll_generation": 6, "deadline_identity": 700},
+  "requirements": {
+    "terminal_verified": true,
+    "ordered_bounded_replay": true,
+    "occurrences": ["all", "including_unknown_and_unsupported"],
+    "provenance": ["logical_views", "wire_evidence", "transport"],
+    "retained_model": {"model_id": 123, "model_length": 24}
+  }
+}


### PR DESCRIPTION
## Summary

- add a RED-first contract for a canonical immutable SunSpec V3 qualification observation
- require registry-derived capability/flavor decisions, exact sample provenance, bounded replay, and deterministic serialization
- preserve the exact Fronius V1.1 chain including standard Model 123 without moving policy into the gateway

## Dependency / docs gate

- closes #23
- existing V3 contract: helianthus-docs-ebus merge `b70063ff8f803f32768059290f2b02f84e1d542d`
- base implementation: modbusreg v0.2.0 / `1f32bf3018aba9671b36f699a8642b6b1a90a563`

## TDD

- RED public: `4e5de551a7617b6bd9569aa33ff0fe846879378a`
- command: `GOWORK=off go test ./... -run ^'TestSunSpecQualificationObservation' -count=1`\n- observed: build fails only because `NewSunSpecQualificationObservation` is absent\n\n## Scope\n\nRegistry record/serialization only. No transport, gateway, socket, write, live-device, canonical PV, GraphQL, Portal, HA, eeBUS, or Matter behavior.\n\n## Gates\n\n- focused and full race CI after GREEN\n- T01..T88 N/A: no transport/framing/request/reconnect behavior\n- fresh exact-HEAD `NO_BLOCKING_FINDINGS` before squash merge