### PR TITLE
Tesla: add bounded TEDAPI semantic registry

### DIFF
--- a/tesla_tedapi_registry.go
+++ b/tesla_tedapi_registry.go
@@ -1,0 +1,109 @@
+package modbusreg
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+const maxTeslaTEDAPIObservations = 64
+
+// TeslaTEDAPISemanticState describes the deliberately narrow projection level.
+type TeslaTEDAPISemanticState string
+
+const (
+	TeslaTEDAPIFramingOnly     TeslaTEDAPISemanticState = "framing_only"
+	TeslaTEDAPIOpaqueQualified TeslaTEDAPISemanticState = "opaque_qualified"
+)
+
+// TeslaTEDAPIObservationSpec is one bounded TEDAPI envelope observation.
+type TeslaTEDAPIObservationSpec struct {
+	ID       string
+	Profile  TeslaHSCProfile
+	Function modbus.FunctionCode
+	Payload  []byte
+}
+
+// TeslaTEDAPIRedactedRecord is safe for gateway/MCP projection. Payload never
+// contains raw bytes; digest and length preserve deterministic replay identity.
+type TeslaTEDAPIRedactedRecord struct {
+	ID              string                   `json:"id"`
+	State           TeslaTEDAPISemanticState `json:"state"`
+	Function        byte                     `json:"function"`
+	PayloadLength   int                      `json:"payload_length"`
+	PayloadDigest   string                   `json:"payload_digest"`
+	OutboundAllowed bool                     `json:"outbound_allowed"`
+}
+
+// TeslaTEDAPISemanticRegistry is a bounded, concurrent registry of opaque
+// observations. It does not decode fields or declare a control operation.
+type TeslaTEDAPISemanticRegistry struct {
+	mu      sync.RWMutex
+	records map[string]TeslaTEDAPIRedactedRecord
+}
+
+// NewTeslaTEDAPISemanticRegistry constructs an empty bounded registry.
+func NewTeslaTEDAPISemanticRegistry() *TeslaTEDAPISemanticRegistry {
+	return &TeslaTEDAPISemanticRegistry{records: make(map[string]TeslaTEDAPIRedactedRecord)}
+}
+
+// Retain validates an envelope and atomically retains a redacted projection.
+func (registry *TeslaTEDAPISemanticRegistry) Retain(spec TeslaTEDAPIObservationSpec) error {
+	if registry == nil || !validIdentity(spec.ID) {
+		return fmt.Errorf("tesla TEDAPI observation identity is invalid")
+	}
+	envelope, err := DecodeTeslaHSCEnvelope(spec.Function, spec.Payload)
+	if err != nil {
+		return err
+	}
+	state := TeslaTEDAPIFramingOnly
+	if spec.Profile.Disposition() == TeslaHSCQualifiedReadOnly {
+		state = TeslaTEDAPIOpaqueQualified
+	}
+	provenance := NewTeslaHSCProvenance(
+		TeslaHSCCompatibilityV1,
+		spec.Profile.Node(),
+		envelope.Function(),
+		envelope.Payload(),
+	)
+	record := TeslaTEDAPIRedactedRecord{
+		ID: spec.ID, State: state, Function: byte(envelope.Function()),
+		PayloadLength: provenance.PayloadLength(), PayloadDigest: provenance.PayloadDigest(),
+		OutboundAllowed: false,
+	}
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	if _, exists := registry.records[spec.ID]; !exists && len(registry.records) >= maxTeslaTEDAPIObservations {
+		return fmt.Errorf("tesla TEDAPI observation registry is full")
+	}
+	registry.records[spec.ID] = record
+	return nil
+}
+
+// Lookup returns an independent redacted record.
+func (registry *TeslaTEDAPISemanticRegistry) Lookup(id string) (TeslaTEDAPIRedactedRecord, bool) {
+	if registry == nil {
+		return TeslaTEDAPIRedactedRecord{}, false
+	}
+	registry.mu.RLock()
+	record, ok := registry.records[id]
+	registry.mu.RUnlock()
+	return record, ok
+}
+
+// List returns redacted records in deterministic identity order.
+func (registry *TeslaTEDAPISemanticRegistry) List() []TeslaTEDAPIRedactedRecord {
+	if registry == nil {
+		return nil
+	}
+	registry.mu.RLock()
+	values := make([]TeslaTEDAPIRedactedRecord, 0, len(registry.records))
+	for _, record := range registry.records {
+		values = append(values, record)
+	}
+	registry.mu.RUnlock()
+	sort.Slice(values, func(i, j int) bool { return values[i].ID < values[j].ID })
+	return values
+}

