### PR TITLE
Tesla HSC: expose fail-closed operation admission

### DIFF
--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -21,6 +21,25 @@ const (
 	TeslaHSCQualifiedReadOnly TeslaHSCDisposition = "qualified_read_only"
 )
 
+// TeslaTEDAPIAdmissionState distinguishes profile qualification from the
+// separate, per-operation wire-admission decision.
+type TeslaTEDAPIAdmissionState string
+
+const (
+	// TeslaTEDAPIAdmissionBlockedProfile denies an unqualified profile.
+	TeslaTEDAPIAdmissionBlockedProfile TeslaTEDAPIAdmissionState = "blocked_profile"
+	// TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation denies a qualified
+	// profile until a later contract proves one particular operation safe.
+	TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation TeslaTEDAPIAdmissionState = "blocked_no_admissible_operation"
+)
+
+// TeslaTEDAPIOperationAdmission is the redacted result of local admission
+// policy. It deliberately carries no request bytes or inferred operation name.
+type TeslaTEDAPIOperationAdmission struct {
+	State           TeslaTEDAPIAdmissionState
+	OutboundAllowed bool
+}
+
 // TeslaHSCProfileConfig is an explicit local flavor configuration. A matching
 // node or a readable frame is not a substitute for this configuration.
 type TeslaHSCProfileConfig struct {
@@ -70,6 +89,18 @@ func (profile TeslaHSCProfile) Disposition() TeslaHSCDisposition {
 // profile. A later typed, read-only operation contract must opt in separately.
 func (TeslaHSCProfile) OutboundAllowed() bool {
 	return false
+}
+
+// OperationAdmission reports that initial profile qualification never itself
+// authorizes an opaque vendor request. A later contract must add a typed,
+// allowlisted operation before this result can become sendable.
+func (profile TeslaHSCProfile) OperationAdmission() TeslaTEDAPIOperationAdmission {
+	if profile.Disposition() != TeslaHSCQualifiedReadOnly {
+		return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedProfile}
+	}
+	return TeslaTEDAPIOperationAdmission{
+		State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation,
+	}
 }
 
 // TeslaHSCEnvelope is a decoded length envelope with uninterpreted inner bytes.

--- a/tesla_hsc_admission_test.go
+++ b/tesla_hsc_admission_test.go
@@ -1,0 +1,32 @@
+package modbusreg
+
+import "testing"
+
+func TestTeslaHSCOperationAdmissionNeverConflatesProfileWithWireAuthorization(t *testing.T) {
+	qualified, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:              true,
+		Node:                 0x10,
+		PassiveCompatible:    true,
+		CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admission := qualified.OperationAdmission()
+	if admission.State != TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation || admission.OutboundAllowed {
+		t.Fatalf("qualified admission = %#v", admission)
+	}
+
+	framing, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:              true,
+		Node:                 0x10,
+		PassiveCompatible:    true,
+		CompatibilityVersion: "unknown",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admission := framing.OperationAdmission(); admission.State != TeslaTEDAPIAdmissionBlockedProfile || admission.OutboundAllowed {
+		t.Fatalf("framing admission = %#v", admission)
+	}
+}

--- a/tesla_hsc_admission_test.go
+++ b/tesla_hsc_admission_test.go
@@ -29,4 +29,15 @@ func TestTeslaHSCOperationAdmissionNeverConflatesProfileWithWireAuthorization(t 
 	if admission := framing.OperationAdmission(); admission.State != TeslaTEDAPIAdmissionBlockedProfile || admission.OutboundAllowed {
 		t.Fatalf("framing admission = %#v", admission)
 	}
+
+	disabled, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Node:                 0x10,
+		CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admission := disabled.OperationAdmission(); admission.State != TeslaTEDAPIAdmissionBlockedProfile || admission.OutboundAllowed {
+		t.Fatalf("disabled admission = %#v", admission)
+	}
 }

--- a/tesla_tedapi_registry.go
+++ b/tesla_tedapi_registry.go
@@ -29,12 +29,13 @@ type TeslaTEDAPIObservationSpec struct {
 // TeslaTEDAPIRedactedRecord is safe for gateway/MCP projection. Payload never
 // contains raw bytes; digest and length preserve deterministic replay identity.
 type TeslaTEDAPIRedactedRecord struct {
-	ID              string                   `json:"id"`
-	State           TeslaTEDAPISemanticState `json:"state"`
-	Function        byte                     `json:"function"`
-	PayloadLength   int                      `json:"payload_length"`
-	PayloadDigest   string                   `json:"payload_digest"`
-	OutboundAllowed bool                     `json:"outbound_allowed"`
+	ID                 string                    `json:"id"`
+	State              TeslaTEDAPISemanticState  `json:"state"`
+	OperationAdmission TeslaTEDAPIAdmissionState `json:"operation_admission"`
+	Function           byte                      `json:"function"`
+	PayloadLength      int                       `json:"payload_length"`
+	PayloadDigest      string                    `json:"payload_digest"`
+	OutboundAllowed    bool                      `json:"outbound_allowed"`
 }
 
 // TeslaTEDAPISemanticRegistry is a bounded, concurrent registry of opaque
@@ -68,8 +69,9 @@ func (registry *TeslaTEDAPISemanticRegistry) Retain(spec TeslaTEDAPIObservationS
 		envelope.Function(),
 		envelope.Payload(),
 	)
+	admission := spec.Profile.OperationAdmission()
 	record := TeslaTEDAPIRedactedRecord{
-		ID: spec.ID, State: state, Function: byte(envelope.Function()),
+		ID: spec.ID, State: state, OperationAdmission: admission.State, Function: byte(envelope.Function()),
 		PayloadLength: provenance.PayloadLength(), PayloadDigest: provenance.PayloadDigest(),
 		OutboundAllowed: false,
 	}

--- a/tesla_tedapi_registry_test.go
+++ b/tesla_tedapi_registry_test.go
@@ -53,7 +53,9 @@ func TestTeslaTEDAPIRegistryFailsClosedForUnqualifiedOrMalformedInput(t *testing
 		t.Fatal(err)
 	}
 	record, _ := registry.Lookup("sample-2")
-	if record.State != TeslaTEDAPIFramingOnly || record.OutboundAllowed {
+	if record.State != TeslaTEDAPIFramingOnly ||
+		record.OperationAdmission != TeslaTEDAPIAdmissionBlockedProfile ||
+		record.OutboundAllowed {
 		t.Fatalf("unqualified record = %#v", record)
 	}
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{

--- a/tesla_tedapi_registry_test.go
+++ b/tesla_tedapi_registry_test.go
@@ -29,8 +29,9 @@ func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) 
 	if !ok {
 		t.Fatal("retained observation missing")
 	}
-	if record.State != TeslaTEDAPIOpaqueQualified || record.PayloadLength != 2 ||
-		record.PayloadDigest == "" || record.OutboundAllowed {
+	if record.State != TeslaTEDAPIOpaqueQualified ||
+		record.OperationAdmission != TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation ||
+		record.PayloadLength != 2 || record.PayloadDigest == "" || record.OutboundAllowed {
 		t.Fatalf("record = %#v", record)
 	}
 }


### PR DESCRIPTION
Closes #40

RED-first contract for a redacted operation-admission state. It makes explicit that profile qualification is not permission to transmit a vendor request.

No request bytes, serial transport, gateway/MCP wiring, or hardware I/O.