### PR TITLE
FMV3-M7-03: record Growatt no-admissible-profile disposition

### DIFF
--- a/growatt_disposition_test.go
+++ b/growatt_disposition_test.go
@@ -1,0 +1,86 @@
+package modbusreg
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGrowattDispositionFailsClosedWithoutQualifiedEvidence(t *testing.T) {
+	data, err := os.ReadFile("profiles/vendor/growatt/disposition.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var record struct {
+		Schema         string `json:"schema"`
+		Profile        string `json:"profile"`
+		ProfileVersion string `json:"profile_version"`
+		Outcome        string `json:"outcome"`
+		Evidence       struct {
+			PacketID          string `json:"packet_id"`
+			DocsMergeSHA      string `json:"docs_merge_sha"`
+			SourceIdentity    string `json:"source_identity"`
+			SourceLicense     string `json:"source_license"`
+			PacketDisposition string `json:"packet_disposition"`
+			Eligible          bool   `json:"eligible"`
+		}
+		CandidateOperations []struct {
+			Function         uint8
+			Offset, Quantity uint16
+			Purpose          string
+			Executable       bool
+		} `json:"candidate_operations"`
+		Unresolved        []string            `json:"unresolved"`
+		DecoderKeys       []SunSpecDecoderKey `json:"decoder_keys"`
+		CatalogRegistered bool                `json:"catalog_registered"`
+		SupportClaim      bool                `json:"support_claim"`
+		ReopenRequires    []string            `json:"reopen_requires"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Schema != "helianthus-modbusreg-profile-disposition/v1" ||
+		record.Profile != "growatt" ||
+		record.ProfileVersion != "1.0.0" ||
+		record.Outcome != "NO_ADMISSIBLE_PROFILE" {
+		t.Fatalf("unexpected disposition identity: %#v", record)
+	}
+	if record.Evidence.PacketID != "GROWATT-CANDIDATE-V1" ||
+		record.Evidence.DocsMergeSHA != "42da2afdb0fd46bdb4301a847d59096e252bfe00" ||
+		record.Evidence.SourceIdentity != "sha256:fac88d609d74ff6b3c9c31ed65370d166d1fb17461e91b4b4855018fe232a320" ||
+		record.Evidence.SourceLicense != "vendor-copyright-inspection-only" ||
+		record.Evidence.PacketDisposition != "HYPOTHESIS" ||
+		record.Evidence.Eligible {
+		t.Fatalf("unexpected evidence lock: %#v", record.Evidence)
+	}
+	wantOperations := []struct {
+		function         uint8
+		offset, quantity uint16
+		purpose          string
+	}{{3, 9, 6, "firmware_tuple"}, {3, 43, 1, "device_type_code"}, {3, 82, 2, "model_build_code"}, {3, 88, 1, "protocol_version"}}
+	if len(record.CandidateOperations) != len(wantOperations) {
+		t.Fatalf("candidate operations=%d", len(record.CandidateOperations))
+	}
+	for index, operation := range record.CandidateOperations {
+		want := wantOperations[index]
+		if operation.Executable || operation.Function != want.function || operation.Offset != want.offset || operation.Quantity != want.quantity || operation.Purpose != want.purpose {
+			t.Fatalf("candidate operation %d=%#v want=%#v", index, operation, want)
+		}
+	}
+	if len(record.DecoderKeys) != 0 || record.CatalogRegistered || record.SupportClaim {
+		t.Fatalf("non-admission leaked support: keys=%v catalog=%v claim=%v", record.DecoderKeys, record.CatalogRegistered, record.SupportClaim)
+	}
+	wantUnresolved := []string{"exact_product_family", "firmware_branch", "address_normalization", "word_and_byte_order", "detector_uniqueness"}
+	wantReopen := []string{"public_clean_room_fixture", "exact_family_and_firmware_applicability", "verified_zero_based_address_normalization", "declared_word_and_byte_order", "mutually_exclusive_identity_tuple"}
+	if !reflect.DeepEqual(record.Unresolved, wantUnresolved) || !reflect.DeepEqual(record.ReopenRequires, wantReopen) {
+		t.Fatalf("closure conditions unresolved=%v reopen=%v", record.Unresolved, record.ReopenRequires)
+	}
+	if strings.Contains(strings.ToLower(string(data)), "serial") {
+		t.Fatal("disposition contains a sensitive identity field")
+	}
+}

--- a/profiles/vendor/growatt/disposition.json
+++ b/profiles/vendor/growatt/disposition.json
@@ -1,0 +1,37 @@
+{
+  "schema": "helianthus-modbusreg-profile-disposition/v1",
+  "profile": "growatt",
+  "profile_version": "1.0.0",
+  "outcome": "NO_ADMISSIBLE_PROFILE",
+  "evidence": {
+    "packet_id": "GROWATT-CANDIDATE-V1",
+    "docs_merge_sha": "42da2afdb0fd46bdb4301a847d59096e252bfe00",
+    "source_identity": "sha256:fac88d609d74ff6b3c9c31ed65370d166d1fb17461e91b4b4855018fe232a320",
+    "source_license": "vendor-copyright-inspection-only",
+    "packet_disposition": "HYPOTHESIS",
+    "eligible": false
+  },
+  "candidate_operations": [
+    {"function": 3, "offset": 9, "quantity": 6, "purpose": "firmware_tuple", "executable": false},
+    {"function": 3, "offset": 43, "quantity": 1, "purpose": "device_type_code", "executable": false},
+    {"function": 3, "offset": 82, "quantity": 2, "purpose": "model_build_code", "executable": false},
+    {"function": 3, "offset": 88, "quantity": 1, "purpose": "protocol_version", "executable": false}
+  ],
+  "unresolved": [
+    "exact_product_family",
+    "firmware_branch",
+    "address_normalization",
+    "word_and_byte_order",
+    "detector_uniqueness"
+  ],
+  "decoder_keys": [],
+  "catalog_registered": false,
+  "support_claim": false,
+  "reopen_requires": [
+    "public_clean_room_fixture",
+    "exact_family_and_firmware_applicability",
+    "verified_zero_based_address_normalization",
+    "declared_word_and_byte_order",
+    "mutually_exclusive_identity_tuple"
+  ]
+}

--- a/profiles/vendor/growatt/evidence.json
+++ b/profiles/vendor/growatt/evidence.json
@@ -1,0 +1,16 @@
+{
+  "schema": "helianthus-modbusreg-vendor-evidence/v1",
+  "profile": "growatt",
+  "profile_version": "1.0.0",
+  "public_sources": [
+    {
+      "id": "growatt-candidate-v1",
+      "locator": "https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/42da2afdb0fd46bdb4301a847d59096e252bfe00/protocols/modbus/growatt-candidate-evidence-v1.md",
+      "license": "CC0-1.0"
+    }
+  ],
+  "applicability": [
+    "candidate-only; exact product family, firmware branch, address normalization, and detector uniqueness unresolved"
+  ],
+  "license": "CC0-1.0"
+}


### PR DESCRIPTION
## Summary

- record Growatt as `NO_ADMISSIBLE_PROFILE` from the immutable M7-01 evidence packet
- keep all four research PDUs non-executable and leave decoder/catalog surfaces empty
- lock the unresolved evidence and qualified conditions required to reopen admission

## Evidence

- M7-01 docs gate: `42da2afdb0fd46bdb4301a847d59096e252bfe00`
- M7-02 dependency: `7137bf4e3cb5cf84dc581b490fa9c9ddf8ea49f6`
- exact HEAD: `6938fdb3ecbe7569fa9f1b328e8196381c0fb561`
- full local `GOWORK=off ./scripts/ci_local.sh`: scope/licensing PASS, 14 policy tests PASS, vet/build/race PASS, lint 0 issues

## Gate Applicability

- TDD_RED: N/A, no profile or behavior admitted
- T01..T88, hardware, live: N/A, disposition-only
- licensing: public derived facts CC0-1.0; vendor document is not redistributed

Closes #28