--- a/tesla_tedapi_registry_test.go
+++ b/tesla_tedapi_registry_test.go
@@ -1,0 +1,66 @@
+package modbusreg
+
+import (
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:              true,
+		Node:                 0x10,
+		PassiveCompatible:    true,
+		CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := NewTeslaTEDAPISemanticRegistry()
+	if err := registry.Retain(TeslaTEDAPIObservationSpec{
+		ID:      "sample-1",
+		Profile: profile,
+		Function: modbus.FunctionVendor100,
+		Payload:  []byte{2, 0xaa, 0xbb},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, ok := registry.Lookup("sample-1")
+	if !ok {
+		t.Fatal("retained observation missing")
+	}
+	if record.State != TeslaTEDAPIOpaqueQualified || record.PayloadLength != 2 ||
+		record.PayloadDigest == "" || record.OutboundAllowed {
+		t.Fatalf("record = %#v", record)
+	}
+	if len(record.Payload) != 0 {
+		t.Fatalf("raw payload leaked: %x", record.Payload)
+	}
+}
+
+func TestTeslaTEDAPIRegistryFailsClosedForUnqualifiedOrMalformedInput(t *testing.T) {
+	registry := NewTeslaTEDAPISemanticRegistry()
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:              true,
+		Node:                 0x10,
+		PassiveCompatible:    true,
+		CompatibilityVersion: "unknown",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Retain(TeslaTEDAPIObservationSpec{
+		ID: "sample-2", Profile: profile, Function: modbus.FunctionVendor101, Payload: []byte{0},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	record, _ := registry.Lookup("sample-2")
+	if record.State != TeslaTEDAPIFramingOnly || record.OutboundAllowed {
+		t.Fatalf("unqualified record = %#v", record)
+	}
+	if err := registry.Retain(TeslaTEDAPIObservationSpec{
+		ID: "bad", Profile: profile, Function: modbus.FunctionVendor102, Payload: []byte{1},
+	}); err == nil {
+		t.Fatal("malformed payload accepted")
+	}
+}

--- a/tesla_tedapi_registry_test.go
+++ b/tesla_tedapi_registry_test.go
@@ -18,8 +18,8 @@ func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) 
 	}
 	registry := NewTeslaTEDAPISemanticRegistry()
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
-		ID:      "sample-1",
-		Profile: profile,
+		ID:       "sample-1",
+		Profile:  profile,
 		Function: modbus.FunctionVendor100,
 		Payload:  []byte{2, 0xaa, 0xbb},
 	}); err != nil {
@@ -32,9 +32,6 @@ func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) 
 	if record.State != TeslaTEDAPIOpaqueQualified || record.PayloadLength != 2 ||
 		record.PayloadDigest == "" || record.OutboundAllowed {
 		t.Fatalf("record = %#v", record)
-	}
-	if len(record.Payload) != 0 {
-		t.Fatalf("raw payload leaked: %x", record.Payload)
 	}
 }
 


### PR DESCRIPTION
Closes #38

## Scope

Adds a bounded Tesla TEDAPI semantic registry above the HSC envelope/profile contract. It projects only framing-only or opaque-qualified state; it does not create typed telemetry, fields, units, enums, commands, or outbound admission.

## Strict RED-first

Tests-only RED head: `e58415d5efb6c05df28907899fc413648b549d5c`; hosted CI run `32648642292` failed before implementation.

## Safety

- exact FC100/101/102 envelope validation;
- unknown/unqualified payloads remain opaque;
- registry retention is bounded and deterministic;
- records expose function, state, payload length and digest only, never raw payload;
- outbound permission remains false.

## Local GREEN

`./scripts/ci_local.sh` passed scope gate, policy tests, formatting, vet, build, race tests, and lint. T01–T88 is eBUS-only and not applicable.

Awaiting GitHub CI and fresh exact-HEAD review.