### PR TITLE
REG-HW-03: admit exact EMMA A01/A02 offline gates

### DIFF
--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -89,6 +89,16 @@ func huaweiInt(t *testing.T, value any) int {
 	return int(integer)
 }
 
+func TestHuaweiGatewayEvidenceRetainsIndependentFamilyContracts(t *testing.T) {
+	evidence := decodeHuaweiObject(t, "profiles/vendor/huawei/evidence.json")
+	requireHuaweiKeys(t, evidence, "schema", "profile", "profile_version", "public_sources", "applicability", "license")
+	if evidence["schema"] != "helianthus-modbusreg-vendor-evidence/v1" ||
+		evidence["profile"] != "huawei" || evidence["profile_version"] != "1.0.0" ||
+		evidence["license"] != "CC0-1.0" {
+		t.Fatalf("unexpected Huawei evidence identity: %#v", evidence)
+	}
+}
+
 func TestHuaweiEMMAOfflineDispositionIsDefaultDeniedAndPinnedToDocs(t *testing.T) {
 	goMod, err := os.ReadFile("go.mod")
 	if err != nil {

--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -99,6 +99,152 @@ func TestHuaweiGatewayEvidenceRetainsIndependentFamilyContracts(t *testing.T) {
 	}
 }
 
+func TestHuaweiV1FamilyDispositionsRetainFailClosedContracts(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		schema           string
+		profile          string
+		outcome          string
+		docsMergeSHA     string
+		admission        func(*testing.T, map[string]any)
+		childEnumeration func(*testing.T, map[string]any)
+		remaining        func(*testing.T, map[string]any)
+	}{
+		{
+			name:         "SmartLogger",
+			path:         "profiles/vendor/huawei/smartlogger-disposition.json",
+			schema:       "helianthus-modbusreg-huawei-smartlogger-disposition/v1",
+			profile:      "huawei.smartlogger",
+			outcome:      "NO_ADMISSIBLE_PROFILE",
+			docsMergeSHA: smartLoggerDocsMergeSHA,
+			admission: func(t *testing.T, admission map[string]any) {
+				t.Helper()
+				requireHuaweiKeys(t, admission, "unit_id", "registered", "executable", "required_tuple", "forbidden_identity", "firmware_gates", "version_comparison", "multiple_positive_outcome", "first_match_priority")
+				if huaweiInt(t, admission["unit_id"]) != 0 || admission["registered"] != false || admission["executable"] != false ||
+					admission["version_comparison"] != "EXACT_TUPLE_ONLY" || admission["multiple_positive_outcome"] != "INSUFFICIENT_EVIDENCE" || admission["first_match_priority"] != false ||
+					!reflect.DeepEqual(huaweiStringSlice(t, admission["required_tuple"]), []string{"fc03_65521_q1_u16_counter_stable", "fc2b_mei0e_code03_object87_inventory", "self_entry_model_smartlogger", "exact_firmware_tuple"}) ||
+					!reflect.DeepEqual(huaweiStringSlice(t, admission["forbidden_identity"]), []string{"writable_device_name_65524", "esn_40713", "basic_mei_only", "optional_offering_string"}) ||
+					!reflect.DeepEqual(huaweiStringSlice(t, admission["firmware_gates"]), []string{"V300R024C10SPC191", "V300R024C10SPC210"}) {
+					t.Fatalf("unexpected SmartLogger admission: %#v", admission)
+				}
+			},
+			childEnumeration: func(t *testing.T, inventory map[string]any) {
+				t.Helper()
+				requireHuaweiKeys(t, inventory, "function", "read_device_id_code", "start_object_id", "executable", "max_children", "limits", "reject")
+				limits := huaweiObject(t, inventory["limits"])
+				requireHuaweiKeys(t, limits, "deadline_ms", "max_pages", "max_objects", "max_bytes")
+				if inventory["function"] != "FC2B_MEI_0E" || huaweiInt(t, inventory["read_device_id_code"]) != 3 || huaweiInt(t, inventory["start_object_id"]) != 135 ||
+					inventory["executable"] != false || huaweiInt(t, inventory["max_children"]) != 247 || huaweiInt(t, limits["deadline_ms"]) != 15000 ||
+					huaweiInt(t, limits["max_pages"]) != 248 || huaweiInt(t, limits["max_objects"]) != 248 || huaweiInt(t, limits["max_bytes"]) != 65536 ||
+					!reflect.DeepEqual(huaweiStringSlice(t, inventory["reject"]), []string{"cursor_loop", "duplicate_object", "duplicate_child_address", "count_mismatch", "malformed_attribute", "second_wrap", "change_counter_mismatch", "limit_exhausted"}) {
+					t.Fatalf("unexpected SmartLogger child enumeration: %#v", inventory)
+				}
+			},
+			remaining: func(t *testing.T, record map[string]any) {
+				t.Helper()
+				requireHuaweiKeys(t, record, "schema", "profile", "profile_version", "outcome", "evidence", "admission", "change_counter", "child_enumeration", "private_functions", "decoder_keys", "catalog_registered", "automatic_runtime_admission", "support_claim", "reopen_requires")
+				evidence := huaweiObject(t, record["evidence"])
+				requireHuaweiKeys(t, evidence, "docs_merge_sha", "candidate_id", "source_license", "eligible", "missing_evidence")
+				if evidence["candidate_id"] != "huawei.smartlogger.v1" || evidence["source_license"] != "CC0-1.0" ||
+					!reflect.DeepEqual(huaweiStringSlice(t, evidence["missing_evidence"]), []string{"sanitized_extended_mei_self_entry_fixture", "exact_child_attribute_encoding_fixture", "pairwise_negative_overlap_with_emma_fixture"}) {
+					t.Fatalf("unexpected SmartLogger evidence: %#v", evidence)
+				}
+				counter := huaweiObject(t, record["change_counter"])
+				requireHuaweiKeys(t, counter, "function", "offset", "quantity", "type", "equal_before_after")
+				if counter["function"] != "FC03" || huaweiInt(t, counter["offset"]) != 65521 || huaweiInt(t, counter["quantity"]) != 1 || counter["type"] != "U16" || counter["equal_before_after"] != true ||
+					!reflect.DeepEqual(huaweiStringSlice(t, record["reopen_requires"]), []string{"sanitized_extended_mei_self_entry_fixture", "exact_child_attribute_encoding_fixture", "pairwise_negative_overlap_with_emma_fixture"}) {
+					t.Fatalf("unexpected SmartLogger counter or reopen contract: %#v", record)
+				}
+			},
+		},
+		{
+			name:         "S-Dongle",
+			path:         "profiles/vendor/huawei/sdongle-disposition.json",
+			schema:       "helianthus-modbusreg-huawei-sdongle-disposition/v1",
+			profile:      "huawei.sdongle",
+			outcome:      "PRE_LIVE_INSUFFICIENT_EVIDENCE",
+			docsMergeSHA: sdongleDocsMergeSHA,
+			admission: func(t *testing.T, admission map[string]any) {
+				t.Helper()
+				requireHuaweiKeys(t, admission, "unit_id", "registered", "executable", "default_denied", "models", "firmware_gates", "protocol_gate", "required_tuple", "forbidden_identity", "version_comparison", "multiple_positive_outcome", "first_match_priority")
+				if huaweiInt(t, admission["unit_id"]) != 100 || admission["registered"] != false || admission["executable"] != false || admission["default_denied"] != true ||
+					admission["protocol_gate"] != "D5.0" || admission["version_comparison"] != "EXACT_TUPLE_ONLY" || admission["multiple_positive_outcome"] != "INSUFFICIENT_EVIDENCE" || admission["first_match_priority"] != false ||
+					!reflect.DeepEqual(huaweiStringSlice(t, admission["models"]), []string{"S-DongleA-05", "S-DongleB-03", "S-DongleB-06"}) ||
+					!reflect.DeepEqual(huaweiStringSlice(t, admission["required_tuple"]), []string{"basic_mei_product_identity", "fc03_30068_q2_protocol_version", "fc03_37410_q3_type_search_state_change_sequence", "fc03_37429_q1_capacity", "exact_model_firmware_protocol_tuple"}) ||
+					!reflect.DeepEqual(huaweiStringSlice(t, admission["forbidden_identity"]), []string{"unit_100_readability_only", "search_status_only", "serial_number", "basic_mei_only"}) {
+					t.Fatalf("unexpected S-Dongle admission: %#v", admission)
+				}
+			},
+			childEnumeration: func(t *testing.T, inventory map[string]any) {
+				t.Helper()
+				requireHuaweiKeys(t, inventory, "function", "read_device_id_code", "start_object_id", "unit_target", "gateway_unit_100", "executable", "max_children", "limits", "reject")
+				limits := huaweiObject(t, inventory["limits"])
+				requireHuaweiKeys(t, limits, "deadline_ms", "max_pages", "max_objects", "max_bytes")
+				if inventory["function"] != "FC2B_MEI_0E" || huaweiInt(t, inventory["read_device_id_code"]) != 3 || huaweiInt(t, inventory["start_object_id"]) != 135 ||
+					inventory["unit_target"] != "SEPARATELY_QUALIFIED_CHILD_UNIT_1_TO_247" || inventory["gateway_unit_100"] != "NO_SEND" || inventory["executable"] != false ||
+					huaweiInt(t, inventory["max_children"]) != 120 || huaweiInt(t, limits["deadline_ms"]) != 15000 || huaweiInt(t, limits["max_pages"]) != 121 ||
+					huaweiInt(t, limits["max_objects"]) != 121 || huaweiInt(t, limits["max_bytes"]) != 32768 ||
+					!reflect.DeepEqual(huaweiStringSlice(t, inventory["reject"]), []string{"cursor_loop", "duplicate_object", "duplicate_child_address", "count_mismatch", "search_in_progress", "change_sequence_mismatch", "unit_target_ambiguous", "limit_exhausted"}) {
+					t.Fatalf("unexpected S-Dongle child enumeration: %#v", inventory)
+				}
+			},
+			remaining: func(t *testing.T, record map[string]any) {
+				t.Helper()
+				requireHuaweiKeys(t, record, "schema", "profile", "profile_version", "outcome", "evidence", "admission", "protocol_version", "search_sequence", "capacity", "child_enumeration", "private_functions", "decoder_keys", "catalog_registered", "automatic_runtime_admission", "support_claim", "qualification_plan")
+				evidence := huaweiObject(t, record["evidence"])
+				requireHuaweiKeys(t, evidence, "docs_merge_sha", "candidate_id", "source_license", "eligible", "missing_evidence", "live_qualification")
+				live := huaweiObject(t, evidence["live_qualification"])
+				requireHuaweiKeys(t, live, "status", "identification_claim", "incompatibility_claim", "subsequent_modbus_requests_sent", "attempts", "retry_matrix")
+				if evidence["candidate_id"] != "huawei.sdongle.v1" || evidence["source_license"] != "CC0-1.0" || live["status"] != "LIVE_STOPPED_PERSISTENT_NON_RESPONSE" ||
+					live["identification_claim"] != false || live["incompatibility_claim"] != false || huaweiInt(t, live["subsequent_modbus_requests_sent"]) != 0 {
+					t.Fatalf("unexpected S-Dongle evidence: %#v", evidence)
+				}
+				protocol := huaweiObject(t, record["protocol_version"])
+				search := huaweiObject(t, record["search_sequence"])
+				capacity := huaweiObject(t, record["capacity"])
+				requireHuaweiKeys(t, protocol, "function", "offset", "quantity", "type")
+				requireHuaweiKeys(t, search, "function", "offset", "quantity", "fields", "search_must_be_complete", "change_sequence_stable")
+				requireHuaweiKeys(t, capacity, "function", "offset", "quantity", "reconcile_child_count")
+				if protocol["function"] != "FC03" || huaweiInt(t, protocol["offset"]) != 30068 || huaweiInt(t, protocol["quantity"]) != 2 || protocol["type"] != "U32" ||
+					search["function"] != "FC03" || huaweiInt(t, search["offset"]) != 37410 || huaweiInt(t, search["quantity"]) != 3 || search["search_must_be_complete"] != true || search["change_sequence_stable"] != true ||
+					!reflect.DeepEqual(huaweiStringSlice(t, search["fields"]), []string{"type", "search_state", "change_sequence"}) ||
+					capacity["function"] != "FC03" || huaweiInt(t, capacity["offset"]) != 37429 || huaweiInt(t, capacity["quantity"]) != 1 || capacity["reconcile_child_count"] != true {
+					t.Fatalf("unexpected S-Dongle protocol contract: %#v", record)
+				}
+				plan := huaweiObject(t, record["qualification_plan"])
+				requireHuaweiKeys(t, plan, "status", "read_only", "live_io_performed", "further_live_io", "operator_confirmation_required", "required_connection_context", "capture_sequence", "redact", "promotion_outcomes")
+				if plan["status"] != "LIVE_STOPPED_PERSISTENT_NON_RESPONSE" || plan["read_only"] != true || plan["live_io_performed"] != true ||
+					plan["further_live_io"] != "HARD_STOP" || plan["operator_confirmation_required"] != true ||
+					!reflect.DeepEqual(huaweiStringSlice(t, plan["promotion_outcomes"]), []string{"PROFILE_ADMITTED", "NO_ADMISSIBLE_PROFILE"}) {
+					t.Fatalf("unexpected S-Dongle qualification contract: %#v", plan)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record := decodeHuaweiObject(t, test.path)
+			if record["schema"] != test.schema || record["profile"] != test.profile || record["profile_version"] != "1.0.0" || record["outcome"] != test.outcome ||
+				record["catalog_registered"] != false || record["automatic_runtime_admission"] != false || record["support_claim"] != false || len(record["decoder_keys"].([]any)) != 0 {
+				t.Fatalf("unexpected v1 fail-closed disposition: %#v", record)
+			}
+			evidence := huaweiObject(t, record["evidence"])
+			if evidence["docs_merge_sha"] != test.docsMergeSHA || evidence["eligible"] != false {
+				t.Fatalf("unexpected evidence: %#v", evidence)
+			}
+			test.admission(t, huaweiObject(t, record["admission"]))
+			test.childEnumeration(t, huaweiObject(t, record["child_enumeration"]))
+			test.remaining(t, record)
+			privateFunctions := huaweiObject(t, record["private_functions"])
+			if privateFunctions["FC0x41"] != "NO_SEND" || privateFunctions["FC0x17"] != "NO_SEND" {
+				t.Fatalf("unexpected private-function policy: %#v", privateFunctions)
+			}
+		})
+	}
+}
+
 func TestHuaweiEMMAOfflineDispositionIsDefaultDeniedAndPinnedToDocs(t *testing.T) {
 	goMod, err := os.ReadFile("go.mod")
 	if err != nil {
@@ -157,8 +303,8 @@ func TestHuaweiFamilyDispositionsPinOwnDocumentation(t *testing.T) {
 	tests := []struct {
 		name, path, docsMergeSHA string
 	}{
-		{"SmartLogger", "profiles/vendor/huawei/smartlogger-disposition.json", "2abcb26a06ffa71149177de2cc2817a24d82081f"},
-		{"S-Dongle", "profiles/vendor/huawei/sdongle-disposition.json", "2d44c22f27c4be0e1de460f63b8330c728a5af8f"},
+		{"SmartLogger", "profiles/vendor/huawei/smartlogger-disposition.json", smartLoggerDocsMergeSHA},
+		{"S-Dongle", "profiles/vendor/huawei/sdongle-disposition.json", sdongleDocsMergeSHA},
 		{"EMMA", "profiles/vendor/huawei/emma-disposition.json", huaweiDocsMergeSHA},
 	}
 	for _, test := range tests {

--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -13,29 +13,9 @@ import (
 )
 
 const (
-	huaweiDocsMergeSHA = "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f"
-	huaweiModbusMerge  = "c78030472c24f0f2b849fd30124611157a81f834"
-	huaweiModbusPin    = "v0.0.0-20260820212315-c78030472c24"
+	huaweiDocsMergeSHA = "fa8838c92f3ce2eac3ad953d7059eccc21be19c7"
 	currentModbusPin   = "v0.3.0"
 )
-
-type huaweiFamilyExpectation struct {
-	file                  string
-	profile               string
-	candidateID           string
-	gatewayKind           string
-	missingDiscriminators []string
-	requiredTuple         []string
-	forbiddenIdentity     []string
-	firmwareGateCount     int
-	negativeFixtures      []string
-	unitTarget            string
-	maxChildren           int
-	maxPages              int
-	maxObjects            int
-	maxBytes              int
-	reject                []string
-}
 
 func decodeHuaweiObject(t *testing.T, path string) map[string]any {
 	t.Helper()
@@ -109,7 +89,7 @@ func huaweiInt(t *testing.T, value any) int {
 	return int(integer)
 }
 
-func TestHuaweiGatewayDispositionsFailClosedIndependently(t *testing.T) {
+func TestHuaweiEMMAOfflineDispositionIsDefaultDeniedAndPinnedToDocs(t *testing.T) {
 	goMod, err := os.ReadFile("go.mod")
 	if err != nil {
 		t.Fatal(err)
@@ -119,87 +99,64 @@ func TestHuaweiGatewayDispositionsFailClosedIndependently(t *testing.T) {
 		t.Fatalf("missing exact transport dependency %q", wantDependency)
 	}
 
-	evidence := decodeHuaweiObject(t, "profiles/vendor/huawei/evidence.json")
-	requireHuaweiKeys(t, evidence, "schema", "profile", "profile_version", "public_sources", "applicability", "license")
-	if evidence["schema"] != "helianthus-modbusreg-vendor-evidence/v1" ||
-		evidence["profile"] != "huawei" || evidence["profile_version"] != "1.0.0" ||
-		evidence["license"] != "CC0-1.0" {
-		t.Fatalf("unexpected Huawei evidence identity: %#v", evidence)
-	}
-
-	expectations := []huaweiFamilyExpectation{
-		{
-			file: "emma-disposition.json", profile: "huawei.emma", candidateID: "huawei.emma.v1", gatewayKind: "EMMA",
-			missingDiscriminators: []string{"sanitized_model_software_self_entry_fixture", "negative_overlap_with_smartlogger", "live_mei_child_inventory_fixture"},
-			requiredTuple:         []string{"offering_name", "model_emma_family", "software_version_branch_match", "mei_child_inventory_self_entry_device_id_zero_product_type_hems"},
-			forbiddenIdentity:     []string{"serial_number_30015", "model_register_readability_only", "basic_mei_only", "smarthems_prefix_without_fixture"},
-			firmwareGateCount:     2, negativeFixtures: []string{"emma-cross-branch-r026", "emma-r025-below-minimum"},
-			unitTarget: "0", maxChildren: 247, maxPages: 248, maxObjects: 248, maxBytes: 65536,
-			reject: []string{"cursor_loop", "duplicate_object", "duplicate_device_id", "count_mismatch", "presence_or_count_changed"},
-		},
-	}
-
 	privateEndpoint := regexp.MustCompile(`(?m)\b(?:10|127|169\.254|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.`)
-	for _, expected := range expectations {
-		t.Run(expected.gatewayKind, func(t *testing.T) {
-			path := "profiles/vendor/huawei/" + expected.file
-			data, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if privateEndpoint.Match(data) || bytes.Contains(bytes.ToLower(data), []byte("credential")) {
-				t.Fatal("disposition contains private endpoint or credential material")
-			}
-			record := decodeHuaweiObject(t, path)
-			requireHuaweiKeys(t, record, "schema", "profile", "profile_version", "outcome", "evidence", "transport_dependency", "detector", "firmware_gate_count", "negative_fixture_ids", "child_enumeration", "decoder_keys", "catalog_registered", "support_claim", "reopen_requires")
-			if record["schema"] != "helianthus-modbusreg-profile-disposition/v1" || record["profile"] != expected.profile ||
-				record["profile_version"] != "1.0.0" || record["outcome"] != "NO_ADMISSIBLE_PROFILE" ||
-				record["catalog_registered"] != false || record["support_claim"] != false {
-				t.Fatalf("unexpected disposition: %#v", record)
-			}
-			if len(record["decoder_keys"].([]any)) != 0 {
-				t.Fatal("decoder key registered for an inadmissible profile")
-			}
+	path := "profiles/vendor/huawei/emma-disposition.json"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if privateEndpoint.Match(data) || bytes.Contains(bytes.ToLower(data), []byte("credential")) {
+		t.Fatal("disposition contains private endpoint or credential material")
+	}
+	record := decodeHuaweiObject(t, path)
+	requireHuaweiKeys(t, record, "schema", "profile", "profile_version", "outcome", "evidence", "offline_identity_gate_registered", "catalog_registered", "automatic_runtime_admission", "support_claim", "detector", "firmware_gates", "child_enumeration", "decoder_keys", "reopen_requires")
+	if record["schema"] != "helianthus-modbusreg-huawei-emma-disposition/v2" || record["profile"] != HuaweiEMMAReadOnlyProfileID ||
+		record["profile_version"] != "1.0.0" || record["outcome"] != "OFFLINE_IDENTITY_ADMITTED" ||
+		record["offline_identity_gate_registered"] != true || record["catalog_registered"] != false ||
+		record["automatic_runtime_admission"] != false || record["support_claim"] != false || len(record["decoder_keys"].([]any)) != 0 {
+		t.Fatalf("unexpected disposition: %#v", record)
+	}
 
-			source := huaweiObject(t, record["evidence"])
-			requireHuaweiKeys(t, source, "packet_id", "docs_merge_sha", "candidate_id", "gateway_kind", "documentary_status", "eligible", "missing_discriminators")
-			if source["packet_id"] != "HUAWEI-GATEWAYS-V1" || source["docs_merge_sha"] != huaweiDocsMergeSHA ||
-				source["candidate_id"] != expected.candidateID || source["gateway_kind"] != expected.gatewayKind ||
-				source["documentary_status"] != "DOCUMENTARY_CANDIDATE" || source["eligible"] != false ||
-				!reflect.DeepEqual(huaweiStringSlice(t, source["missing_discriminators"]), expected.missingDiscriminators) {
-				t.Fatalf("unexpected evidence: %#v", source)
-			}
+	source := huaweiObject(t, record["evidence"])
+	requireHuaweiKeys(t, source, "docs_merge_sha", "candidate_id", "canonical_class", "eligible", "missing_capability_evidence")
+	if source["docs_merge_sha"] != huaweiDocsMergeSHA || source["candidate_id"] != "huawei.emma.offline.v1" ||
+		source["canonical_class"] != HuaweiEMMACanonicalClass || source["eligible"] != true {
+		t.Fatalf("unexpected evidence: %#v", source)
+	}
 
-			dependency := huaweiObject(t, record["transport_dependency"])
-			requireHuaweiKeys(t, dependency, "module", "merge_sha", "version", "prerequisites")
-			if dependency["module"] != "github.com/Project-Helianthus/helianthus-modbus" || dependency["merge_sha"] != huaweiModbusMerge || dependency["version"] != huaweiModbusPin ||
-				!reflect.DeepEqual(huaweiStringSlice(t, dependency["prerequisites"]), []string{"modbus.unit-id-zero.v1", "modbus.mei-vendor-cursor.v1", "modbus.mei-object-wrap.v1"}) {
-				t.Fatalf("unexpected transport dependency: %#v", dependency)
-			}
+	detector := huaweiObject(t, record["detector"])
+	requireHuaweiKeys(t, detector, "registered", "executable", "default_denied", "normalization", "model_aliases", "required_tuple", "optional_enrichment", "forbidden_identity", "multiple_positive_outcome", "first_match_priority")
+	if detector["registered"] != false || detector["executable"] != true || detector["default_denied"] != true ||
+		detector["normalization"] != "terminal_nul_or_space_only" || detector["multiple_positive_outcome"] != "INSUFFICIENT_EVIDENCE" || detector["first_match_priority"] != false ||
+		!reflect.DeepEqual(huaweiStringSlice(t, detector["model_aliases"]), []string{"EMMA-A01", "EMMA-A02"}) ||
+		!reflect.DeepEqual(huaweiStringSlice(t, detector["required_tuple"]), []string{"exact_model_alias", "same_branch_firmware_floor"}) ||
+		!reflect.DeepEqual(huaweiStringSlice(t, detector["optional_enrichment"]), []string{"basic_mei", "extended_mei"}) ||
+		!reflect.DeepEqual(huaweiStringSlice(t, detector["forbidden_identity"]), []string{"offering_name", "serial_number_30015", "basic_mei_only", "extended_mei_only", "prefix_or_wildcard_model_match"}) {
+		t.Fatalf("unexpected detector disposition: %#v", detector)
+	}
 
-			detector := huaweiObject(t, record["detector"])
-			requireHuaweiKeys(t, detector, "registered", "executable", "required_tuple", "forbidden_identity", "candidate_ambiguity_outcome", "multiple_positive_outcome", "first_match_priority")
-			if detector["registered"] != false || detector["executable"] != false || detector["candidate_ambiguity_outcome"] != "NO_ADMISSIBLE_PROFILE" || detector["multiple_positive_outcome"] != "INSUFFICIENT_EVIDENCE" || detector["first_match_priority"] != false ||
-				!reflect.DeepEqual(huaweiStringSlice(t, detector["required_tuple"]), expected.requiredTuple) || !reflect.DeepEqual(huaweiStringSlice(t, detector["forbidden_identity"]), expected.forbiddenIdentity) {
-				t.Fatalf("unexpected detector disposition: %#v", detector)
-			}
-			if huaweiInt(t, record["firmware_gate_count"]) != expected.firmwareGateCount ||
-				!reflect.DeepEqual(huaweiStringSlice(t, record["negative_fixture_ids"]), expected.negativeFixtures) {
-				t.Fatalf("unexpected gate evidence: %#v", record)
-			}
+	gates := huaweiObject(t, record["firmware_gates"])
+	requireHuaweiKeys(t, gates, "V100R024C00", "V100R025C00")
+	if huaweiInt(t, huaweiObject(t, gates["V100R024C00"])["minimum_spc"]) != 100 ||
+		huaweiInt(t, huaweiObject(t, gates["V100R025C00"])["minimum_spc"]) != 102 {
+		t.Fatalf("unexpected firmware gates: %#v", gates)
+	}
+}
 
-			inventory := huaweiObject(t, record["child_enumeration"])
-			requireHuaweiKeys(t, inventory, "operation", "executable", "unit_target", "read_device_id_code", "start_object_id", "max_children", "limits", "reject")
-			limits := huaweiObject(t, inventory["limits"])
-			requireHuaweiKeys(t, limits, "deadline_ms", "max_pages", "max_objects", "max_bytes")
-			if inventory["operation"] != "FC2B_MEI_0E" || inventory["executable"] != false || inventory["unit_target"] != expected.unitTarget ||
-				huaweiInt(t, inventory["read_device_id_code"]) != 3 || huaweiInt(t, inventory["start_object_id"]) != 135 || huaweiInt(t, inventory["max_children"]) != expected.maxChildren ||
-				huaweiInt(t, limits["deadline_ms"]) != 15000 || huaweiInt(t, limits["max_pages"]) != expected.maxPages || huaweiInt(t, limits["max_objects"]) != expected.maxObjects || huaweiInt(t, limits["max_bytes"]) != expected.maxBytes ||
-				!reflect.DeepEqual(huaweiStringSlice(t, inventory["reject"]), expected.reject) {
-				t.Fatalf("unexpected child enumeration: %#v", inventory)
-			}
-			if !reflect.DeepEqual(huaweiStringSlice(t, record["reopen_requires"]), expected.missingDiscriminators) {
-				t.Fatalf("reopen requirements differ from missing discriminators: %#v", record["reopen_requires"])
+func TestHuaweiFamilyDispositionsPinOwnDocumentation(t *testing.T) {
+	tests := []struct {
+		name, path, docsMergeSHA string
+	}{
+		{"SmartLogger", "profiles/vendor/huawei/smartlogger-disposition.json", "2abcb26a06ffa71149177de2cc2817a24d82081f"},
+		{"S-Dongle", "profiles/vendor/huawei/sdongle-disposition.json", "2d44c22f27c4be0e1de460f63b8330c728a5af8f"},
+		{"EMMA", "profiles/vendor/huawei/emma-disposition.json", huaweiDocsMergeSHA},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			record := decodeHuaweiObject(t, test.path)
+			evidence := huaweiObject(t, record["evidence"])
+			if evidence["docs_merge_sha"] != test.docsMergeSHA {
+				t.Fatalf("docs merge SHA=%q want %q", evidence["docs_merge_sha"], test.docsMergeSHA)
 			}
 		})
 	}

--- a/huawei_disposition_test.go
+++ b/huawei_disposition_test.go
@@ -285,9 +285,9 @@ func TestHuaweiEMMAOfflineDispositionIsDefaultDeniedAndPinnedToDocs(t *testing.T
 	if detector["registered"] != false || detector["executable"] != true || detector["default_denied"] != true ||
 		detector["normalization"] != "terminal_nul_or_space_only" || detector["multiple_positive_outcome"] != "INSUFFICIENT_EVIDENCE" || detector["first_match_priority"] != false ||
 		!reflect.DeepEqual(huaweiStringSlice(t, detector["model_aliases"]), []string{"EMMA-A01", "EMMA-A02"}) ||
-		!reflect.DeepEqual(huaweiStringSlice(t, detector["required_tuple"]), []string{"exact_model_alias", "same_branch_firmware_floor"}) ||
+		!reflect.DeepEqual(huaweiStringSlice(t, detector["required_tuple"]), []string{"bounded_contextual_offering", "exact_model_alias", "same_branch_firmware_floor"}) ||
 		!reflect.DeepEqual(huaweiStringSlice(t, detector["optional_enrichment"]), []string{"basic_mei", "extended_mei"}) ||
-		!reflect.DeepEqual(huaweiStringSlice(t, detector["forbidden_identity"]), []string{"offering_name", "serial_number_30015", "basic_mei_only", "extended_mei_only", "prefix_or_wildcard_model_match"}) {
+		!reflect.DeepEqual(huaweiStringSlice(t, detector["forbidden_identity"]), []string{"serial_number_30015", "basic_mei_only", "extended_mei_only", "prefix_or_wildcard_model_match"}) {
 		t.Fatalf("unexpected detector disposition: %#v", detector)
 	}
 

--- a/huawei_emma.go
+++ b/huawei_emma.go
@@ -15,6 +15,7 @@ type HuaweiEMMAOfflineReason string
 
 const (
 	HuaweiEMMAOfflineMatched          HuaweiEMMAOfflineReason = "matched"
+	HuaweiEMMAOfflineOfferingMismatch HuaweiEMMAOfflineReason = "offering_mismatch"
 	HuaweiEMMAOfflineModelMismatch    HuaweiEMMAOfflineReason = "model_mismatch"
 	HuaweiEMMAOfflineFirmwareMismatch HuaweiEMMAOfflineReason = "firmware_mismatch"
 )
@@ -48,10 +49,13 @@ func (d HuaweiEMMAOfflineDecision) DefaultDenied() bool { return true }
 
 func (d HuaweiEMMAOfflineDecision) Reason() HuaweiEMMAOfflineReason { return d.reason }
 
-// EvaluateHuaweiEMMAOfflineIdentity classifies only documented EMMA model and
-// firmware strings. It performs no transport work and never enables runtime
+// EvaluateHuaweiEMMAOfflineIdentity classifies a complete documented FC03 EMMA
+// identity tuple. It performs no transport work and never enables runtime
 // admission.
-func EvaluateHuaweiEMMAOfflineIdentity(model, firmware string) HuaweiEMMAOfflineDecision {
+func EvaluateHuaweiEMMAOfflineIdentity(offering, model, firmware string) HuaweiEMMAOfflineDecision {
+	if !isHuaweiEMMAOffering(offering) {
+		return HuaweiEMMAOfflineDecision{reason: HuaweiEMMAOfflineOfferingMismatch}
+	}
 	model = trimHuaweiTerminalPadding(model)
 	if model != "EMMA-A01" && model != "EMMA-A02" {
 		return HuaweiEMMAOfflineDecision{reason: HuaweiEMMAOfflineModelMismatch}
@@ -64,6 +68,19 @@ func EvaluateHuaweiEMMAOfflineIdentity(model, firmware string) HuaweiEMMAOffline
 		model:   model,
 		reason:  HuaweiEMMAOfflineMatched,
 	}
+}
+
+func isHuaweiEMMAOffering(offering string) bool {
+	offering = trimHuaweiTerminalPadding(offering)
+	if len(offering) == 0 || len(offering) > 30 {
+		return false
+	}
+	for _, character := range offering {
+		if character < 0x20 || character > 0x7e {
+			return false
+		}
+	}
+	return true
 }
 
 func trimHuaweiTerminalPadding(value string) string {

--- a/huawei_emma.go
+++ b/huawei_emma.go
@@ -1,0 +1,90 @@
+package modbusreg
+
+import (
+	"strconv"
+	"strings"
+)
+
+const (
+	HuaweiEMMACanonicalClass    = "EMMA"
+	HuaweiEMMAReadOnlyProfileID = "huawei.emma.readonly.v1"
+)
+
+// HuaweiEMMAOfflineReason explains one transport-free identity gate result.
+type HuaweiEMMAOfflineReason string
+
+const (
+	HuaweiEMMAOfflineMatched          HuaweiEMMAOfflineReason = "matched"
+	HuaweiEMMAOfflineModelMismatch    HuaweiEMMAOfflineReason = "model_mismatch"
+	HuaweiEMMAOfflineFirmwareMismatch HuaweiEMMAOfflineReason = "firmware_mismatch"
+)
+
+// HuaweiEMMAOfflineDecision is an immutable, default-denied identity result.
+type HuaweiEMMAOfflineDecision struct {
+	matched bool
+	model   string
+	reason  HuaweiEMMAOfflineReason
+}
+
+func (d HuaweiEMMAOfflineDecision) Matched() bool { return d.matched }
+
+func (d HuaweiEMMAOfflineDecision) CanonicalClass() string {
+	if !d.matched {
+		return ""
+	}
+	return HuaweiEMMACanonicalClass
+}
+
+func (d HuaweiEMMAOfflineDecision) ModelVariant() string { return d.model }
+
+func (d HuaweiEMMAOfflineDecision) ProfileID() string {
+	if !d.matched {
+		return ""
+	}
+	return HuaweiEMMAReadOnlyProfileID
+}
+
+func (d HuaweiEMMAOfflineDecision) DefaultDenied() bool { return true }
+
+func (d HuaweiEMMAOfflineDecision) Reason() HuaweiEMMAOfflineReason { return d.reason }
+
+// EvaluateHuaweiEMMAOfflineIdentity classifies only documented EMMA model and
+// firmware strings. It performs no transport work and never enables runtime
+// admission.
+func EvaluateHuaweiEMMAOfflineIdentity(model, firmware string) HuaweiEMMAOfflineDecision {
+	model = trimHuaweiTerminalPadding(model)
+	if model != "EMMA-A01" && model != "EMMA-A02" {
+		return HuaweiEMMAOfflineDecision{reason: HuaweiEMMAOfflineModelMismatch}
+	}
+	if !matchesHuaweiEMMAFirmwareFloor(trimHuaweiTerminalPadding(firmware)) {
+		return HuaweiEMMAOfflineDecision{reason: HuaweiEMMAOfflineFirmwareMismatch}
+	}
+	return HuaweiEMMAOfflineDecision{
+		matched: true,
+		model:   model,
+		reason:  HuaweiEMMAOfflineMatched,
+	}
+}
+
+func trimHuaweiTerminalPadding(value string) string {
+	return strings.TrimRight(value, "\x00 ")
+}
+
+func matchesHuaweiEMMAFirmwareFloor(firmware string) bool {
+	var prefix string
+	var floor int
+	switch {
+	case strings.HasPrefix(firmware, "SmartHEMS V100R024C00SPC"):
+		prefix, floor = "SmartHEMS V100R024C00SPC", 100
+	case strings.HasPrefix(firmware, "SmartHEMS V100R025C00SPC"):
+		prefix, floor = "SmartHEMS V100R025C00SPC", 102
+	default:
+		return false
+	}
+	patch := strings.TrimPrefix(firmware, prefix)
+	if len(patch) != 3 {
+		return false
+	}
+	value, err := strconv.Atoi(patch)
+	return err == nil && value >= floor
+}

--- a/huawei_emma_test.go
+++ b/huawei_emma_test.go
@@ -1,0 +1,61 @@
+package modbusreg
+
+import "testing"
+
+func TestEvaluateHuaweiEMMAOfflineIdentityUsesFiniteAliasesAndBranchFloors(t *testing.T) {
+	tests := []struct {
+		name, model, firmware string
+		matched                bool
+		variant                string
+		reason                 HuaweiEMMAOfflineReason
+	}{
+		{
+			name: "A01 R024 floor", model: "EMMA-A01", firmware: "SmartHEMS V100R024C00SPC100",
+			matched: true, variant: "EMMA-A01", reason: HuaweiEMMAOfflineMatched,
+		},
+		{
+			name: "A02 R025 above floor with terminal padding", model: "EMMA-A02\x00 ", firmware: "SmartHEMS V100R025C00SPC131 ",
+			matched: true, variant: "EMMA-A02", reason: HuaweiEMMAOfflineMatched,
+		},
+		{
+			name: "R025 below floor", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC101",
+			matched: false, reason: HuaweiEMMAOfflineFirmwareMismatch,
+		},
+		{
+			name: "unknown R branch", model: "EMMA-A02", firmware: "SmartHEMS V100R026C00SPC999",
+			matched: false, reason: HuaweiEMMAOfflineFirmwareMismatch,
+		},
+		{
+			name: "near model suffix", model: "EMMA-A02-Pro", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
+		},
+		{
+			name: "canonical class alone is not an alias", model: "EMMA", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
+		},
+		{
+			name: "case differs", model: "emma-a02", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
+		},
+		{
+			name: "leading whitespace is not padding", model: " EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := EvaluateHuaweiEMMAOfflineIdentity(test.model, test.firmware)
+			if decision.Matched() != test.matched || decision.Reason() != test.reason {
+				t.Fatalf("decision=(matched=%t reason=%q), want (matched=%t reason=%q)", decision.Matched(), decision.Reason(), test.matched, test.reason)
+			}
+			if !test.matched {
+				return
+			}
+			if decision.CanonicalClass() != "EMMA" || decision.ModelVariant() != test.variant ||
+				decision.ProfileID() != "huawei.emma.readonly.v1" || !decision.DefaultDenied() {
+				t.Fatalf("unexpected accepted decision: %+v", decision)
+			}
+		})
+	}
+}

--- a/huawei_emma_test.go
+++ b/huawei_emma_test.go
@@ -5,9 +5,9 @@ import "testing"
 func TestEvaluateHuaweiEMMAOfflineIdentityUsesFiniteAliasesAndBranchFloors(t *testing.T) {
 	tests := []struct {
 		name, model, firmware string
-		matched                bool
-		variant                string
-		reason                 HuaweiEMMAOfflineReason
+		matched               bool
+		variant               string
+		reason                HuaweiEMMAOfflineReason
 	}{
 		{
 			name: "A01 R024 floor", model: "EMMA-A01", firmware: "SmartHEMS V100R024C00SPC100",

--- a/huawei_emma_test.go
+++ b/huawei_emma_test.go
@@ -4,48 +4,56 @@ import "testing"
 
 func TestEvaluateHuaweiEMMAOfflineIdentityUsesFiniteAliasesAndBranchFloors(t *testing.T) {
 	tests := []struct {
-		name, model, firmware string
-		matched               bool
-		variant               string
-		reason                HuaweiEMMAOfflineReason
+		name, offering, model, firmware string
+		matched                         bool
+		variant                         string
+		reason                          HuaweiEMMAOfflineReason
 	}{
 		{
-			name: "A01 R024 floor", model: "EMMA-A01", firmware: "SmartHEMS V100R024C00SPC100",
+			name: "A01 R024 floor", offering: "SmartHEMS", model: "EMMA-A01", firmware: "SmartHEMS V100R024C00SPC100",
 			matched: true, variant: "EMMA-A01", reason: HuaweiEMMAOfflineMatched,
 		},
 		{
-			name: "A02 R025 above floor with terminal padding", model: "EMMA-A02\x00 ", firmware: "SmartHEMS V100R025C00SPC131 ",
+			name: "A02 R025 above floor with terminal padding", offering: "SmartHEMS\x00 ", model: "EMMA-A02\x00 ", firmware: "SmartHEMS V100R025C00SPC131 ",
 			matched: true, variant: "EMMA-A02", reason: HuaweiEMMAOfflineMatched,
 		},
 		{
-			name: "R025 below floor", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC101",
+			name: "R025 below floor", offering: "SmartHEMS", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC101",
 			matched: false, reason: HuaweiEMMAOfflineFirmwareMismatch,
 		},
 		{
-			name: "unknown R branch", model: "EMMA-A02", firmware: "SmartHEMS V100R026C00SPC999",
+			name: "unknown R branch", offering: "SmartHEMS", model: "EMMA-A02", firmware: "SmartHEMS V100R026C00SPC999",
 			matched: false, reason: HuaweiEMMAOfflineFirmwareMismatch,
 		},
 		{
-			name: "near model suffix", model: "EMMA-A02-Pro", firmware: "SmartHEMS V100R025C00SPC131",
+			name: "near model suffix", offering: "SmartHEMS", model: "EMMA-A02-Pro", firmware: "SmartHEMS V100R025C00SPC131",
 			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
 		},
 		{
-			name: "canonical class alone is not an alias", model: "EMMA", firmware: "SmartHEMS V100R025C00SPC131",
+			name: "canonical class alone is not an alias", offering: "SmartHEMS", model: "EMMA", firmware: "SmartHEMS V100R025C00SPC131",
 			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
 		},
 		{
-			name: "case differs", model: "emma-a02", firmware: "SmartHEMS V100R025C00SPC131",
+			name: "case differs", offering: "SmartHEMS", model: "emma-a02", firmware: "SmartHEMS V100R025C00SPC131",
 			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
 		},
 		{
-			name: "leading whitespace is not padding", model: " EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
+			name: "leading whitespace is not padding", offering: "SmartHEMS", model: " EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
 			matched: false, reason: HuaweiEMMAOfflineModelMismatch,
+		},
+		{
+			name: "empty offering rejects partial tuple", offering: "", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineOfferingMismatch,
+		},
+		{
+			name: "offering non printable ASCII rejects partial tuple", offering: "Smart\nHEMS", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineOfferingMismatch,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			decision := EvaluateHuaweiEMMAOfflineIdentity(test.model, test.firmware)
+			decision := EvaluateHuaweiEMMAOfflineIdentity(test.offering, test.model, test.firmware)
 			if decision.Matched() != test.matched || decision.Reason() != test.reason {
 				t.Fatalf("decision=(matched=%t reason=%q), want (matched=%t reason=%q)", decision.Matched(), decision.Reason(), test.matched, test.reason)
 			}

--- a/huawei_emma_test.go
+++ b/huawei_emma_test.go
@@ -49,6 +49,10 @@ func TestEvaluateHuaweiEMMAOfflineIdentityUsesFiniteAliasesAndBranchFloors(t *te
 			name: "offering non printable ASCII rejects partial tuple", offering: "Smart\nHEMS", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
 			matched: false, reason: HuaweiEMMAOfflineOfferingMismatch,
 		},
+		{
+			name: "offering longer than FC03 field rejects partial tuple", offering: "1234567890123456789012345678901", model: "EMMA-A02", firmware: "SmartHEMS V100R025C00SPC131",
+			matched: false, reason: HuaweiEMMAOfflineOfferingMismatch,
+		},
 	}
 
 	for _, test := range tests {

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -114,15 +114,21 @@ func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
 			t.Fatal(err)
 		}
 		var disposition struct {
-			Outcome           string `json:"outcome"`
-			CatalogRegistered bool   `json:"catalog_registered"`
-			SupportClaim      bool   `json:"support_claim"`
+			Outcome                   string `json:"outcome"`
+			CatalogRegistered         bool   `json:"catalog_registered"`
+			AutomaticRuntimeAdmission bool   `json:"automatic_runtime_admission"`
+			OfflineIdentityGate       bool   `json:"offline_identity_gate_registered"`
+			SupportClaim              bool   `json:"support_claim"`
 		}
 		if err := json.Unmarshal(data, &disposition); err != nil {
 			t.Fatal(err)
 		}
-		if disposition.Outcome != got.Disposition || disposition.CatalogRegistered || disposition.SupportClaim {
+		if disposition.Outcome != got.Disposition || disposition.CatalogRegistered ||
+			disposition.AutomaticRuntimeAdmission || disposition.SupportClaim {
 			t.Fatalf("participant %s became actionable: %#v", got.ID, disposition)
+		}
+		if got.ID == "huawei.emma" && !disposition.OfflineIdentityGate {
+			t.Fatalf("participant %s lacks its offline identity gate: %#v", got.ID, disposition)
 		}
 	}
 }

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -95,7 +95,7 @@ func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
 		{"growatt.direct-inverter", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/growatt/disposition.json"},
 		{"huawei.smartlogger", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/huawei/smartlogger-disposition.json"},
 		{"huawei.sdongle", "PRIMARY_CANDIDATE", "PRE_LIVE_INSUFFICIENT_EVIDENCE", "", "profiles/vendor/huawei/sdongle-disposition.json"},
-		{"huawei.emma", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/huawei/emma-disposition.json"},
+		{"huawei.emma", "PRIMARY_CANDIDATE", "OFFLINE_IDENTITY_ADMITTED", "", "profiles/vendor/huawei/emma-disposition.json"},
 	}
 	if len(closure.Participants) != len(wantParticipants) {
 		t.Fatalf("participants=%d want=%d", len(closure.Participants), len(wantParticipants))

--- a/profiles/mixed-catalog-closure-v1.json
+++ b/profiles/mixed-catalog-closure-v1.json
@@ -64,7 +64,7 @@
     {
       "id": "huawei.emma",
       "role": "PRIMARY_CANDIDATE",
-      "disposition": "NO_ADMISSIBLE_PROFILE",
+      "disposition": "OFFLINE_IDENTITY_ADMITTED",
       "runtime_identity": "",
       "disposition_file": "profiles/vendor/huawei/emma-disposition.json"
     }

--- a/profiles/vendor/huawei/emma-disposition.json
+++ b/profiles/vendor/huawei/emma-disposition.json
@@ -28,6 +28,7 @@
       "EMMA-A02"
     ],
     "required_tuple": [
+      "bounded_contextual_offering",
       "exact_model_alias",
       "same_branch_firmware_floor"
     ],
@@ -36,7 +37,6 @@
       "extended_mei"
     ],
     "forbidden_identity": [
-      "offering_name",
       "serial_number_30015",
       "basic_mei_only",
       "extended_mei_only",

--- a/profiles/vendor/huawei/emma-disposition.json
+++ b/profiles/vendor/huawei/emma-disposition.json
@@ -1,55 +1,58 @@
 {
-  "schema": "helianthus-modbusreg-profile-disposition/v1",
-  "profile": "huawei.emma",
+  "schema": "helianthus-modbusreg-huawei-emma-disposition/v2",
+  "profile": "huawei.emma.readonly.v1",
   "profile_version": "1.0.0",
-  "outcome": "NO_ADMISSIBLE_PROFILE",
+  "outcome": "OFFLINE_IDENTITY_ADMITTED",
   "evidence": {
-    "packet_id": "HUAWEI-GATEWAYS-V1",
-    "docs_merge_sha": "aa67e0c2a7c2042c7c1dccad6ebe3c4900dab04f",
-    "candidate_id": "huawei.emma.v1",
-    "gateway_kind": "EMMA",
-    "documentary_status": "DOCUMENTARY_CANDIDATE",
-    "eligible": false,
-    "missing_discriminators": [
-      "sanitized_model_software_self_entry_fixture",
+    "docs_merge_sha": "fa8838c92f3ce2eac3ad953d7059eccc21be19c7",
+    "candidate_id": "huawei.emma.offline.v1",
+    "canonical_class": "EMMA",
+    "eligible": true,
+    "missing_capability_evidence": [
+      "sanitized_readonly_capability_fixture",
       "negative_overlap_with_smartlogger",
-      "live_mei_child_inventory_fixture"
+      "model_specific_capability_fixture"
     ]
   },
-  "transport_dependency": {
-    "module": "github.com/Project-Helianthus/helianthus-modbus",
-    "merge_sha": "c78030472c24f0f2b849fd30124611157a81f834",
-    "version": "v0.0.0-20260820212315-c78030472c24",
-    "prerequisites": [
-      "modbus.unit-id-zero.v1",
-      "modbus.mei-vendor-cursor.v1",
-      "modbus.mei-object-wrap.v1"
-    ]
-  },
+  "offline_identity_gate_registered": true,
+  "catalog_registered": false,
+  "automatic_runtime_admission": false,
+  "support_claim": false,
   "detector": {
     "registered": false,
-    "executable": false,
+    "executable": true,
+    "default_denied": true,
+    "normalization": "terminal_nul_or_space_only",
+    "model_aliases": [
+      "EMMA-A01",
+      "EMMA-A02"
+    ],
     "required_tuple": [
-      "offering_name",
-      "model_emma_family",
-      "software_version_branch_match",
-      "mei_child_inventory_self_entry_device_id_zero_product_type_hems"
+      "exact_model_alias",
+      "same_branch_firmware_floor"
+    ],
+    "optional_enrichment": [
+      "basic_mei",
+      "extended_mei"
     ],
     "forbidden_identity": [
+      "offering_name",
       "serial_number_30015",
-      "model_register_readability_only",
       "basic_mei_only",
-      "smarthems_prefix_without_fixture"
+      "extended_mei_only",
+      "prefix_or_wildcard_model_match"
     ],
-    "candidate_ambiguity_outcome": "NO_ADMISSIBLE_PROFILE",
     "multiple_positive_outcome": "INSUFFICIENT_EVIDENCE",
     "first_match_priority": false
   },
-  "firmware_gate_count": 2,
-  "negative_fixture_ids": [
-    "emma-cross-branch-r026",
-    "emma-r025-below-minimum"
-  ],
+  "firmware_gates": {
+    "V100R024C00": {
+      "minimum_spc": 100
+    },
+    "V100R025C00": {
+      "minimum_spc": 102
+    }
+  },
   "child_enumeration": {
     "operation": "FC2B_MEI_0E",
     "executable": false,
@@ -72,11 +75,9 @@
     ]
   },
   "decoder_keys": [],
-  "catalog_registered": false,
-  "support_claim": false,
   "reopen_requires": [
-    "sanitized_model_software_self_entry_fixture",
+    "sanitized_readonly_capability_fixture",
     "negative_overlap_with_smartlogger",
-    "live_mei_child_inventory_fixture"
+    "model_specific_capability_fixture"
   ]
 }


### PR DESCRIPTION
## RED evidence
Public RED commit `3d2cda9` adds the focused contract test. It fails because the offline EMMA matcher API is intentionally absent.

## Planned GREEN
- finite case-sensitive A01/A02 aliases after terminal NUL/space padding only
- R024C00 SPC100+ and R025C00 SPC102+ floors evaluated only within each branch
- default-denied result with no activation or transport work
- disposition/evidence/mixed-catalog pin to docs merge `fa8838c92f3ce2eac3ad953d7059eccc21be19c7`

## Excluded
No Modbus I/O, FC41/FC17, decoder, gateway, deployment, or live mutation.