### PR TITLE
REG-SF-01: close SunSpec and Fronius offline audit

### DIFF
--- a/profiles/vendor/fronius/disposition.json
+++ b/profiles/vendor/fronius/disposition.json
@@ -1,0 +1,49 @@
+{
+  "schema": "helianthus-modbusreg-sunspec-fronius-audit/v1",
+  "milestone": "REG-SF-01",
+  "outcome": "OFFLINE_PROFILE_ADMITTED",
+  "docs": {
+    "merge_sha": "2abcb26a06ffa71149177de2cc2817a24d82081f",
+    "logical_schema_id": "sunspec.models.v1",
+    "registry_revision": "sunspec.models@7abdf898-v1",
+    "source_commit": "7abdf8982d5364f8ae916deee18aac86c11be36d"
+  },
+  "registry": {
+    "base_sha": "b7248d6c60529fd11c4ea02c9f374dd2dccd6536",
+    "decoder_behavior_changed": false,
+    "exact_model_catalog_verified": true,
+    "unknown_retention_verified": true,
+    "equivalence_103_113_verified": true,
+    "sentinel_handling_verified": true,
+    "executable_evidence": [
+      "TestSunSpecDecoderRegistryUsesExactImmutableKeys",
+      "TestSunSpecChainRetainsOrderedDuplicatesUnknownAndWrongLength",
+      "TestSunSpecModels103And113CanonicalEquivalence",
+      "TestSunSpecValueSentinelsAndExactDecimal",
+      "TestFroniusObservedFlavorV11MatchesOnlyTheModel123Chain"
+    ]
+  },
+  "fronius": {
+    "flavor_id": "sunspec.flavor.fronius.gen24.float.observed@1.1.0",
+    "manufacturer": "Fronius",
+    "model": "Symo GEN24 10.0",
+    "firmware": "1.41.11-1",
+    "chain": [
+      {"ModelID": 1, "ModelLength": 65},
+      {"ModelID": 113, "ModelLength": 60},
+      {"ModelID": 120, "ModelLength": 26},
+      {"ModelID": 121, "ModelLength": 30},
+      {"ModelID": 122, "ModelLength": 44},
+      {"ModelID": 123, "ModelLength": 24},
+      {"ModelID": 160, "ModelLength": 88},
+      {"ModelID": 124, "ModelLength": 24},
+      {"ModelID": 65535, "ModelLength": 0}
+    ],
+    "offline_fixture": "testdata/sunspec/chains/fronius_gen24_float_v1_1.json",
+    "offline_classifier_executable": true,
+    "automatic_runtime_admission": false,
+    "live_qualified": false,
+    "write_authority": false,
+    "support_claim": false
+  }
+}

--- a/profiles/vendor/fronius/evidence.json
+++ b/profiles/vendor/fronius/evidence.json
@@ -1,0 +1,18 @@
+{
+  "schema": "helianthus-modbusreg-vendor-evidence/v1",
+  "profile": "fronius",
+  "profile_version": "1.0.0",
+  "public_sources": [
+    {
+      "id": "fronius-sunspec-float-v1",
+      "locator": "https://github.com/Project-Helianthus/helianthus-docs-modbus/blob/2abcb26a06ffa71149177de2cc2817a24d82081f/protocols/fronius/sunspec-float-v1.md",
+      "license": "CC0-1.0"
+    }
+  ],
+  "applicability": [
+    "Fronius Symo GEN24 10.0 firmware 1.41.11-1",
+    "exact SunSpec V1.1 chain ending in ffff/0",
+    "offline read-only fixture classification only; no live support or write authority"
+  ],
+  "license": "CC0-1.0"
+}

