### PR TITLE
Tesla: add HSC TEDAPI-over-Modbus profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Project-Helianthus/helianthus-modbusreg
 
 go 1.22
 
-require github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260820212315-c78030472c24
+require github.com/Project-Helianthus/helianthus-modbus v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260820212315-c78030472c24 h1:6VN7739EZvGVwyMJ7F8k9Qavy37d33CFFNq1xqhXebY=
 github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260820212315-c78030472c24/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
+github.com/Project-Helianthus/helianthus-modbus v0.1.0 h1:doB3rq5aCC2uZ5MmLBCTBzYbB7o3XixUAWxfYc+Sr8Q=
+github.com/Project-Helianthus/helianthus-modbus v0.1.0/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=

--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -16,6 +16,7 @@ const (
 	huaweiDocsMergeSHA = "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f"
 	huaweiModbusMerge  = "c78030472c24f0f2b849fd30124611157a81f834"
 	huaweiModbusPin    = "v0.0.0-20260820212315-c78030472c24"
+	currentModbusPin   = "v0.1.0"
 )
 
 type huaweiFamilyExpectation struct {
@@ -113,7 +114,7 @@ func TestHuaweiGatewayDispositionsFailClosedIndependently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantDependency := "github.com/Project-Helianthus/helianthus-modbus " + huaweiModbusPin
+	wantDependency := "github.com/Project-Helianthus/helianthus-modbus " + currentModbusPin
 	if !strings.Contains(string(goMod), wantDependency) {
 		t.Fatalf("missing exact transport dependency %q", wantDependency)
 	}

--- a/policy/registry-boundary.json
+++ b/policy/registry-boundary.json
@@ -58,7 +58,8 @@
   "vendor_identifiers": [
     "fronius",
     "growatt",
-    "huawei"
+    "huawei",
+    "tesla"
   ],
   "standard_family_vendor_neutral": true,
   "vendor_overlay_requires_public_evidence": true

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -1,0 +1,185 @@
+package modbusreg
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// TeslaHSCCompatibilityV1 is the initial public profile compatibility gate.
+const TeslaHSCCompatibilityV1 = "tesla_hsc_modbus_v1"
+
+// TeslaHSCDisposition records whether a configured profile can do more than
+// parse bounded frames. Qualification never grants opaque outbound admission.
+type TeslaHSCDisposition string
+
+const (
+	TeslaHSCDisabled          TeslaHSCDisposition = "disabled"
+	TeslaHSCFramingOnly       TeslaHSCDisposition = "framing_only"
+	TeslaHSCQualifiedReadOnly TeslaHSCDisposition = "qualified_read_only"
+)
+
+// TeslaHSCProfileConfig is an explicit local flavor configuration. A matching
+// node or a readable frame is not a substitute for this configuration.
+type TeslaHSCProfileConfig struct {
+	Enabled              bool
+	Node                 byte
+	PassiveCompatible    bool
+	CompatibilityVersion string
+}
+
+// TeslaHSCProfile retains the immutable profile gate decision.
+type TeslaHSCProfile struct {
+	config      TeslaHSCProfileConfig
+	disposition TeslaHSCDisposition
+}
+
+// NewTeslaHSCProfile validates explicit configuration and calculates its
+// fail-closed disposition without transmitting any vendor request.
+func NewTeslaHSCProfile(config TeslaHSCProfileConfig) (TeslaHSCProfile, error) {
+	if config.Node == 0 || config.Node > 247 {
+		return TeslaHSCProfile{}, fmt.Errorf("tesla HSC node is invalid")
+	}
+	if config.CompatibilityVersion == "" {
+		return TeslaHSCProfile{}, fmt.Errorf("tesla HSC compatibility version is required")
+	}
+	disposition := TeslaHSCDisabled
+	if config.Enabled {
+		disposition = TeslaHSCFramingOnly
+		if config.PassiveCompatible &&
+			config.CompatibilityVersion == TeslaHSCCompatibilityV1 {
+			disposition = TeslaHSCQualifiedReadOnly
+		}
+	}
+	return TeslaHSCProfile{config: config, disposition: disposition}, nil
+}
+
+// Node returns the explicitly configured RTU node.
+func (profile TeslaHSCProfile) Node() byte {
+	return profile.config.Node
+}
+
+// Disposition returns the fail-closed profile qualification result.
+func (profile TeslaHSCProfile) Disposition() TeslaHSCDisposition {
+	return profile.disposition
+}
+
+// OutboundAllowed always denies wire transmission in the opaque initial
+// profile. A later typed, read-only operation contract must opt in separately.
+func (TeslaHSCProfile) OutboundAllowed() bool {
+	return false
+}
+
+// TeslaHSCEnvelope is a decoded length envelope with uninterpreted inner bytes.
+type TeslaHSCEnvelope struct {
+	function modbus.FunctionCode
+	payload  []byte
+}
+
+// DecodeTeslaHSCEnvelope validates the one-byte exact length envelope used by
+// all supported HSC vendor functions and retains the nested bytes opaquely.
+func DecodeTeslaHSCEnvelope(
+	function modbus.FunctionCode,
+	payload []byte,
+) (TeslaHSCEnvelope, error) {
+	if !isTeslaHSCFunction(function) {
+		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC function is unsupported")
+	}
+	if len(payload) == 0 {
+		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC payload has no length prefix")
+	}
+	if int(payload[0]) != len(payload)-1 {
+		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC length prefix is inexact")
+	}
+	return TeslaHSCEnvelope{
+		function: function,
+		payload:  append([]byte(nil), payload[1:]...),
+	}, nil
+}
+
+// Function returns the vendor function identified by this envelope.
+func (envelope TeslaHSCEnvelope) Function() modbus.FunctionCode {
+	return envelope.function
+}
+
+// Payload returns an independent copy of opaque inner bytes.
+func (envelope TeslaHSCEnvelope) Payload() []byte {
+	return append([]byte(nil), envelope.payload...)
+}
+
+func isTeslaHSCFunction(function modbus.FunctionCode) bool {
+	switch function {
+	case modbus.FunctionVendor100,
+		modbus.FunctionVendor101,
+		modbus.FunctionVendor102:
+		return true
+	default:
+		return false
+	}
+}
+
+// TeslaHSCException classifies only the documented opaque response outcomes.
+type TeslaHSCException string
+
+const (
+	TeslaHSCExceptionUnknown         TeslaHSCException = "unknown"
+	TeslaHSCExceptionUnknownFunction TeslaHSCException = "unknown_function"
+	TeslaHSCExceptionCodecFailure    TeslaHSCException = "codec_failure"
+)
+
+// ClassifyTeslaHSCException classifies exception status without decoding any
+// opaque vendor payload or inventing field semantics.
+func ClassifyTeslaHSCException(
+	function modbus.FunctionCode,
+	status byte,
+) TeslaHSCException {
+	if !isTeslaHSCFunction(function) {
+		return TeslaHSCExceptionUnknown
+	}
+	if status == 1 {
+		return TeslaHSCExceptionUnknownFunction
+	}
+	if status == 4 &&
+		(function == modbus.FunctionVendor101 || function == modbus.FunctionVendor102) {
+		return TeslaHSCExceptionCodecFailure
+	}
+	return TeslaHSCExceptionUnknown
+}
+
+// TeslaHSCProvenance retains redacted, deterministic payload identity only.
+type TeslaHSCProvenance struct {
+	compatibilityVersion string
+	node                 byte
+	function             modbus.FunctionCode
+	payloadLength        int
+	payloadDigest        string
+}
+
+// NewTeslaHSCProvenance creates provenance that contains no raw payload bytes.
+func NewTeslaHSCProvenance(
+	compatibilityVersion string,
+	node byte,
+	function modbus.FunctionCode,
+	payload []byte,
+) TeslaHSCProvenance {
+	digest := sha256.Sum256(payload)
+	return TeslaHSCProvenance{
+		compatibilityVersion: compatibilityVersion,
+		node:                 node,
+		function:             function,
+		payloadLength:        len(payload),
+		payloadDigest:        hex.EncodeToString(digest[:]),
+	}
+}
+
+// PayloadLength returns the retained opaque payload length.
+func (provenance TeslaHSCProvenance) PayloadLength() int {
+	return provenance.payloadLength
+}
+
+// PayloadDigest returns the redacted deterministic payload digest.
+func (provenance TeslaHSCProvenance) PayloadDigest() string {
+	return provenance.payloadDigest
+}

--- a/tesla_hsc_test.go
+++ b/tesla_hsc_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestTeslaHSCProfileFailsClosedUntilExplicitlyQualified(t *testing.T) {
 	framing, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
-		Enabled:               true,
-		Node:                  0x10,
-		PassiveCompatible:     true,
-		CompatibilityVersion:  "unknown",
+		Enabled:              true,
+		Node:                 0x10,
+		PassiveCompatible:    true,
+		CompatibilityVersion: "unknown",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -21,10 +21,10 @@ func TestTeslaHSCProfileFailsClosedUntilExplicitlyQualified(t *testing.T) {
 		t.Fatalf("framing profile = %#v", framing)
 	}
 	qualified, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
-		Enabled:               true,
-		Node:                  0x10,
-		PassiveCompatible:     true,
-		CompatibilityVersion:  TeslaHSCCompatibilityV1,
+		Enabled:              true,
+		Node:                 0x10,
+		PassiveCompatible:    true,
+		CompatibilityVersion: TeslaHSCCompatibilityV1,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/tesla_hsc_test.go
+++ b/tesla_hsc_test.go
@@ -1,0 +1,79 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaHSCProfileFailsClosedUntilExplicitlyQualified(t *testing.T) {
+	framing, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:               true,
+		Node:                  0x10,
+		PassiveCompatible:     true,
+		CompatibilityVersion:  "unknown",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if framing.Disposition() != TeslaHSCFramingOnly || framing.OutboundAllowed() {
+		t.Fatalf("framing profile = %#v", framing)
+	}
+	qualified, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:               true,
+		Node:                  0x10,
+		PassiveCompatible:     true,
+		CompatibilityVersion:  TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if qualified.Disposition() != TeslaHSCQualifiedReadOnly {
+		t.Fatalf("qualified disposition = %q", qualified.Disposition())
+	}
+	if qualified.OutboundAllowed() {
+		t.Fatal("opaque profile permitted live outbound operation")
+	}
+}
+
+func TestTeslaHSCEnvelopesValidateAndRetainOpaquePayload(t *testing.T) {
+	for _, function := range []modbus.FunctionCode{
+		modbus.FunctionVendor100,
+		modbus.FunctionVendor101,
+		modbus.FunctionVendor102,
+	} {
+		envelope, err := DecodeTeslaHSCEnvelope(function, []byte{2, 0xaa, 0xbb})
+		if err != nil {
+			t.Fatalf("function %d: %v", function, err)
+		}
+		if got, want := envelope.Payload(), []byte{0xaa, 0xbb}; !bytes.Equal(got, want) {
+			t.Fatalf("function %d payload = %x, want %x", function, got, want)
+		}
+	}
+	for _, payload := range [][]byte{nil, {1}, {1, 0xaa, 0xbb}} {
+		if _, err := DecodeTeslaHSCEnvelope(modbus.FunctionVendor100, payload); err == nil {
+			t.Fatalf("FC100 invalid payload accepted: %x", payload)
+		}
+	}
+}
+
+func TestTeslaHSCExceptionAndRedactedProvenance(t *testing.T) {
+	classification := ClassifyTeslaHSCException(modbus.FunctionVendor101, 4)
+	if classification != TeslaHSCExceptionCodecFailure {
+		t.Fatalf("exception classification = %q", classification)
+	}
+	provenance := NewTeslaHSCProvenance(
+		TeslaHSCCompatibilityV1,
+		0x10,
+		modbus.FunctionVendor102,
+		[]byte("sensitive-fixture-identifier"),
+	)
+	if provenance.PayloadLength() != len("sensitive-fixture-identifier") ||
+		provenance.PayloadDigest() == "" {
+		t.Fatalf("provenance = %#v", provenance)
+	}
+	if bytes.Contains([]byte(provenance.PayloadDigest()), []byte("sensitive")) {
+		t.Fatal("provenance leaked raw payload")
+	}
+}


### PR DESCRIPTION
Closes #36

## Scope

Adds the Tesla HSC profile above generic Modbus RTU: explicit configuration, passive compatibility/version gates, FC100/101/102 exact-length envelopes, narrow exception classification, copy-safe opaque retention, and redacted deterministic provenance.

## Strict RED-first

Tests-only RED head: `65b55400208f208cbafd36a67a6f78b26fbc40ac`. GitHub Actions run `32644399053` observed the exact-head compile failure before implementation.

## Safety

- disabled/framing-only unless explicit config plus passive compatibility and v1 compatibility gate pass;
- matching node, readable frame, and detection never admit vendor transmission;
- no typed TEDAPI codec is proven in this milestone, so `OutboundAllowed()` remains false even when profile qualification succeeds;
- FC101/102 stay opaque; no inferred fields, units, enums, or command semantics;
- provenance retains only length and SHA-256 digest, never raw payload bytes.

## Exact-HEAD local GREEN

`./scripts/ci_local.sh`: scope and Python policy tests, gofmt, vet, build, race suite, and golangci-lint all PASS.

## Dependencies

- `helianthus-modbus` `v0.1.0` / `f9fbdcca341fa4a8b056a8e9a74bab1bc917e7d8`;
- `helianthus-docs-modbus#2` / `28c90f53713e2c1c9bc66ae7c7c50bee45898dd4`.

T01–T88 is eBUS-only and not applicable. Awaiting GitHub CI and fresh exact-HEAD review.