### PR TITLE
REG-HW-01: close SmartLogger offline disposition

### DIFF
--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -129,15 +129,6 @@ func TestHuaweiGatewayDispositionsFailClosedIndependently(t *testing.T) {
 
 	expectations := []huaweiFamilyExpectation{
 		{
-			file: "smartlogger-disposition.json", profile: "huawei.smartlogger", candidateID: "huawei.smartlogger.v1", gatewayKind: "SmartLogger",
-			missingDiscriminators: []string{"negative_overlap_with_emma", "sanitized_self_entry_and_firmware_fixture"},
-			requiredTuple:         []string{"device_list_change_readable", "mei_child_inventory_self_entry_model_smartlogger", "structured_firmware_gate"},
-			forbiddenIdentity:     []string{"writable_device_name_65524", "esn_only", "basic_mei_only"},
-			firmwareGateCount:     8, negativeFixtures: []string{"smartlogger-unknown-v300r024-spc200", "smartlogger-cross-branch-v300r025"},
-			unitTarget: "0", maxChildren: 247, maxPages: 248, maxObjects: 248, maxBytes: 65536,
-			reject: []string{"cursor_loop", "duplicate_object", "duplicate_device_id", "count_mismatch", "sequence_changed"},
-		},
-		{
 			file: "sdongle-disposition.json", profile: "huawei.sdongle", candidateID: "huawei.sdongle.v1", gatewayKind: "S-Dongle",
 			missingDiscriminators: []string{"sanitized_product_code_and_revision_fixture", "live_child_inventory_target_fixture"},
 			requiredTuple:         []string{"basic_mei_product_code_sdongle", "protocol_version_branch_match", "dongle_type_search_sequence_tuple", "structured_firmware_gate"},

--- a/huawei_smartlogger_disposition_test.go
+++ b/huawei_smartlogger_disposition_test.go
@@ -1,0 +1,105 @@
+package modbusreg
+
+import (
+	"reflect"
+	"testing"
+)
+
+const smartLoggerDocsMergeSHA = "2abcb26a06ffa71149177de2cc2817a24d82081f"
+
+func TestHuaweiSmartLoggerDispositionPinsExactCandidateAndNoSend(t *testing.T) {
+	record := decodeHuaweiObject(t, "profiles/vendor/huawei/smartlogger-disposition.json")
+	requireHuaweiKeys(t, record,
+		"schema", "profile", "profile_version", "outcome", "evidence",
+		"admission", "change_counter", "child_enumeration", "private_functions",
+		"decoder_keys", "catalog_registered", "automatic_runtime_admission",
+		"support_claim", "reopen_requires",
+	)
+	if record["schema"] != "helianthus-modbusreg-huawei-smartlogger-disposition/v1" ||
+		record["profile"] != "huawei.smartlogger" || record["profile_version"] != "1.0.0" ||
+		record["outcome"] != "NO_ADMISSIBLE_PROFILE" || record["catalog_registered"] != false ||
+		record["automatic_runtime_admission"] != false || record["support_claim"] != false ||
+		len(record["decoder_keys"].([]any)) != 0 {
+		t.Fatalf("unexpected SmartLogger disposition: %#v", record)
+	}
+
+	missing := []string{
+		"sanitized_extended_mei_self_entry_fixture",
+		"exact_child_attribute_encoding_fixture",
+		"pairwise_negative_overlap_with_emma_fixture",
+	}
+	evidence := huaweiObject(t, record["evidence"])
+	requireHuaweiKeys(t, evidence, "docs_merge_sha", "candidate_id", "source_license", "eligible", "missing_evidence")
+	if evidence["docs_merge_sha"] != smartLoggerDocsMergeSHA || evidence["candidate_id"] != "huawei.smartlogger.v1" ||
+		evidence["source_license"] != "CC0-1.0" || evidence["eligible"] != false ||
+		!reflect.DeepEqual(huaweiStringSlice(t, evidence["missing_evidence"]), missing) {
+		t.Fatalf("unexpected SmartLogger evidence: %#v", evidence)
+	}
+
+	admission := huaweiObject(t, record["admission"])
+	requireHuaweiKeys(t, admission, "unit_id", "registered", "executable", "required_tuple", "forbidden_identity", "firmware_gates", "version_comparison", "multiple_positive_outcome", "first_match_priority")
+	if huaweiInt(t, admission["unit_id"]) != 0 || admission["registered"] != false || admission["executable"] != false ||
+		admission["version_comparison"] != "EXACT_TUPLE_ONLY" || admission["multiple_positive_outcome"] != "INSUFFICIENT_EVIDENCE" ||
+		admission["first_match_priority"] != false ||
+		!reflect.DeepEqual(huaweiStringSlice(t, admission["required_tuple"]), []string{
+			"fc03_65521_q1_u16_counter_stable",
+			"fc2b_mei0e_code03_object87_inventory",
+			"self_entry_model_smartlogger",
+			"exact_firmware_tuple",
+		}) ||
+		!reflect.DeepEqual(huaweiStringSlice(t, admission["forbidden_identity"]), []string{
+			"writable_device_name_65524", "esn_40713", "basic_mei_only", "optional_offering_string",
+		}) ||
+		!reflect.DeepEqual(huaweiStringSlice(t, admission["firmware_gates"]), []string{
+			"V300R024C10SPC191", "V300R024C10SPC210",
+		}) {
+		t.Fatalf("unexpected SmartLogger admission: %#v", admission)
+	}
+
+	counter := huaweiObject(t, record["change_counter"])
+	requireHuaweiKeys(t, counter, "function", "offset", "quantity", "type", "equal_before_after")
+	if counter["function"] != "FC03" || huaweiInt(t, counter["offset"]) != 65521 ||
+		huaweiInt(t, counter["quantity"]) != 1 || counter["type"] != "U16" || counter["equal_before_after"] != true {
+		t.Fatalf("unexpected SmartLogger counter: %#v", counter)
+	}
+
+	inventory := huaweiObject(t, record["child_enumeration"])
+	requireHuaweiKeys(t, inventory, "function", "read_device_id_code", "start_object_id", "executable", "max_children", "limits", "reject")
+	limits := huaweiObject(t, inventory["limits"])
+	requireHuaweiKeys(t, limits, "deadline_ms", "max_pages", "max_objects", "max_bytes")
+	if inventory["function"] != "FC2B_MEI_0E" || huaweiInt(t, inventory["read_device_id_code"]) != 3 ||
+		huaweiInt(t, inventory["start_object_id"]) != 135 || inventory["executable"] != false ||
+		huaweiInt(t, inventory["max_children"]) != 247 || huaweiInt(t, limits["deadline_ms"]) != 15000 ||
+		huaweiInt(t, limits["max_pages"]) != 248 || huaweiInt(t, limits["max_objects"]) != 248 ||
+		huaweiInt(t, limits["max_bytes"]) != 65536 ||
+		!reflect.DeepEqual(huaweiStringSlice(t, inventory["reject"]), []string{
+			"cursor_loop", "duplicate_object", "duplicate_child_address", "count_mismatch",
+			"malformed_attribute", "second_wrap", "change_counter_mismatch", "limit_exhausted",
+		}) {
+		t.Fatalf("unexpected SmartLogger inventory: %#v", inventory)
+	}
+
+	privateFunctions := huaweiObject(t, record["private_functions"])
+	requireHuaweiKeys(t, privateFunctions, "FC0x41", "FC0x17")
+	if privateFunctions["FC0x41"] != "NO_SEND" || privateFunctions["FC0x17"] != "NO_SEND" ||
+		!reflect.DeepEqual(huaweiStringSlice(t, record["reopen_requires"]), missing) {
+		t.Fatalf("unexpected SmartLogger private-function/reopen policy: %#v", record)
+	}
+}
+
+func TestHuaweiPublicEvidenceIncludesCurrentCandidateContract(t *testing.T) {
+	evidence := decodeHuaweiObject(t, "profiles/vendor/huawei/evidence.json")
+	sources := evidence["public_sources"].([]any)
+	found := false
+	for _, value := range sources {
+		source := huaweiObject(t, value)
+		if source["id"] == "huawei-gateway-readonly-v1" &&
+			source["locator"] == "https://github.com/Project-Helianthus/helianthus-docs-modbus/blob/"+smartLoggerDocsMergeSHA+"/protocols/huawei/gateway-readonly-v1.md" &&
+			source["license"] == "CC0-1.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Huawei public evidence does not include the current docs-modbus contract")
+	}
+}

--- a/profiles/vendor/huawei/evidence.json
+++ b/profiles/vendor/huawei/evidence.json
@@ -4,6 +4,11 @@
   "profile_version": "1.0.0",
   "public_sources": [
     {
+      "id": "huawei-gateway-readonly-v1",
+      "locator": "https://github.com/Project-Helianthus/helianthus-docs-modbus/blob/2abcb26a06ffa71149177de2cc2817a24d82081f/protocols/huawei/gateway-readonly-v1.md",
+      "license": "CC0-1.0"
+    },
+    {
       "id": "huawei-gateway-candidate-evidence-v1",
       "locator": "https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f/protocols/modbus/huawei-gateway-candidate-evidence-v1.md",
       "license": "CC0-1.0"

--- a/profiles/vendor/huawei/smartlogger-disposition.json
+++ b/profiles/vendor/huawei/smartlogger-disposition.json
@@ -1,58 +1,55 @@
 {
-  "schema": "helianthus-modbusreg-profile-disposition/v1",
+  "schema": "helianthus-modbusreg-huawei-smartlogger-disposition/v1",
   "profile": "huawei.smartlogger",
   "profile_version": "1.0.0",
   "outcome": "NO_ADMISSIBLE_PROFILE",
   "evidence": {
-    "packet_id": "HUAWEI-GATEWAYS-V1",
-    "docs_merge_sha": "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f",
+    "docs_merge_sha": "2abcb26a06ffa71149177de2cc2817a24d82081f",
     "candidate_id": "huawei.smartlogger.v1",
-    "gateway_kind": "SmartLogger",
-    "documentary_status": "DOCUMENTARY_CANDIDATE",
+    "source_license": "CC0-1.0",
     "eligible": false,
-    "missing_discriminators": [
-      "negative_overlap_with_emma",
-      "sanitized_self_entry_and_firmware_fixture"
+    "missing_evidence": [
+      "sanitized_extended_mei_self_entry_fixture",
+      "exact_child_attribute_encoding_fixture",
+      "pairwise_negative_overlap_with_emma_fixture"
     ]
   },
-  "transport_dependency": {
-    "module": "github.com/Project-Helianthus/helianthus-modbus",
-    "merge_sha": "c78030472c24f0f2b849fd30124611157a81f834",
-    "version": "v0.0.0-20260820212315-c78030472c24",
-    "prerequisites": [
-      "modbus.unit-id-zero.v1",
-      "modbus.mei-vendor-cursor.v1",
-      "modbus.mei-object-wrap.v1"
-    ]
-  },
-  "detector": {
+  "admission": {
+    "unit_id": 0,
     "registered": false,
     "executable": false,
     "required_tuple": [
-      "device_list_change_readable",
-      "mei_child_inventory_self_entry_model_smartlogger",
-      "structured_firmware_gate"
+      "fc03_65521_q1_u16_counter_stable",
+      "fc2b_mei0e_code03_object87_inventory",
+      "self_entry_model_smartlogger",
+      "exact_firmware_tuple"
     ],
     "forbidden_identity": [
       "writable_device_name_65524",
-      "esn_only",
-      "basic_mei_only"
+      "esn_40713",
+      "basic_mei_only",
+      "optional_offering_string"
     ],
-    "candidate_ambiguity_outcome": "NO_ADMISSIBLE_PROFILE",
+    "firmware_gates": [
+      "V300R024C10SPC191",
+      "V300R024C10SPC210"
+    ],
+    "version_comparison": "EXACT_TUPLE_ONLY",
     "multiple_positive_outcome": "INSUFFICIENT_EVIDENCE",
     "first_match_priority": false
   },
-  "firmware_gate_count": 8,
-  "negative_fixture_ids": [
-    "smartlogger-unknown-v300r024-spc200",
-    "smartlogger-cross-branch-v300r025"
-  ],
+  "change_counter": {
+    "function": "FC03",
+    "offset": 65521,
+    "quantity": 1,
+    "type": "U16",
+    "equal_before_after": true
+  },
   "child_enumeration": {
-    "operation": "FC2B_MEI_0E",
-    "executable": false,
-    "unit_target": "0",
+    "function": "FC2B_MEI_0E",
     "read_device_id_code": 3,
     "start_object_id": 135,
+    "executable": false,
     "max_children": 247,
     "limits": {
       "deadline_ms": 15000,
@@ -63,16 +60,25 @@
     "reject": [
       "cursor_loop",
       "duplicate_object",
-      "duplicate_device_id",
+      "duplicate_child_address",
       "count_mismatch",
-      "sequence_changed"
+      "malformed_attribute",
+      "second_wrap",
+      "change_counter_mismatch",
+      "limit_exhausted"
     ]
+  },
+  "private_functions": {
+    "FC0x41": "NO_SEND",
+    "FC0x17": "NO_SEND"
   },
   "decoder_keys": [],
   "catalog_registered": false,
+  "automatic_runtime_admission": false,
   "support_claim": false,
   "reopen_requires": [
-    "negative_overlap_with_emma",
-    "sanitized_self_entry_and_firmware_fixture"
+    "sanitized_extended_mei_self_entry_fixture",
+    "exact_child_attribute_encoding_fixture",
+    "pairwise_negative_overlap_with_emma_fixture"
   ]
 }


### PR DESCRIPTION
## Summary

- replace the legacy generic SmartLogger assertion with an exact family-specific closure contract
- require two exact firmware tuples, stable counter, bounded extended-MEI inventory, and explicit missing evidence
- keep detector, decoder, runtime admission, private function sends, support, and hardware I/O disabled

Closes #46

## RED evidence

Exact RED HEAD fails because the current legacy disposition lacks the new exact admission/counter/no-send shape and current docs-modbus evidence source.

Command: GOWORK=off go test -run TestHuaweiSmartLoggerDispositionPinsExactCandidateAndNoSend\|TestHuaweiPublicEvidenceIncludesCurrentCandidateContract\|TestHuaweiGatewayDispositionsFailClosedIndependently ./...

## Docs gate

helianthus-docs-modbus merge 2abcb26a06ffa71149177de2cc2817a24d82081f

## Boundaries

Offline disposition only. No production decoder/detector, transport, gateway, hardware I/O, deploy, FC41, or FC17 execution.