--- a/sunspec_fronius_audit_test.go
+++ b/sunspec_fronius_audit_test.go
@@ -76,9 +76,9 @@ func TestSunSpecFroniusAuditClosesAgainstPinnedRegistry(t *testing.T) {
 	}
 	wantEvidence := []string{
 		"TestSunSpecDecoderRegistryUsesExactImmutableKeys",
-		"TestSunSpecChainRetainsUnknownModel",
-		"TestSunSpecIntegerAndFloatThreePhaseModelsAreEquivalent",
-		"TestSunSpecValueSentinels",
+		"TestSunSpecChainRetainsOrderedDuplicatesUnknownAndWrongLength",
+		"TestSunSpecModels103And113CanonicalEquivalence",
+		"TestSunSpecValueSentinelsAndExactDecimal",
 		"TestFroniusObservedFlavorV11MatchesOnlyTheModel123Chain",
 	}
 	if disposition.Registry.BaseSHA != "b7248d6c60529fd11c4ea02c9f374dd2dccd6536" ||

--- a/sunspec_fronius_audit_test.go
+++ b/sunspec_fronius_audit_test.go
@@ -43,6 +43,19 @@ type sunSpecFroniusAuditDisposition struct {
 	} `json:"fronius"`
 }
 
+type sunSpecFroniusPublicEvidence struct {
+	Schema         string `json:"schema"`
+	Profile        string `json:"profile"`
+	ProfileVersion string `json:"profile_version"`
+	PublicSources  []struct {
+		ID      string `json:"id"`
+		Locator string `json:"locator"`
+		License string `json:"license"`
+	} `json:"public_sources"`
+	Applicability []string `json:"applicability"`
+	License       string   `json:"license"`
+}
+
 func readSunSpecFroniusAuditDisposition(t *testing.T) sunSpecFroniusAuditDisposition {
 	t.Helper()
 	data, err := os.ReadFile("profiles/vendor/fronius/disposition.json")
@@ -102,5 +115,44 @@ func TestSunSpecFroniusAuditClosesAgainstPinnedRegistry(t *testing.T) {
 		disposition.Fronius.AutomaticRuntimeAdmission || disposition.Fronius.LiveQualified ||
 		disposition.Fronius.WriteAuthority || disposition.Fronius.SupportClaim {
 		t.Fatalf("unexpected Fronius disposition: %#v", disposition.Fronius)
+	}
+}
+
+func TestSunSpecFroniusAuditUsesPublicProtocolEvidence(t *testing.T) {
+	data, err := os.ReadFile("profiles/vendor/fronius/evidence.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var evidence sunSpecFroniusPublicEvidence
+	if err := decoder.Decode(&evidence); err != nil {
+		t.Fatal(err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		t.Fatalf("trailing JSON value: %v", err)
+	}
+	wantSources := []struct {
+		ID      string `json:"id"`
+		Locator string `json:"locator"`
+		License string `json:"license"`
+	}{
+		{
+			ID:      "fronius-sunspec-float-v1",
+			Locator: "https://github.com/Project-Helianthus/helianthus-docs-modbus/blob/2abcb26a06ffa71149177de2cc2817a24d82081f/protocols/fronius/sunspec-float-v1.md",
+			License: "CC0-1.0",
+		},
+	}
+	wantApplicability := []string{
+		"Fronius Symo GEN24 10.0 firmware 1.41.11-1",
+		"exact SunSpec V1.1 chain ending in ffff/0",
+		"offline read-only fixture classification only; no live support or write authority",
+	}
+	if evidence.Schema != "helianthus-modbusreg-vendor-evidence/v1" || evidence.Profile != "fronius" ||
+		evidence.ProfileVersion != "1.0.0" || evidence.License != "CC0-1.0" ||
+		!reflect.DeepEqual(evidence.PublicSources, wantSources) ||
+		!reflect.DeepEqual(evidence.Applicability, wantApplicability) {
+		t.Fatalf("unexpected Fronius public evidence: %#v", evidence)
 	}
 }

--- a/sunspec_fronius_audit_test.go
+++ b/sunspec_fronius_audit_test.go
@@ -1,0 +1,106 @@
+package modbusreg
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+)
+
+type sunSpecFroniusAuditDisposition struct {
+	Schema    string `json:"schema"`
+	Milestone string `json:"milestone"`
+	Outcome   string `json:"outcome"`
+	Docs      struct {
+		MergeSHA         string                `json:"merge_sha"`
+		LogicalSchemaID  SunSpecSchemaRevision `json:"logical_schema_id"`
+		RegistryRevision SunSpecSchemaRevision `json:"registry_revision"`
+		SourceCommit     string                `json:"source_commit"`
+	} `json:"docs"`
+	Registry struct {
+		BaseSHA                   string   `json:"base_sha"`
+		DecoderBehaviorChanged    bool     `json:"decoder_behavior_changed"`
+		ExactModelCatalogVerified bool     `json:"exact_model_catalog_verified"`
+		UnknownRetentionVerified  bool     `json:"unknown_retention_verified"`
+		Equivalence103113Verified bool     `json:"equivalence_103_113_verified"`
+		SentinelHandlingVerified  bool     `json:"sentinel_handling_verified"`
+		ExecutableEvidence        []string `json:"executable_evidence"`
+	} `json:"registry"`
+	Fronius struct {
+		FlavorID                    string           `json:"flavor_id"`
+		Manufacturer                string           `json:"manufacturer"`
+		Model                       string           `json:"model"`
+		Firmware                    string           `json:"firmware"`
+		Chain                       []SunSpecWireKey `json:"chain"`
+		OfflineFixture              string           `json:"offline_fixture"`
+		OfflineClassifierExecutable bool             `json:"offline_classifier_executable"`
+		AutomaticRuntimeAdmission   bool             `json:"automatic_runtime_admission"`
+		LiveQualified               bool             `json:"live_qualified"`
+		WriteAuthority              bool             `json:"write_authority"`
+		SupportClaim                bool             `json:"support_claim"`
+	} `json:"fronius"`
+}
+
+func readSunSpecFroniusAuditDisposition(t *testing.T) sunSpecFroniusAuditDisposition {
+	t.Helper()
+	data, err := os.ReadFile("profiles/vendor/fronius/disposition.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var disposition sunSpecFroniusAuditDisposition
+	if err := decoder.Decode(&disposition); err != nil {
+		t.Fatal(err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		t.Fatalf("trailing JSON value: %v", err)
+	}
+	return disposition
+}
+
+func TestSunSpecFroniusAuditClosesAgainstPinnedRegistry(t *testing.T) {
+	disposition := readSunSpecFroniusAuditDisposition(t)
+	if disposition.Schema != "helianthus-modbusreg-sunspec-fronius-audit/v1" ||
+		disposition.Milestone != "REG-SF-01" || disposition.Outcome != "OFFLINE_PROFILE_ADMITTED" {
+		t.Fatalf("unexpected audit identity: %#v", disposition)
+	}
+	if disposition.Docs.MergeSHA != "2abcb26a06ffa71149177de2cc2817a24d82081f" ||
+		disposition.Docs.LogicalSchemaID != "sunspec.models.v1" ||
+		disposition.Docs.RegistryRevision != SunSpecModelsRevisionV1 ||
+		disposition.Docs.SourceCommit != "7abdf8982d5364f8ae916deee18aac86c11be36d" {
+		t.Fatalf("unexpected docs binding: %#v", disposition.Docs)
+	}
+	wantEvidence := []string{
+		"TestSunSpecDecoderRegistryUsesExactImmutableKeys",
+		"TestSunSpecChainRetainsUnknownModel",
+		"TestSunSpecIntegerAndFloatThreePhaseModelsAreEquivalent",
+		"TestSunSpecValueSentinels",
+		"TestFroniusObservedFlavorV11MatchesOnlyTheModel123Chain",
+	}
+	if disposition.Registry.BaseSHA != "b7248d6c60529fd11c4ea02c9f374dd2dccd6536" ||
+		disposition.Registry.DecoderBehaviorChanged ||
+		!disposition.Registry.ExactModelCatalogVerified ||
+		!disposition.Registry.UnknownRetentionVerified ||
+		!disposition.Registry.Equivalence103113Verified ||
+		!disposition.Registry.SentinelHandlingVerified ||
+		!reflect.DeepEqual(disposition.Registry.ExecutableEvidence, wantEvidence) {
+		t.Fatalf("unexpected registry audit: %#v", disposition.Registry)
+	}
+
+	wantChain := []SunSpecWireKey{{1, 65}, {113, 60}, {120, 26}, {121, 30}, {122, 44}, {123, 24}, {160, 88}, {124, 24}, {0xffff, 0}}
+	if disposition.Fronius.FlavorID != SunSpecFroniusObservedFlavorV11ID ||
+		disposition.Fronius.Manufacturer != "Fronius" ||
+		disposition.Fronius.Model != "Symo GEN24 10.0" ||
+		disposition.Fronius.Firmware != "1.41.11-1" ||
+		!reflect.DeepEqual(disposition.Fronius.Chain, wantChain) ||
+		disposition.Fronius.OfflineFixture != "testdata/sunspec/chains/fronius_gen24_float_v1_1.json" ||
+		!disposition.Fronius.OfflineClassifierExecutable ||
+		disposition.Fronius.AutomaticRuntimeAdmission || disposition.Fronius.LiveQualified ||
+		disposition.Fronius.WriteAuthority || disposition.Fronius.SupportClaim {
+		t.Fatalf("unexpected Fronius disposition: %#v", disposition.Fronius)
+	}
+}

--- a/sunspec_fronius_audit_test.go
+++ b/sunspec_fronius_audit_test.go
@@ -3,8 +3,12 @@ package modbusreg
 import (
 	"bytes"
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -75,6 +79,74 @@ func readSunSpecFroniusAuditDisposition(t *testing.T) sunSpecFroniusAuditDisposi
 	return disposition
 }
 
+func declaredGoTests(t *testing.T) map[string]bool {
+	t.Helper()
+	paths, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	declared := make(map[string]bool)
+	files := token.NewFileSet()
+	for _, path := range paths {
+		parsed, err := parser.ParseFile(files, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if ok && function.Recv == nil && function.Name.IsExported() && len(function.Name.Name) > len("Test") && function.Name.Name[:len("Test")] == "Test" {
+				declared[function.Name.Name] = true
+			}
+		}
+	}
+	return declared
+}
+
+func readFroniusV11Fixture(t *testing.T, path string) struct {
+	Schema       string           `json:"schema"`
+	FlavorID     string           `json:"flavor_id"`
+	Manufacturer string           `json:"manufacturer"`
+	Model        string           `json:"model"`
+	Firmware     string           `json:"firmware"`
+	Chain        []SunSpecWireKey `json:"chain"`
+	Observation  struct {
+		Function  string `json:"function"`
+		UnitID    uint16 `json:"unit_id"`
+		PDUOffset uint16 `json:"pdu_offset"`
+		Authority string `json:"authority"`
+	} `json:"sanitized_observation"`
+} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		Schema       string           `json:"schema"`
+		FlavorID     string           `json:"flavor_id"`
+		Manufacturer string           `json:"manufacturer"`
+		Model        string           `json:"model"`
+		Firmware     string           `json:"firmware"`
+		Chain        []SunSpecWireKey `json:"chain"`
+		Observation  struct {
+			Function  string `json:"function"`
+			UnitID    uint16 `json:"unit_id"`
+			PDUOffset uint16 `json:"pdu_offset"`
+			Authority string `json:"authority"`
+		} `json:"sanitized_observation"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&fixture); err != nil {
+		t.Fatal(err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		t.Fatalf("fixture has trailing JSON value: %v", err)
+	}
+	return fixture
+}
+
 func TestSunSpecFroniusAuditClosesAgainstPinnedRegistry(t *testing.T) {
 	disposition := readSunSpecFroniusAuditDisposition(t)
 	if disposition.Schema != "helianthus-modbusreg-sunspec-fronius-audit/v1" ||
@@ -103,18 +175,42 @@ func TestSunSpecFroniusAuditClosesAgainstPinnedRegistry(t *testing.T) {
 		!reflect.DeepEqual(disposition.Registry.ExecutableEvidence, wantEvidence) {
 		t.Fatalf("unexpected registry audit: %#v", disposition.Registry)
 	}
+	declared := declaredGoTests(t)
+	for _, testName := range disposition.Registry.ExecutableEvidence {
+		if !declared[testName] {
+			t.Fatalf("audit references missing executable evidence %q", testName)
+		}
+	}
 
-	wantChain := []SunSpecWireKey{{1, 65}, {113, 60}, {120, 26}, {121, 30}, {122, 44}, {123, 24}, {160, 88}, {124, 24}, {0xffff, 0}}
 	if disposition.Fronius.FlavorID != SunSpecFroniusObservedFlavorV11ID ||
 		disposition.Fronius.Manufacturer != "Fronius" ||
 		disposition.Fronius.Model != "Symo GEN24 10.0" ||
 		disposition.Fronius.Firmware != "1.41.11-1" ||
-		!reflect.DeepEqual(disposition.Fronius.Chain, wantChain) ||
+		!reflect.DeepEqual(disposition.Fronius.Chain, froniusObservedChainV11) ||
 		disposition.Fronius.OfflineFixture != "testdata/sunspec/chains/fronius_gen24_float_v1_1.json" ||
 		!disposition.Fronius.OfflineClassifierExecutable ||
 		disposition.Fronius.AutomaticRuntimeAdmission || disposition.Fronius.LiveQualified ||
 		disposition.Fronius.WriteAuthority || disposition.Fronius.SupportClaim {
 		t.Fatalf("unexpected Fronius disposition: %#v", disposition.Fronius)
+	}
+
+	fixture := readFroniusV11Fixture(t, disposition.Fronius.OfflineFixture)
+	if fixture.Schema != "helianthus-sunspec-fronius-observed-flavor/v1.1" ||
+		fixture.FlavorID != disposition.Fronius.FlavorID ||
+		fixture.Manufacturer != disposition.Fronius.Manufacturer || fixture.Model != disposition.Fronius.Model ||
+		fixture.Firmware != disposition.Fronius.Firmware || !reflect.DeepEqual(fixture.Chain, disposition.Fronius.Chain) ||
+		fixture.Observation.Function != "FC03" || fixture.Observation.UnitID != 1 ||
+		fixture.Observation.PDUOffset != 40000 || fixture.Observation.Authority != "non_actionable_provenance_only" {
+		t.Fatalf("fixture does not substantiate disposition: %#v", fixture)
+	}
+
+	registry := mustStandardSunSpecRegistry(t)
+	snapshot := froniusObservedSnapshotV11(t, registry, fixture.Manufacturer, fixture.Model, fixture.Firmware)
+	selection := registry.SelectFroniusObservedFlavor(snapshot)
+	decision, ok := selection.Decision()
+	if !ok || !selection.Matched() || decision.FlavorID() != disposition.Fronius.FlavorID ||
+		!reflect.DeepEqual(decision.Chain(), disposition.Fronius.Chain) {
+		t.Fatalf("classifier does not substantiate disposition: selection=%#v decision=%#v", selection, decision)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add RED-first contractual evidence for the REG-SF-01 closure disposition
- bind the public logical schema to the existing source-pinned registry revision
- require exact Fronius V1.1 offline classification while keeping live/runtime/write authority disabled

Closes #44

## RED evidence

Exact RED HEAD fails only because profiles/vendor/fronius/disposition.json is absent:

    open profiles/vendor/fronius/disposition.json: no such file or directory

Command: GOWORK=off go test -run TestSunSpecFroniusAuditClosesAgainstPinnedRegistry ./...

## Docs gate

helianthus-docs-modbus merge 2abcb26a06ffa71149177de2cc2817a24d82081f

## Boundaries

Audit/closure only. No decoder, detector, transport, gateway, hardware, deploy, or write-authority behavior change.