### PR TITLE
Registry: scope private function codecs by qualified profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Project-Helianthus/helianthus-modbusreg
 
 go 1.22
 
-require github.com/Project-Helianthus/helianthus-modbus v0.1.0
+require github.com/Project-Helianthus/helianthus-modbus v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260820212315-c78030472c24 h1:6VN7739EZvGVwyMJ7F8k9Qavy37d33CFFNq1xqhXebY=
-github.com/Project-Helianthus/helianthus-modbus v0.0.0-20260820212315-c78030472c24/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
-github.com/Project-Helianthus/helianthus-modbus v0.1.0 h1:doB3rq5aCC2uZ5MmLBCTBzYbB7o3XixUAWxfYc+Sr8Q=
-github.com/Project-Helianthus/helianthus-modbus v0.1.0/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=
+github.com/Project-Helianthus/helianthus-modbus v0.3.0 h1:cmYb4WqaAl9DmDAfwnBJf5YIzXyYfnsZRcuZEk1d7/I=
+github.com/Project-Helianthus/helianthus-modbus v0.3.0/go.mod h1:Nr8SW7fE3SIjnp+rj8PCOtwk8JZ9wqafu1ZCgq3Zz+Q=

--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -16,7 +16,7 @@ const (
 	huaweiDocsMergeSHA = "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f"
 	huaweiModbusMerge  = "c78030472c24f0f2b849fd30124611157a81f834"
 	huaweiModbusPin    = "v0.0.0-20260820212315-c78030472c24"
-	currentModbusPin   = "v0.1.0"
+	currentModbusPin   = "v0.3.0"
 )
 
 type huaweiFamilyExpectation struct {

--- a/qualified_function_registry.go
+++ b/qualified_function_registry.go
@@ -1,0 +1,121 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// ErrQualifiedFunctionNoSend reports a rejected profile or operation before
+// any exchange has been invoked.
+var ErrQualifiedFunctionNoSend = errors.New("qualified function operation is not admitted")
+
+// QualifiedFunctionSelector identifies one profile-scoped operation. It
+// deliberately contains no caller-provided function-code or raw payload.
+type QualifiedFunctionSelector struct {
+	Endpoint      string
+	UnitID        byte
+	VendorProfile string
+	Operation     string
+}
+
+// QualifiedFunctionResult retains bytes accepted by the selected codec only.
+// The registry does not infer fields, units, or operation semantics.
+type QualifiedFunctionResult struct {
+	Payload []byte
+}
+
+// QualifiedFunctionCodec owns construction and normal-response decoding for
+// one selected vendor profile. It is never selected from a function code.
+type QualifiedFunctionCodec interface {
+	EncodeQualifiedFunction(string) (modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy, error)
+	DecodeQualifiedFunction(string, modbus.PrivateFunctionCode, []byte) (QualifiedFunctionResult, error)
+}
+
+// QualifiedFunctionProfile binds one codec to one endpoint and unit identity.
+type QualifiedFunctionProfile struct {
+	Endpoint      string
+	UnitID        byte
+	VendorProfile string
+	Codec         QualifiedFunctionCodec
+}
+
+// QualifiedFunctionExchanger is the generic raw RTU exchange boundary. It
+// owns framing, correlation, deadlines, retry, and serialization; it owns no
+// vendor codec or registry selection.
+type QualifiedFunctionExchanger interface {
+	Exchange(context.Context, byte, modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy) ([]modbus.RTUPrivateFunctionResponseADU, error)
+}
+
+// QualifiedFunctionRegistry is an immutable endpoint-scoped codec selector.
+type QualifiedFunctionRegistry struct {
+	profiles []QualifiedFunctionProfile
+}
+
+// NewQualifiedFunctionRegistry validates a finite set of endpoint-scoped
+// profiles. More than one matching endpoint/unit is retained as an explicit
+// ambiguity and fails closed at dispatch time.
+func NewQualifiedFunctionRegistry(profiles []QualifiedFunctionProfile) (*QualifiedFunctionRegistry, error) {
+	if len(profiles) == 0 {
+		return nil, fmt.Errorf("qualified function registry has no profiles")
+	}
+	copyProfiles := make([]QualifiedFunctionProfile, len(profiles))
+	for index, profile := range profiles {
+		if !validIdentity(profile.Endpoint) || profile.UnitID == 0 || profile.UnitID > 247 ||
+			!validIdentity(profile.VendorProfile) || profile.Codec == nil {
+			return nil, fmt.Errorf("qualified function profile is invalid")
+		}
+		copyProfiles[index] = profile
+	}
+	return &QualifiedFunctionRegistry{profiles: copyProfiles}, nil
+}
+
+// Dispatch selects exactly one endpoint/unit profile, validates its explicit
+// profile and operation identity, then exchanges only the codec-constructed
+// request. Every selection or codec failure is no-send.
+func (registry *QualifiedFunctionRegistry) Dispatch(
+	ctx context.Context,
+	exchanger QualifiedFunctionExchanger,
+	selector QualifiedFunctionSelector,
+) ([]QualifiedFunctionResult, error) {
+	if registry == nil || ctx == nil || exchanger == nil ||
+		!validIdentity(selector.Endpoint) || selector.UnitID == 0 || selector.UnitID > 247 ||
+		!validIdentity(selector.VendorProfile) || !validIdentity(selector.Operation) {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	var selected QualifiedFunctionProfile
+	matches := 0
+	for _, profile := range registry.profiles {
+		if profile.Endpoint == selector.Endpoint && profile.UnitID == selector.UnitID {
+			selected = profile
+			matches++
+		}
+	}
+	if matches != 1 || selected.VendorProfile != selector.VendorProfile {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	request, policy, err := selected.Codec.EncodeQualifiedFunction(selector.Operation)
+	if err != nil {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	responses, err := exchanger.Exchange(ctx, selector.UnitID, request, policy)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]QualifiedFunctionResult, 0, len(responses))
+	for _, response := range responses {
+		result, err := selected.Codec.DecodeQualifiedFunction(
+			selector.Operation,
+			request.FunctionCode(),
+			response.Payload(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		result.Payload = append([]byte(nil), result.Payload...)
+		results = append(results, result)
+	}
+	return results, nil
+}

--- a/qualified_function_registry_test.go
+++ b/qualified_function_registry_test.go
@@ -1,0 +1,151 @@
+package modbusreg
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestQualifiedFunctionRegistryScopesSameCodeToItsSelectedProfile(t *testing.T) {
+	code, err := modbus.NewPrivateFunctionCode(0x64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := &qualifiedFunctionTestCodec{code: code, request: []byte{0xa1}, response: []byte{0xa1}}
+	second := &qualifiedFunctionTestCodec{code: code, request: []byte{0xb2}, response: []byte{0xb2}}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{
+		{Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "test-a", Codec: first},
+		{Endpoint: "rtu-b", UnitID: 0x10, VendorProfile: "test-b", Codec: second},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{}
+	for _, selector := range []QualifiedFunctionSelector{
+		{Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "test-a", Operation: "read"},
+		{Endpoint: "rtu-b", UnitID: 0x10, VendorProfile: "test-b", Operation: "read"},
+	} {
+		if _, err := registry.Dispatch(context.Background(), transport, selector); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if first.decodeCalls != 1 || second.decodeCalls != 1 {
+		t.Fatalf("decode calls = %d, %d", first.decodeCalls, second.decodeCalls)
+	}
+	if got, want := transport.requests[0].Payload(), []byte{0xa1}; string(got) != string(want) {
+		t.Fatalf("first payload = %x, want %x", got, want)
+	}
+	if got, want := transport.requests[1].Payload(), []byte{0xb2}; string(got) != string(want) {
+		t.Fatalf("second payload = %x, want %x", got, want)
+	}
+}
+
+func TestQualifiedFunctionRegistryDeniesAmbiguousOrUnqualifiedSelectionWithoutSend(t *testing.T) {
+	code, err := modbus.NewPrivateFunctionCode(0x64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	codec := &qualifiedFunctionTestCodec{code: code, request: []byte{1}, response: []byte{1}}
+	transport := &qualifiedFunctionTestTransport{}
+	ambiguous, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{
+		{Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "test-a", Codec: codec},
+		{Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "test-b", Codec: codec},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ambiguous.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "test-a", Operation: "read",
+	}); err == nil {
+		t.Fatal("ambiguous selection sent")
+	}
+	if transport.calls != 0 {
+		t.Fatalf("ambiguous sends = %d", transport.calls)
+	}
+
+	qualified, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{
+		{Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "test-a", Codec: codec},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := qualified.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: 0x10, VendorProfile: "wrong", Operation: "read",
+	}); err == nil {
+		t.Fatal("mismatched profile sent")
+	}
+	if transport.calls != 0 {
+		t.Fatalf("unqualified sends = %d", transport.calls)
+	}
+}
+
+func TestTeslaQualifiedFunctionProfileKeepsUnknownOperationNoSend(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{
+		{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{}
+	if _, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: "unknown",
+	}); err == nil {
+		t.Fatal("unknown Tesla operation sent")
+	}
+	if transport.calls != 0 {
+		t.Fatalf("Tesla no-send calls = %d", transport.calls)
+	}
+}
+
+type qualifiedFunctionTestCodec struct {
+	code        modbus.PrivateFunctionCode
+	request     []byte
+	response    []byte
+	decodeCalls int
+}
+
+func (codec *qualifiedFunctionTestCodec) EncodeQualifiedFunction(operation string) (modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy, error) {
+	if operation != "read" {
+		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("operation is not admitted")
+	}
+	request, err := modbus.NewPrivateFunctionRequest(codec.code, codec.request)
+	if err != nil {
+		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, err
+	}
+	return request, modbus.DefaultPrivateFunctionResponsePolicy(), nil
+}
+
+func (codec *qualifiedFunctionTestCodec) DecodeQualifiedFunction(operation string, function modbus.PrivateFunctionCode, payload []byte) (QualifiedFunctionResult, error) {
+	if operation != "read" || function != codec.code || string(payload) != string(codec.response) {
+		return QualifiedFunctionResult{}, fmt.Errorf("replay belongs to another codec")
+	}
+	codec.decodeCalls++
+	return QualifiedFunctionResult{Payload: append([]byte(nil), payload...)}, nil
+}
+
+type qualifiedFunctionTestTransport struct {
+	calls    int
+	requests []modbus.PrivateFunctionRequest
+}
+
+func (transport *qualifiedFunctionTestTransport) Exchange(_ context.Context, unitID byte, request modbus.PrivateFunctionRequest, _ modbus.PrivateFunctionResponsePolicy) ([]modbus.RTUPrivateFunctionResponseADU, error) {
+	transport.calls++
+	transport.requests = append(transport.requests, request)
+	frame, err := modbus.EncodeRTUPrivateFunctionADU(unitID, request)
+	if err != nil {
+		return nil, err
+	}
+	response, err := modbus.DecodeRTUPrivateFunctionResponseADU(unitID, request, frame)
+	if err != nil {
+		return nil, err
+	}
+	return []modbus.RTUPrivateFunctionResponseADU{response}, nil
+}

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -11,6 +11,15 @@ import (
 // TeslaHSCCompatibilityV1 is the initial public profile compatibility gate.
 const TeslaHSCCompatibilityV1 = "tesla_hsc_modbus_v1"
 
+// TeslaHSCProfileName identifies the profile only inside registry selection.
+const TeslaHSCProfileName = "tesla_hsc"
+
+const (
+	teslaHSCFunction100 modbus.PrivateFunctionCode = 100
+	teslaHSCFunction101 modbus.PrivateFunctionCode = 101
+	teslaHSCFunction102 modbus.PrivateFunctionCode = 102
+)
+
 // TeslaHSCDisposition records whether a configured profile can do more than
 // parse bounded frames. Qualification never grants opaque outbound admission.
 type TeslaHSCDisposition string
@@ -105,14 +114,14 @@ func (profile TeslaHSCProfile) OperationAdmission() TeslaTEDAPIOperationAdmissio
 
 // TeslaHSCEnvelope is a decoded length envelope with uninterpreted inner bytes.
 type TeslaHSCEnvelope struct {
-	function modbus.FunctionCode
+	function modbus.PrivateFunctionCode
 	payload  []byte
 }
 
 // DecodeTeslaHSCEnvelope validates the one-byte exact length envelope used by
 // all supported HSC vendor functions and retains the nested bytes opaquely.
 func DecodeTeslaHSCEnvelope(
-	function modbus.FunctionCode,
+	function modbus.PrivateFunctionCode,
 	payload []byte,
 ) (TeslaHSCEnvelope, error) {
 	if !isTeslaHSCFunction(function) {
@@ -131,7 +140,7 @@ func DecodeTeslaHSCEnvelope(
 }
 
 // Function returns the vendor function identified by this envelope.
-func (envelope TeslaHSCEnvelope) Function() modbus.FunctionCode {
+func (envelope TeslaHSCEnvelope) Function() modbus.PrivateFunctionCode {
 	return envelope.function
 }
 
@@ -140,11 +149,9 @@ func (envelope TeslaHSCEnvelope) Payload() []byte {
 	return append([]byte(nil), envelope.payload...)
 }
 
-func isTeslaHSCFunction(function modbus.FunctionCode) bool {
+func isTeslaHSCFunction(function modbus.PrivateFunctionCode) bool {
 	switch function {
-	case modbus.FunctionVendor100,
-		modbus.FunctionVendor101,
-		modbus.FunctionVendor102:
+	case teslaHSCFunction100, teslaHSCFunction101, teslaHSCFunction102:
 		return true
 	default:
 		return false
@@ -163,7 +170,7 @@ const (
 // ClassifyTeslaHSCException classifies exception status without decoding any
 // opaque vendor payload or inventing field semantics.
 func ClassifyTeslaHSCException(
-	function modbus.FunctionCode,
+	function modbus.PrivateFunctionCode,
 	status byte,
 ) TeslaHSCException {
 	if !isTeslaHSCFunction(function) {
@@ -173,7 +180,7 @@ func ClassifyTeslaHSCException(
 		return TeslaHSCExceptionUnknownFunction
 	}
 	if status == 4 &&
-		(function == modbus.FunctionVendor101 || function == modbus.FunctionVendor102) {
+		(function == teslaHSCFunction101 || function == teslaHSCFunction102) {
 		return TeslaHSCExceptionCodecFailure
 	}
 	return TeslaHSCExceptionUnknown
@@ -183,7 +190,7 @@ func ClassifyTeslaHSCException(
 type TeslaHSCProvenance struct {
 	compatibilityVersion string
 	node                 byte
-	function             modbus.FunctionCode
+	function             modbus.PrivateFunctionCode
 	payloadLength        int
 	payloadDigest        string
 }
@@ -192,7 +199,7 @@ type TeslaHSCProvenance struct {
 func NewTeslaHSCProvenance(
 	compatibilityVersion string,
 	node byte,
-	function modbus.FunctionCode,
+	function modbus.PrivateFunctionCode,
 	payload []byte,
 ) TeslaHSCProvenance {
 	digest := sha256.Sum256(payload)
@@ -203,6 +210,23 @@ func NewTeslaHSCProvenance(
 		payloadLength:        len(payload),
 		payloadDigest:        hex.EncodeToString(digest[:]),
 	}
+}
+
+// EncodeQualifiedFunction denies every outbound Tesla operation until a later
+// typed, proven read-only contract adds an explicit operation allowlist.
+func (TeslaHSCProfile) EncodeQualifiedFunction(string) (modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy, error) {
+	return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
+}
+
+// DecodeQualifiedFunction validates only the Tesla profile envelope and keeps
+// the nested payload opaque. It is available to an already selected codec and
+// does not itself grant outbound admission.
+func (TeslaHSCProfile) DecodeQualifiedFunction(_ string, function modbus.PrivateFunctionCode, payload []byte) (QualifiedFunctionResult, error) {
+	envelope, err := DecodeTeslaHSCEnvelope(function, payload)
+	if err != nil {
+		return QualifiedFunctionResult{}, err
+	}
+	return QualifiedFunctionResult{Payload: envelope.Payload()}, nil
 }
 
 // PayloadLength returns the retained opaque payload length.

--- a/tesla_hsc_test.go
+++ b/tesla_hsc_test.go
@@ -38,10 +38,10 @@ func TestTeslaHSCProfileFailsClosedUntilExplicitlyQualified(t *testing.T) {
 }
 
 func TestTeslaHSCEnvelopesValidateAndRetainOpaquePayload(t *testing.T) {
-	for _, function := range []modbus.FunctionCode{
-		modbus.FunctionVendor100,
-		modbus.FunctionVendor101,
-		modbus.FunctionVendor102,
+	for _, function := range []modbus.PrivateFunctionCode{
+		teslaHSCFunction100,
+		teslaHSCFunction101,
+		teslaHSCFunction102,
 	} {
 		envelope, err := DecodeTeslaHSCEnvelope(function, []byte{2, 0xaa, 0xbb})
 		if err != nil {
@@ -52,21 +52,21 @@ func TestTeslaHSCEnvelopesValidateAndRetainOpaquePayload(t *testing.T) {
 		}
 	}
 	for _, payload := range [][]byte{nil, {1}, {1, 0xaa, 0xbb}} {
-		if _, err := DecodeTeslaHSCEnvelope(modbus.FunctionVendor100, payload); err == nil {
+		if _, err := DecodeTeslaHSCEnvelope(teslaHSCFunction100, payload); err == nil {
 			t.Fatalf("FC100 invalid payload accepted: %x", payload)
 		}
 	}
 }
 
 func TestTeslaHSCExceptionAndRedactedProvenance(t *testing.T) {
-	classification := ClassifyTeslaHSCException(modbus.FunctionVendor101, 4)
+	classification := ClassifyTeslaHSCException(teslaHSCFunction101, 4)
 	if classification != TeslaHSCExceptionCodecFailure {
 		t.Fatalf("exception classification = %q", classification)
 	}
 	provenance := NewTeslaHSCProvenance(
 		TeslaHSCCompatibilityV1,
 		0x10,
-		modbus.FunctionVendor102,
+		teslaHSCFunction102,
 		[]byte("sensitive-fixture-identifier"),
 	)
 	if provenance.PayloadLength() != len("sensitive-fixture-identifier") ||

--- a/tesla_tedapi_registry.go
+++ b/tesla_tedapi_registry.go
@@ -22,7 +22,7 @@ const (
 type TeslaTEDAPIObservationSpec struct {
 	ID       string
 	Profile  TeslaHSCProfile
-	Function modbus.FunctionCode
+	Function modbus.PrivateFunctionCode
 	Payload  []byte
 }
 

--- a/tesla_tedapi_registry_test.go
+++ b/tesla_tedapi_registry_test.go
@@ -2,8 +2,6 @@ package modbusreg
 
 import (
 	"testing"
-
-	modbus "github.com/Project-Helianthus/helianthus-modbus"
 )
 
 func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) {
@@ -20,7 +18,7 @@ func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) 
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
 		ID:       "sample-1",
 		Profile:  profile,
-		Function: modbus.FunctionVendor100,
+		Function: teslaHSCFunction100,
 		Payload:  []byte{2, 0xaa, 0xbb},
 	}); err != nil {
 		t.Fatal(err)
@@ -48,7 +46,7 @@ func TestTeslaTEDAPIRegistryFailsClosedForUnqualifiedOrMalformedInput(t *testing
 		t.Fatal(err)
 	}
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
-		ID: "sample-2", Profile: profile, Function: modbus.FunctionVendor101, Payload: []byte{0},
+		ID: "sample-2", Profile: profile, Function: teslaHSCFunction101, Payload: []byte{0},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +57,7 @@ func TestTeslaTEDAPIRegistryFailsClosedForUnqualifiedOrMalformedInput(t *testing
 		t.Fatalf("unqualified record = %#v", record)
 	}
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
-		ID: "bad", Profile: profile, Function: modbus.FunctionVendor102, Payload: []byte{1},
+		ID: "bad", Profile: profile, Function: teslaHSCFunction102, Payload: []byte{1},
 	}); err == nil {
 		t.Fatal("malformed payload accepted")
 	}


### PR DESCRIPTION
Closes #42.

RED-first registry integration for generic private Modbus function-code transport.

- exact endpoint/unit/profile/operation selection;
- no-send for absent/ambiguous/mismatched profile;
- test-only incompatible same-code codecs at separate endpoints;
- Tesla remains profile-scoped and unknown operations remain denied;
- no gateway or hardware I/O.