### PR TITLE
REG-GR-01: fix Growatt docs merge pin + locator

### DIFF
--- a/growatt_disposition_test.go
+++ b/growatt_disposition_test.go
@@ -51,7 +51,7 @@ func TestGrowattDispositionFailsClosedWithoutQualifiedEvidence(t *testing.T) {
 		t.Fatalf("unexpected disposition identity: %#v", record)
 	}
 	if record.Evidence.PacketID != "GROWATT-CANDIDATE-V1" ||
-		record.Evidence.DocsMergeSHA != "42da2afdb0fd46bdb4301a847d59096e252bfe00" ||
+		record.Evidence.DocsMergeSHA != "6654837a4ec29a3f226a29f701574ee84495ff2f" ||
 		record.Evidence.SourceIdentity != "sha256:fac88d609d74ff6b3c9c31ed65370d166d1fb17461e91b4b4855018fe232a320" ||
 		record.Evidence.SourceLicense != "vendor-copyright-inspection-only" ||
 		record.Evidence.PacketDisposition != "HYPOTHESIS" ||

--- a/profiles/vendor/growatt/disposition.json
+++ b/profiles/vendor/growatt/disposition.json
@@ -5,7 +5,7 @@
   "outcome": "NO_ADMISSIBLE_PROFILE",
   "evidence": {
     "packet_id": "GROWATT-CANDIDATE-V1",
-    "docs_merge_sha": "42da2afdb0fd46bdb4301a847d59096e252bfe00",
+    "docs_merge_sha": "6654837a4ec29a3f226a29f701574ee84495ff2f",
     "source_identity": "sha256:fac88d609d74ff6b3c9c31ed65370d166d1fb17461e91b4b4855018fe232a320",
     "source_license": "vendor-copyright-inspection-only",
     "packet_disposition": "HYPOTHESIS",

--- a/profiles/vendor/growatt/evidence.json
+++ b/profiles/vendor/growatt/evidence.json
@@ -5,7 +5,7 @@
   "public_sources": [
     {
       "id": "growatt-candidate-v1",
-      "locator": "https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/42da2afdb0fd46bdb4301a847d59096e252bfe00/protocols/modbus/growatt-candidate-evidence-v1.md",
+      "locator": "https://github.com/Project-Helianthus/helianthus-docs-modbus/blob/6654837a4ec29a3f226a29f701574ee84495ff2f/protocols/growatt/protocol-ii-readonly-v1.md",
       "license": "CC0-1.0"
     }
   ],


### PR DESCRIPTION
## Scope
- Replace stale Growatt evidences pining to 42da... with DOC-MV-01 merge SHA 6654837a4ec29a3f226a29f701574ee84495ff2f.
- Update public evidence locator from helianthus-docs-ebus Growatt candidate page to docs-modbus Protocol II page.
- Keep outcome as NO_ADMISSIBLE_PROFILE, catalog_registered=false, support_claim=false.

No runtime/gateway/transport changes. No live I/O. NO_SEND/default-denied preserved.