### PR TITLE
FMV3-M7-05: close mixed-catalog detection

### DIFF
--- a/decision_serialization.go
+++ b/decision_serialization.go
@@ -38,6 +38,7 @@ func validDetectionReason(reason DetectionReason) bool {
 	switch reason {
 	case DetectionReasonSelected,
 		DetectionReasonEqualBest,
+		DetectionReasonMultipleMatches,
 		DetectionReasonLowerScore,
 		DetectionReasonIdentityMismatch,
 		DetectionReasonFirmwareMismatch,
@@ -118,6 +119,7 @@ func validateDetectionEvidence(
 	switch evidence.Reason {
 	case DetectionReasonSelected,
 		DetectionReasonEqualBest,
+		DetectionReasonMultipleMatches,
 		DetectionReasonLowerScore:
 		if gateCount != 3 {
 			return fmt.Errorf("ranked detection evidence lacks complete gates")
@@ -154,6 +156,7 @@ func validateDetectionDecision(
 	}
 	selectedCount := 0
 	equalBestCount := 0
+	multipleMatchCount := 0
 	lowerScoreCount := 0
 	var equalBestScore uint32
 	var selectedScore uint32
@@ -179,6 +182,8 @@ func validateDetectionDecision(
 				return fmt.Errorf("ambiguous candidates do not have equal scores")
 			}
 			equalBestCount++
+		case DetectionReasonMultipleMatches:
+			multipleMatchCount++
 		case DetectionReasonLowerScore:
 			lowerScoreCount++
 		}
@@ -189,7 +194,7 @@ func validateDetectionDecision(
 		if decision.reason != DetectionReasonSelected ||
 			!validIdentity(decision.selectedProfileID) ||
 			!decision.selectedProfileVersion.valid() ||
-			selectedCount != 1 || equalBestCount != 0 {
+			selectedCount != 1 || equalBestCount != 0 || multipleMatchCount != 0 {
 			return fmt.Errorf("matched detection decision is inconsistent")
 		}
 		found := false
@@ -209,25 +214,36 @@ func validateDetectionDecision(
 			}
 		}
 	case DetectionAmbiguous:
-		if decision.reason != DetectionReasonEqualBest ||
-			decision.selectedProfileID != "" ||
-			decision.selectedProfileVersion.valid() ||
-			selectedCount != 0 || equalBestCount < 2 {
+		if decision.selectedProfileID != "" ||
+			decision.selectedProfileVersion.valid() || selectedCount != 0 {
 			return fmt.Errorf("ambiguous detection decision is inconsistent")
 		}
-		for _, evidence := range decision.evidence {
-			if evidence.Reason == DetectionReasonLowerScore &&
-				evidence.Score >= equalBestScore {
-				return fmt.Errorf("ambiguous detection ranking is inconsistent")
+		switch decision.reason {
+		case DetectionReasonEqualBest:
+			if equalBestCount < 2 || multipleMatchCount != 0 {
+				return fmt.Errorf("ambiguous detection decision is inconsistent")
 			}
+			for _, evidence := range decision.evidence {
+				if evidence.Reason == DetectionReasonLowerScore &&
+					evidence.Score >= equalBestScore {
+					return fmt.Errorf("ambiguous detection ranking is inconsistent")
+				}
+			}
+		case DetectionReasonMultipleMatches:
+			if multipleMatchCount < 2 || equalBestCount != 0 || lowerScoreCount != 0 {
+				return fmt.Errorf("exclusive detection decision is inconsistent")
+			}
+		default:
+			return fmt.Errorf("ambiguous detection decision is inconsistent")
 		}
 	case DetectionNoMatch:
 		if decision.reason == DetectionReasonSelected ||
 			decision.reason == DetectionReasonEqualBest ||
+			decision.reason == DetectionReasonMultipleMatches ||
 			decision.reason == DetectionReasonLowerScore ||
 			decision.selectedProfileID != "" ||
 			decision.selectedProfileVersion.valid() ||
-			selectedCount != 0 || equalBestCount != 0 || lowerScoreCount != 0 ||
+			selectedCount != 0 || equalBestCount != 0 || multipleMatchCount != 0 || lowerScoreCount != 0 ||
 			!overallReasonPresent {
 			return fmt.Errorf("no-match detection decision is inconsistent")
 		}

--- a/detector_contract_test.go
+++ b/detector_contract_test.go
@@ -395,7 +395,7 @@ func TestDetectorFirmwareComparisonDoesNotUseMachineIntegers(t *testing.T) {
 	}
 }
 
-func TestDetectorRankingIsCatalogOrderIndependentAndTiesAreAmbiguous(t *testing.T) {
+func TestDetectorRejectsEveryMultipleEligibleMatchIndependentOfOrderAndScore(t *testing.T) {
 	first := detectionProfile(t, "example.standard.alpha", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
 	second := detectionProfile(t, "example.standard.beta", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
 	firstCandidate := detectionCandidate(t, first, 20, true, false)
@@ -408,8 +408,9 @@ func TestDetectorRankingIsCatalogOrderIndependentAndTiesAreAmbiguous(t *testing.
 		}
 		detector := newDetector(t, catalog, secondCandidate, firstCandidate)
 		decision, err := detector.Detect(context.Background(), detectionReader(t), reg.DetectionOptions{})
-		if err != nil || decision.Outcome() != reg.DetectionMatched ||
-			decision.SelectedProfileID() != first.ID() {
+		if err != nil || decision.Outcome() != reg.DetectionAmbiguous ||
+			decision.Reason() != reg.DetectionReasonMultipleMatches ||
+			decision.SelectedProfileID() != "" {
 			t.Fatalf("permuted selection=(%+v,%v)", decision, err)
 		}
 	}
@@ -422,7 +423,7 @@ func TestDetectorRankingIsCatalogOrderIndependentAndTiesAreAmbiguous(t *testing.
 		reg.DetectionOptions{},
 	)
 	if err != nil || decision.Outcome() != reg.DetectionAmbiguous ||
-		decision.Reason() != reg.DetectionReasonEqualBest ||
+		decision.Reason() != reg.DetectionReasonMultipleMatches ||
 		decision.SelectedProfileID() != "" {
 		t.Fatalf("equal-best decision=(%+v,%v)", decision, err)
 	}

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -22,7 +22,7 @@ type mixedCatalogClosure struct {
 		VendorDocumentationMerge string `json:"vendor_docs_merge"`
 	} `json:"dependencies"`
 	Selection struct {
-		DetectorOption                    string   `json:"detector_option"`
+		SelectionMode                     string   `json:"selection_mode"`
 		MaxSelectedPrimaries              int      `json:"max_selected_primaries"`
 		NoPositiveOutcome                 string   `json:"no_positive_outcome"`
 		MultiplePositiveOutcome           string   `json:"multiple_positive_outcome"`
@@ -73,7 +73,7 @@ func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
 		t.Fatalf("unexpected dependency closure: %#v", closure.Dependencies)
 	}
 	wantRequirements := []string{"qualified", "active", "default_enabled", "candidate_enabled"}
-	if closure.Selection.DetectorOption != "RequireExclusiveMatch" ||
+	if closure.Selection.SelectionMode != "exclusive" ||
 		closure.Selection.MaxSelectedPrimaries != 1 ||
 		closure.Selection.NoPositiveOutcome != "NO_MATCH" ||
 		closure.Selection.MultiplePositiveOutcome != "INSUFFICIENT_EVIDENCE" ||
@@ -148,7 +148,7 @@ func TestMixedCatalogExclusiveSelectionRejectsUnequalScoreOverlap(t *testing.T) 
 		decision, err := newDetector(t, catalog, candidates...).Detect(
 			context.Background(),
 			detectionReader(t),
-			reg.DetectionOptions{AllowFixtureOnly: true, RequireExclusiveMatch: true},
+			reg.DetectionOptions{AllowFixtureOnly: true},
 		)
 		if err != nil || decision.Outcome() != reg.DetectionAmbiguous ||
 			decision.Reason() != reg.DetectionReasonMultipleMatches ||
@@ -197,7 +197,7 @@ func TestMixedCatalogExclusiveSelectionPreservesEligibilityLifecycle(t *testing.
 	decision, err := detector.Detect(
 		context.Background(),
 		detectionReader(t),
-		reg.DetectionOptions{AllowFixtureOnly: true, RequireExclusiveMatch: true},
+		reg.DetectionOptions{AllowFixtureOnly: true},
 	)
 	if err != nil || decision.Outcome() != reg.DetectionMatched || decision.SelectedProfileID() != eligible.ID() {
 		t.Fatalf("lifecycle decision=(%+v,%v)", decision, err)

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -53,8 +54,9 @@ func readMixedCatalogClosure(t *testing.T) mixedCatalogClosure {
 	if err := decoder.Decode(&closure); err != nil {
 		t.Fatal(err)
 	}
-	if decoder.More() {
-		t.Fatal("mixed-catalog closure has trailing JSON")
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		t.Fatalf("mixed-catalog closure has trailing JSON: %v", err)
 	}
 	return closure
 }

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -20,6 +20,7 @@ type mixedCatalogClosure struct {
 		GrowattDispositionMerge  string `json:"growatt_disposition_merge"`
 		HuaweiDispositionMerge   string `json:"huawei_disposition_merge"`
 		VendorDocumentationMerge string `json:"vendor_docs_merge"`
+		MixedCatalogDocsMerge    string `json:"mixed_catalog_docs_merge"`
 	} `json:"dependencies"`
 	Selection struct {
 		SelectionMode                     string   `json:"selection_mode"`
@@ -69,7 +70,8 @@ func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
 	if closure.Dependencies.SunSpecExpansionMerge != "7137bf4e3cb5cf84dc581b490fa9c9ddf8ea49f6" ||
 		closure.Dependencies.GrowattDispositionMerge != "5c76899f6e15c52110e14e33e0cc25fe2f3a452b" ||
 		closure.Dependencies.HuaweiDispositionMerge != "110fe6417b511d8cacfdf22fce5d3d5581672c32" ||
-		closure.Dependencies.VendorDocumentationMerge != "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f" {
+		closure.Dependencies.VendorDocumentationMerge != "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f" ||
+		closure.Dependencies.MixedCatalogDocsMerge != "736fd599cf0128b32257c178b454114893b5dc57" {
 		t.Fatalf("unexpected dependency closure: %#v", closure.Dependencies)
 	}
 	wantRequirements := []string{"qualified", "active", "default_enabled", "candidate_enabled"}

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -1,0 +1,217 @@
+package modbusreg_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+type mixedCatalogClosure struct {
+	Schema       string `json:"schema"`
+	Milestone    string `json:"milestone"`
+	Dependencies struct {
+		SunSpecExpansionMerge    string `json:"sunspec_expansion_merge"`
+		GrowattDispositionMerge  string `json:"growatt_disposition_merge"`
+		HuaweiDispositionMerge   string `json:"huawei_disposition_merge"`
+		VendorDocumentationMerge string `json:"vendor_docs_merge"`
+	} `json:"dependencies"`
+	Selection struct {
+		DetectorOption                    string   `json:"detector_option"`
+		MaxSelectedPrimaries              int      `json:"max_selected_primaries"`
+		NoPositiveOutcome                 string   `json:"no_positive_outcome"`
+		MultiplePositiveOutcome           string   `json:"multiple_positive_outcome"`
+		SerializedMultiplePositiveOutcome string   `json:"serialized_multiple_positive_outcome"`
+		SerializedMultiplePositiveReason  string   `json:"serialized_multiple_positive_reason"`
+		ImplicitPriority                  bool     `json:"implicit_priority"`
+		SelectionIsStateless              bool     `json:"selection_is_stateless"`
+		ActivationMutation                bool     `json:"activation_mutation"`
+		EligibleProfileRequirements       []string `json:"eligible_profile_requirements"`
+	} `json:"selection"`
+	Participants []struct {
+		ID              string `json:"id"`
+		Role            string `json:"role"`
+		Disposition     string `json:"disposition"`
+		RuntimeIdentity string `json:"runtime_identity"`
+		DispositionFile string `json:"disposition_file"`
+	} `json:"participants"`
+}
+
+func readMixedCatalogClosure(t *testing.T) mixedCatalogClosure {
+	t.Helper()
+	data, err := os.ReadFile("profiles/mixed-catalog-closure-v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var closure mixedCatalogClosure
+	if err := decoder.Decode(&closure); err != nil {
+		t.Fatal(err)
+	}
+	if decoder.More() {
+		t.Fatal("mixed-catalog closure has trailing JSON")
+	}
+	return closure
+}
+
+func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
+	closure := readMixedCatalogClosure(t)
+	if closure.Schema != "helianthus-modbusreg-mixed-catalog-closure/v1" || closure.Milestone != "FMV3-M7-05" {
+		t.Fatalf("unexpected closure identity: %#v", closure)
+	}
+	if closure.Dependencies.SunSpecExpansionMerge != "7137bf4e3cb5cf84dc581b490fa9c9ddf8ea49f6" ||
+		closure.Dependencies.GrowattDispositionMerge != "5c76899f6e15c52110e14e33e0cc25fe2f3a452b" ||
+		closure.Dependencies.HuaweiDispositionMerge != "110fe6417b511d8cacfdf22fce5d3d5581672c32" ||
+		closure.Dependencies.VendorDocumentationMerge != "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f" {
+		t.Fatalf("unexpected dependency closure: %#v", closure.Dependencies)
+	}
+	wantRequirements := []string{"qualified", "active", "default_enabled", "candidate_enabled"}
+	if closure.Selection.DetectorOption != "RequireExclusiveMatch" ||
+		closure.Selection.MaxSelectedPrimaries != 1 ||
+		closure.Selection.NoPositiveOutcome != "NO_MATCH" ||
+		closure.Selection.MultiplePositiveOutcome != "INSUFFICIENT_EVIDENCE" ||
+		closure.Selection.SerializedMultiplePositiveOutcome != string(reg.DetectionAmbiguous) ||
+		closure.Selection.SerializedMultiplePositiveReason != string(reg.DetectionReasonMultipleMatches) ||
+		closure.Selection.ImplicitPriority || !closure.Selection.SelectionIsStateless ||
+		closure.Selection.ActivationMutation ||
+		!reflect.DeepEqual(closure.Selection.EligibleProfileRequirements, wantRequirements) {
+		t.Fatalf("unexpected selection policy: %#v", closure.Selection)
+	}
+
+	wantParticipants := []struct {
+		id, role, disposition, runtimeIdentity, dispositionFile string
+	}{
+		{"sunspec.direct-inverter", "PRIMARY", "CONDITIONAL_CAPABILITY", reg.SunSpecThreePhaseMonitoringCapabilityID, ""},
+		{"fronius.gen24", "POST_PRIMARY_FLAVOR", "QUALIFIED_FLAVOR_CLASSIFICATION", reg.SunSpecFroniusObservedFlavorID + "," + reg.SunSpecFroniusObservedFlavorV11ID, ""},
+		{"growatt.direct-inverter", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/growatt/disposition.json"},
+		{"huawei.smartlogger", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/huawei/smartlogger-disposition.json"},
+		{"huawei.sdongle", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/huawei/sdongle-disposition.json"},
+		{"huawei.emma", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/huawei/emma-disposition.json"},
+	}
+	if len(closure.Participants) != len(wantParticipants) {
+		t.Fatalf("participants=%d want=%d", len(closure.Participants), len(wantParticipants))
+	}
+	for index, want := range wantParticipants {
+		got := closure.Participants[index]
+		if got.ID != want.id || got.Role != want.role || got.Disposition != want.disposition ||
+			got.RuntimeIdentity != want.runtimeIdentity || got.DispositionFile != want.dispositionFile {
+			t.Fatalf("participant %d=%#v want=%#v", index, got, want)
+		}
+		if got.DispositionFile == "" {
+			continue
+		}
+		data, err := os.ReadFile(got.DispositionFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var disposition struct {
+			Outcome           string `json:"outcome"`
+			CatalogRegistered bool   `json:"catalog_registered"`
+			SupportClaim      bool   `json:"support_claim"`
+		}
+		if err := json.Unmarshal(data, &disposition); err != nil {
+			t.Fatal(err)
+		}
+		if disposition.Outcome != "NO_ADMISSIBLE_PROFILE" || disposition.CatalogRegistered || disposition.SupportClaim {
+			t.Fatalf("participant %s became actionable: %#v", got.ID, disposition)
+		}
+	}
+}
+
+func TestMixedCatalogExclusiveSelectionRejectsUnequalScoreOverlap(t *testing.T) {
+	profiles := []reg.ProfileDescriptor{
+		detectionProfile(t, "fixture.sunspec.direct", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true),
+		detectionProfile(t, "fixture.huawei.smartlogger", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true),
+		detectionProfile(t, "fixture.huawei.sdongle", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true),
+		detectionProfile(t, "fixture.huawei.emma", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true),
+	}
+	scores := []uint32{100, 80, 60, 40}
+
+	for _, order := range [][]int{{0, 1, 2, 3}, {3, 1, 0, 2}} {
+		catalogProfiles := make([]reg.ProfileDescriptor, len(order))
+		candidates := make([]reg.DetectionCandidate, len(order))
+		for index, source := range order {
+			catalogProfiles[index] = profiles[source]
+			candidates[index] = detectionCandidate(t, profiles[source], scores[source], true, true)
+		}
+		catalog, err := reg.NewCatalog(catalogProfiles...)
+		if err != nil {
+			t.Fatalf("NewCatalog: %v", err)
+		}
+		decision, err := newDetector(t, catalog, candidates...).Detect(
+			context.Background(),
+			detectionReader(t),
+			reg.DetectionOptions{AllowFixtureOnly: true, RequireExclusiveMatch: true},
+		)
+		if err != nil || decision.Outcome() != reg.DetectionAmbiguous ||
+			decision.Reason() != reg.DetectionReasonMultipleMatches ||
+			decision.SelectedProfileID() != "" {
+			t.Fatalf("exclusive overlap decision=(%+v,%v)", decision, err)
+		}
+		for _, evidence := range decision.Evidence() {
+			if evidence.Reason != reg.DetectionReasonMultipleMatches {
+				t.Fatalf("overlap evidence for %s=%q", evidence.ProfileID, evidence.Reason)
+			}
+		}
+		encoded, err := reg.MarshalDetectionDecision(decision)
+		if err != nil {
+			t.Fatalf("MarshalDetectionDecision: %v", err)
+		}
+		roundTrip, err := reg.UnmarshalDetectionDecision(encoded)
+		if err != nil || roundTrip.Outcome() != reg.DetectionAmbiguous || roundTrip.Reason() != reg.DetectionReasonMultipleMatches {
+			t.Fatalf("round-trip decision=(%+v,%v)", roundTrip, err)
+		}
+	}
+}
+
+func TestMixedCatalogExclusiveSelectionPreservesEligibilityLifecycle(t *testing.T) {
+	eligible := detectionProfile(t, "fixture.sunspec.eligible", "1.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	unqualified := detectionProfile(t, "fixture.huawei.emma", "1.0.0", reg.MaturityExperimental, reg.ProfileActive, false)
+	revoked := detectionProfile(t, "fixture.huawei.smartlogger", "1.0.0", reg.MaturityQualified, reg.ProfileRevoked, false)
+	replacement := detectionProfile(t, "fixture.huawei.sdongle.v2", "2.0.0", reg.MaturityQualified, reg.ProfileActive, true)
+	supersededSpec := detectionProfile(t, "fixture.huawei.sdongle", "1.0.0", reg.MaturityQualified, reg.ProfileActive, false).Spec()
+	supersededSpec.State = reg.ProfileSuperseded
+	supersededSpec.SupersededByID = replacement.ID()
+	supersededSpec.SupersededByVersion = replacement.Version()
+	superseded, err := reg.NewProfileDescriptor(supersededSpec)
+	if err != nil {
+		t.Fatalf("NewProfileDescriptor(superseded): %v", err)
+	}
+	catalog, err := reg.NewCatalog(eligible, unqualified, revoked, superseded, replacement)
+	if err != nil {
+		t.Fatalf("NewCatalog: %v", err)
+	}
+	detector := newDetector(t, catalog,
+		detectionCandidate(t, unqualified, 400, true, true),
+		detectionCandidate(t, revoked, 300, true, true),
+		detectionCandidate(t, superseded, 200, true, true),
+		detectionCandidate(t, eligible, 1, true, true),
+	)
+	decision, err := detector.Detect(
+		context.Background(),
+		detectionReader(t),
+		reg.DetectionOptions{AllowFixtureOnly: true, RequireExclusiveMatch: true},
+	)
+	if err != nil || decision.Outcome() != reg.DetectionMatched || decision.SelectedProfileID() != eligible.ID() {
+		t.Fatalf("lifecycle decision=(%+v,%v)", decision, err)
+	}
+	reasons := make(map[string]reg.DetectionReason)
+	for _, evidence := range decision.Evidence() {
+		reasons[evidence.ProfileID] = evidence.Reason
+	}
+	want := map[string]reg.DetectionReason{
+		unqualified.ID(): reg.DetectionReasonProfileUnqualified,
+		revoked.ID():     reg.DetectionReasonProfileRevoked,
+		superseded.ID():  reg.DetectionReasonProfileSuperseded,
+	}
+	for profileID, reason := range want {
+		if reasons[profileID] != reason {
+			t.Fatalf("reason[%s]=%q want=%q", profileID, reasons[profileID], reason)
+		}
+	}
+}

--- a/profile_detection.go
+++ b/profile_detection.go
@@ -227,6 +227,7 @@ type DetectionReason string
 const (
 	DetectionReasonSelected             DetectionReason = "selected"
 	DetectionReasonEqualBest            DetectionReason = "equal_best"
+	DetectionReasonMultipleMatches      DetectionReason = "multiple_matches"
 	DetectionReasonLowerScore           DetectionReason = "lower_score"
 	DetectionReasonIdentityMismatch     DetectionReason = "identity_mismatch"
 	DetectionReasonFirmwareMismatch     DetectionReason = "firmware_mismatch"
@@ -247,6 +248,8 @@ const (
 // DetectionOptions contains per-call policy that cannot alter declarations.
 type DetectionOptions struct {
 	AllowFixtureOnly bool
+	// RequireExclusiveMatch rejects every multi-match before score ranking.
+	RequireExclusiveMatch bool
 }
 
 // DetectionCandidateEvidence is one immutable-decision candidate projection.
@@ -569,6 +572,18 @@ func (detector *ProfileDetector) Detect(
 		return detector.finalizeDecision(detector.decision(
 			DetectionNoMatch,
 			noMatchReason(evidence),
+			"",
+			Version{},
+			evidence,
+		))
+	}
+	if options.RequireExclusiveMatch && len(matched) > 1 {
+		for _, index := range matched {
+			evidence[index].Reason = DetectionReasonMultipleMatches
+		}
+		return detector.finalizeDecision(detector.decision(
+			DetectionAmbiguous,
+			DetectionReasonMultipleMatches,
 			"",
 			Version{},
 			evidence,

--- a/profile_detection.go
+++ b/profile_detection.go
@@ -248,8 +248,6 @@ const (
 // DetectionOptions contains per-call policy that cannot alter declarations.
 type DetectionOptions struct {
 	AllowFixtureOnly bool
-	// RequireExclusiveMatch rejects every multi-match before score ranking.
-	RequireExclusiveMatch bool
 }
 
 // DetectionCandidateEvidence is one immutable-decision candidate projection.
@@ -577,7 +575,7 @@ func (detector *ProfileDetector) Detect(
 			evidence,
 		))
 	}
-	if options.RequireExclusiveMatch && len(matched) > 1 {
+	if len(matched) > 1 {
 		for _, index := range matched {
 			evidence[index].Reason = DetectionReasonMultipleMatches
 		}
@@ -589,33 +587,7 @@ func (detector *ProfileDetector) Detect(
 			evidence,
 		))
 	}
-	highest := uint32(0)
-	for _, index := range matched {
-		if evidence[index].Score > highest {
-			highest = evidence[index].Score
-		}
-	}
-	best := make([]int, 0, len(matched))
-	for _, index := range matched {
-		if evidence[index].Score == highest {
-			best = append(best, index)
-		} else {
-			evidence[index].Reason = DetectionReasonLowerScore
-		}
-	}
-	if len(best) != 1 {
-		for _, index := range best {
-			evidence[index].Reason = DetectionReasonEqualBest
-		}
-		return detector.finalizeDecision(detector.decision(
-			DetectionAmbiguous,
-			DetectionReasonEqualBest,
-			"",
-			Version{},
-			evidence,
-		))
-	}
-	selected := evidence[best[0]]
+	selected := evidence[matched[0]]
 	return detector.finalizeDecision(detector.decision(
 		DetectionMatched,
 		DetectionReasonSelected,

--- a/profiles/mixed-catalog-closure-v1.json
+++ b/profiles/mixed-catalog-closure-v1.json
@@ -1,0 +1,71 @@
+{
+  "schema": "helianthus-modbusreg-mixed-catalog-closure/v1",
+  "milestone": "FMV3-M7-05",
+  "dependencies": {
+    "sunspec_expansion_merge": "7137bf4e3cb5cf84dc581b490fa9c9ddf8ea49f6",
+    "growatt_disposition_merge": "5c76899f6e15c52110e14e33e0cc25fe2f3a452b",
+    "huawei_disposition_merge": "110fe6417b511d8cacfdf22fce5d3d5581672c32",
+    "vendor_docs_merge": "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f"
+  },
+  "selection": {
+    "detector_option": "RequireExclusiveMatch",
+    "max_selected_primaries": 1,
+    "no_positive_outcome": "NO_MATCH",
+    "multiple_positive_outcome": "INSUFFICIENT_EVIDENCE",
+    "serialized_multiple_positive_outcome": "ambiguous",
+    "serialized_multiple_positive_reason": "multiple_matches",
+    "implicit_priority": false,
+    "selection_is_stateless": true,
+    "activation_mutation": false,
+    "eligible_profile_requirements": [
+      "qualified",
+      "active",
+      "default_enabled",
+      "candidate_enabled"
+    ]
+  },
+  "participants": [
+    {
+      "id": "sunspec.direct-inverter",
+      "role": "PRIMARY",
+      "disposition": "CONDITIONAL_CAPABILITY",
+      "runtime_identity": "sunspec.inverter.three_phase.monitoring@1.0.0",
+      "disposition_file": ""
+    },
+    {
+      "id": "fronius.gen24",
+      "role": "POST_PRIMARY_FLAVOR",
+      "disposition": "QUALIFIED_FLAVOR_CLASSIFICATION",
+      "runtime_identity": "sunspec.flavor.fronius.gen24.float.observed@1.0.0,sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+      "disposition_file": ""
+    },
+    {
+      "id": "growatt.direct-inverter",
+      "role": "PRIMARY_CANDIDATE",
+      "disposition": "NO_ADMISSIBLE_PROFILE",
+      "runtime_identity": "",
+      "disposition_file": "profiles/vendor/growatt/disposition.json"
+    },
+    {
+      "id": "huawei.smartlogger",
+      "role": "PRIMARY_CANDIDATE",
+      "disposition": "NO_ADMISSIBLE_PROFILE",
+      "runtime_identity": "",
+      "disposition_file": "profiles/vendor/huawei/smartlogger-disposition.json"
+    },
+    {
+      "id": "huawei.sdongle",
+      "role": "PRIMARY_CANDIDATE",
+      "disposition": "NO_ADMISSIBLE_PROFILE",
+      "runtime_identity": "",
+      "disposition_file": "profiles/vendor/huawei/sdongle-disposition.json"
+    },
+    {
+      "id": "huawei.emma",
+      "role": "PRIMARY_CANDIDATE",
+      "disposition": "NO_ADMISSIBLE_PROFILE",
+      "runtime_identity": "",
+      "disposition_file": "profiles/vendor/huawei/emma-disposition.json"
+    }
+  ]
+}

--- a/profiles/mixed-catalog-closure-v1.json
+++ b/profiles/mixed-catalog-closure-v1.json
@@ -5,7 +5,8 @@
     "sunspec_expansion_merge": "7137bf4e3cb5cf84dc581b490fa9c9ddf8ea49f6",
     "growatt_disposition_merge": "5c76899f6e15c52110e14e33e0cc25fe2f3a452b",
     "huawei_disposition_merge": "110fe6417b511d8cacfdf22fce5d3d5581672c32",
-    "vendor_docs_merge": "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f"
+    "vendor_docs_merge": "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f",
+    "mixed_catalog_docs_merge": "736fd599cf0128b32257c178b454114893b5dc57"
   },
   "selection": {
     "selection_mode": "exclusive",

--- a/profiles/mixed-catalog-closure-v1.json
+++ b/profiles/mixed-catalog-closure-v1.json
@@ -8,7 +8,7 @@
     "vendor_docs_merge": "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f"
   },
   "selection": {
-    "detector_option": "RequireExclusiveMatch",
+    "selection_mode": "exclusive",
     "max_selected_primaries": 1,
     "no_positive_outcome": "NO_MATCH",
     "multiple_positive_outcome": "INSUFFICIENT_EVIDENCE",


### PR DESCRIPTION
Closes #33

## Scope
- add the canonical FMV3-M7-05 mixed-catalog closure
- make every 2+ eligible match fail closed before scoring
- preserve one-match selection and all lifecycle eligibility filters
- preserve decoding compatibility for historical ranked/equal-best durable decisions
- prove unequal-score overlap, catalog-order independence, decision round-trip, and current vendor non-admission

## TDD
- initial RED: `0fb42c67c60eac7d929944b16b462ed992be8b39`
- initial GREEN: `d1144eea079e8feae40144c1ee21f8c4415d0322`
- canonical-rule RED: `08f9f3c` (default detector still selected highest score)
- corrective GREEN: `379e0d8`
- final docs pin exact HEAD: `1eece2c54087248cfe5209feb39635e1a58222c2`

## Validation
- focused race: mixed-catalog, default multi-match, lifecycle PASS
- `GOWORK=off ./scripts/ci_local.sh` PASS: scope policy + 14 mutation tests, gofmt, vet, build, full race, lint 0
- GitHub exact-HEAD checks pending
- fresh exact-HEAD review pending

## Docs gate
- companion PR #479 squash-merged
- premerge docs HEAD: `6694e6c6d3945fd7b098b5995003f4d21613af0f`
- docs merge/main: `736fd599cf0128b32257c178b454114893b5dc57`
- docs full local/GitHub CI and fresh NO_BLOCKING_FINDINGS

## Boundaries
- no vendor profile admission
- no Modbus I/O or transport change; T01..T88 N/A
- no gateway/add-on/live work
- no semantic-registry dependency