### PR TITLE
REG-TESLA-02: make HSC envelope decoding direction-specific

### DIFF
--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -18,6 +18,7 @@ const (
 	teslaHSCFunction100 modbus.PrivateFunctionCode = 100
 	teslaHSCFunction101 modbus.PrivateFunctionCode = 101
 	teslaHSCFunction102 modbus.PrivateFunctionCode = 102
+	maxTeslaHSCPayload                             = modbus.MaxPDUSize - 1
 )
 
 // TeslaHSCDisposition records whether a configured profile can do more than
@@ -112,20 +113,42 @@ func (profile TeslaHSCProfile) OperationAdmission() TeslaTEDAPIOperationAdmissio
 	}
 }
 
-// TeslaHSCEnvelope is a decoded length envelope with uninterpreted inner bytes.
+// TeslaHSCEnvelope is a decoded exact-length request or FC100 data envelope.
 type TeslaHSCEnvelope struct {
 	function modbus.PrivateFunctionCode
 	payload  []byte
 }
 
-// DecodeTeslaHSCEnvelope validates the one-byte exact length envelope used by
-// all supported HSC vendor functions and retains the nested bytes opaquely.
+// DecodeTeslaHSCEnvelope validates the FC100 data envelope. FC101 and FC102
+// use the exact-length envelope only in the request direction.
 func DecodeTeslaHSCEnvelope(
+	function modbus.PrivateFunctionCode,
+	payload []byte,
+) (TeslaHSCEnvelope, error) {
+	if function != teslaHSCFunction100 {
+		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC function is unsupported")
+	}
+	return decodeTeslaHSCExactEnvelope(function, payload)
+}
+
+// DecodeTeslaHSCRequestEnvelope validates the exact-length request envelope
+// used by FC100, FC101, and FC102 without granting outbound admission.
+func DecodeTeslaHSCRequestEnvelope(
 	function modbus.PrivateFunctionCode,
 	payload []byte,
 ) (TeslaHSCEnvelope, error) {
 	if !isTeslaHSCFunction(function) {
 		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC function is unsupported")
+	}
+	return decodeTeslaHSCExactEnvelope(function, payload)
+}
+
+func decodeTeslaHSCExactEnvelope(
+	function modbus.PrivateFunctionCode,
+	payload []byte,
+) (TeslaHSCEnvelope, error) {
+	if len(payload) > maxTeslaHSCPayload {
+		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC payload exceeds bound")
 	}
 	if len(payload) == 0 {
 		return TeslaHSCEnvelope{}, fmt.Errorf("tesla HSC payload has no length prefix")
@@ -137,6 +160,46 @@ func DecodeTeslaHSCEnvelope(
 		function: function,
 		payload:  append([]byte(nil), payload[1:]...),
 	}, nil
+}
+
+// TeslaHSCResponse is one bounded direction-aware normal response. FC100
+// retains decoded data bytes; FC101 and FC102 retain raw bytes opaquely.
+type TeslaHSCResponse struct {
+	function modbus.PrivateFunctionCode
+	payload  []byte
+}
+
+// DecodeTeslaHSCResponse decodes FC100 data envelopes while retaining FC101
+// and FC102 normal response payloads as bounded opaque bytes.
+func DecodeTeslaHSCResponse(
+	function modbus.PrivateFunctionCode,
+	payload []byte,
+) (TeslaHSCResponse, error) {
+	if !isTeslaHSCFunction(function) {
+		return TeslaHSCResponse{}, fmt.Errorf("tesla HSC function is unsupported")
+	}
+	if len(payload) > maxTeslaHSCPayload {
+		return TeslaHSCResponse{}, fmt.Errorf("tesla HSC response exceeds bound")
+	}
+	if function == teslaHSCFunction100 {
+		envelope, err := DecodeTeslaHSCEnvelope(function, payload)
+		if err != nil {
+			return TeslaHSCResponse{}, err
+		}
+		return TeslaHSCResponse{function: function, payload: envelope.Payload()}, nil
+	}
+	return TeslaHSCResponse{function: function, payload: append([]byte(nil), payload...)}, nil
+}
+
+// Function returns the vendor function identified by this response.
+func (response TeslaHSCResponse) Function() modbus.PrivateFunctionCode {
+	return response.function
+}
+
+// Payload returns independent normal-response bytes under the selected
+// direction contract.
+func (response TeslaHSCResponse) Payload() []byte {
+	return append([]byte(nil), response.payload...)
 }
 
 // Function returns the vendor function identified by this envelope.
@@ -218,15 +281,15 @@ func (TeslaHSCProfile) EncodeQualifiedFunction(string) (modbus.PrivateFunctionRe
 	return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
 }
 
-// DecodeQualifiedFunction validates only the Tesla profile envelope and keeps
-// the nested payload opaque. It is available to an already selected codec and
-// does not itself grant outbound admission.
+// DecodeQualifiedFunction validates only the Tesla profile normal-response
+// contract. It is available to an already selected codec and does not itself
+// grant outbound admission.
 func (TeslaHSCProfile) DecodeQualifiedFunction(_ string, function modbus.PrivateFunctionCode, payload []byte) (QualifiedFunctionResult, error) {
-	envelope, err := DecodeTeslaHSCEnvelope(function, payload)
+	response, err := DecodeTeslaHSCResponse(function, payload)
 	if err != nil {
 		return QualifiedFunctionResult{}, err
 	}
-	return QualifiedFunctionResult{Payload: envelope.Payload()}, nil
+	return QualifiedFunctionResult{Payload: response.Payload()}, nil
 }
 
 // PayloadLength returns the retained opaque payload length.

--- a/tesla_hsc_direction_test.go
+++ b/tesla_hsc_direction_test.go
@@ -1,0 +1,127 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaHSCRequestEnvelopeIsDirectionalAndBounded(t *testing.T) {
+	maximum := make([]byte, 252)
+	maximum[0] = 251
+	overflow := make([]byte, 253)
+	overflow[0] = 252
+
+	for _, test := range []struct {
+		name     string
+		function modbus.PrivateFunctionCode
+		payload  []byte
+		valid    bool
+	}{
+		{name: "fc100_empty", function: teslaHSCFunction100, payload: []byte{0}, valid: true},
+		{name: "fc101_empty", function: teslaHSCFunction101, payload: []byte{0}, valid: true},
+		{name: "fc102_empty", function: teslaHSCFunction102, payload: []byte{0}, valid: true},
+		{name: "maximum", function: teslaHSCFunction101, payload: maximum, valid: true},
+		{name: "missing_prefix", function: teslaHSCFunction100, payload: nil},
+		{name: "underflow", function: teslaHSCFunction102, payload: []byte{1}},
+		{name: "trailing", function: teslaHSCFunction101, payload: []byte{0, 0}},
+		{name: "overflow", function: teslaHSCFunction100, payload: overflow},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			envelope, err := DecodeTeslaHSCRequestEnvelope(test.function, test.payload)
+			if test.valid {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got, want := envelope.Payload(), test.payload[1:]; !bytes.Equal(got, want) {
+					t.Fatalf("payload = %x, want %x", got, want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("invalid request envelope accepted: %x", test.payload)
+			}
+		})
+	}
+}
+
+func TestTeslaHSCResponseDecodingKeepsFC101And102Raw(t *testing.T) {
+	maximum := make([]byte, 252)
+	overflow := make([]byte, 253)
+	for _, function := range []modbus.PrivateFunctionCode{
+		teslaHSCFunction101,
+		teslaHSCFunction102,
+	} {
+		for _, payload := range [][]byte{nil, {0}, {1}, {2, 0}, maximum} {
+			response, err := DecodeTeslaHSCResponse(function, payload)
+			if err != nil {
+				t.Fatalf("function %d payload %x: %v", function, payload, err)
+			}
+			if got := response.Payload(); !bytes.Equal(got, payload) {
+				t.Fatalf("function %d payload = %x, want %x", function, got, payload)
+			}
+		}
+		if _, err := DecodeTeslaHSCResponse(function, overflow); err == nil {
+			t.Fatalf("function %d accepted oversized response", function)
+		}
+	}
+	if _, err := DecodeTeslaHSCResponse(teslaHSCFunction100, []byte{0}); err != nil {
+		t.Fatal(err)
+	}
+	for _, payload := range [][]byte{nil, {1}, {0, 0}} {
+		if _, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload); err == nil {
+			t.Fatalf("FC100 invalid response accepted: %x", payload)
+		}
+	}
+}
+
+func TestTeslaTEDAPIRegistryRequiresDirectionAndPreservesRawResponse(t *testing.T) {
+	profile := testTeslaDirectionalProfile(t)
+	registry := NewTeslaTEDAPISemanticRegistry()
+	if err := registry.Retain(TeslaTEDAPIObservationSpec{
+		ID: "missing-direction", Profile: profile, Function: teslaHSCFunction101, Payload: []byte{0},
+	}); err == nil {
+		t.Fatal("observation without direction retained")
+	}
+	if err := registry.Retain(TeslaTEDAPIObservationSpec{
+		ID: "request", Profile: profile, Direction: TeslaTEDAPIRequest,
+		Function: teslaHSCFunction101, Payload: []byte{0},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Retain(TeslaTEDAPIObservationSpec{
+		ID: "response", Profile: profile, Direction: TeslaTEDAPIResponse,
+		Function: teslaHSCFunction101, Payload: []byte{1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request, ok := registry.Lookup("request")
+	if !ok || request.Direction != TeslaTEDAPIRequest || request.PayloadLength != 0 || request.OutboundAllowed {
+		t.Fatalf("request record = %#v", request)
+	}
+	response, ok := registry.Lookup("response")
+	if !ok || response.Direction != TeslaTEDAPIResponse || response.PayloadLength != 1 || response.OutboundAllowed {
+		t.Fatalf("response record = %#v", response)
+	}
+}
+
+func TestTeslaHSCNoSendSurvivesDirectionalValidation(t *testing.T) {
+	profile := testTeslaDirectionalProfile(t)
+	for _, operation := range []string{"fc100", "fc101", "fc102"} {
+		if _, _, err := profile.EncodeQualifiedFunction(operation); err == nil {
+			t.Fatalf("operation %q was admitted", operation)
+		}
+	}
+}
+
+func testTeslaDirectionalProfile(t *testing.T) TeslaHSCProfile {
+	t.Helper()
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return profile
+}

--- a/tesla_hsc_test.go
+++ b/tesla_hsc_test.go
@@ -43,7 +43,7 @@ func TestTeslaHSCEnvelopesValidateAndRetainOpaquePayload(t *testing.T) {
 		teslaHSCFunction101,
 		teslaHSCFunction102,
 	} {
-		envelope, err := DecodeTeslaHSCEnvelope(function, []byte{2, 0xaa, 0xbb})
+		envelope, err := DecodeTeslaHSCRequestEnvelope(function, []byte{2, 0xaa, 0xbb})
 		if err != nil {
 			t.Fatalf("function %d: %v", function, err)
 		}
@@ -55,6 +55,9 @@ func TestTeslaHSCEnvelopesValidateAndRetainOpaquePayload(t *testing.T) {
 		if _, err := DecodeTeslaHSCEnvelope(teslaHSCFunction100, payload); err == nil {
 			t.Fatalf("FC100 invalid payload accepted: %x", payload)
 		}
+	}
+	if _, err := DecodeTeslaHSCEnvelope(teslaHSCFunction101, []byte{0}); err == nil {
+		t.Fatal("FC101 response envelope accepted as FC100 data")
 	}
 }
 

--- a/tesla_tedapi_registry.go
+++ b/tesla_tedapi_registry.go
@@ -10,6 +10,15 @@ import (
 
 const maxTeslaTEDAPIObservations = 64
 
+// TeslaTEDAPIDirection identifies the wire direction needed to select the
+// appropriate opaque envelope contract.
+type TeslaTEDAPIDirection string
+
+const (
+	TeslaTEDAPIRequest  TeslaTEDAPIDirection = "request"
+	TeslaTEDAPIResponse TeslaTEDAPIDirection = "response"
+)
+
 // TeslaTEDAPISemanticState describes the deliberately narrow projection level.
 type TeslaTEDAPISemanticState string
 
@@ -20,10 +29,11 @@ const (
 
 // TeslaTEDAPIObservationSpec is one bounded TEDAPI envelope observation.
 type TeslaTEDAPIObservationSpec struct {
-	ID       string
-	Profile  TeslaHSCProfile
-	Function modbus.PrivateFunctionCode
-	Payload  []byte
+	ID        string
+	Profile   TeslaHSCProfile
+	Direction TeslaTEDAPIDirection
+	Function  modbus.PrivateFunctionCode
+	Payload   []byte
 }
 
 // TeslaTEDAPIRedactedRecord is safe for gateway/MCP projection. Payload never
@@ -32,6 +42,7 @@ type TeslaTEDAPIRedactedRecord struct {
 	ID                 string                    `json:"id"`
 	State              TeslaTEDAPISemanticState  `json:"state"`
 	OperationAdmission TeslaTEDAPIAdmissionState `json:"operation_admission"`
+	Direction          TeslaTEDAPIDirection      `json:"direction"`
 	Function           byte                      `json:"function"`
 	PayloadLength      int                       `json:"payload_length"`
 	PayloadDigest      string                    `json:"payload_digest"`
@@ -50,12 +61,29 @@ func NewTeslaTEDAPISemanticRegistry() *TeslaTEDAPISemanticRegistry {
 	return &TeslaTEDAPISemanticRegistry{records: make(map[string]TeslaTEDAPIRedactedRecord)}
 }
 
-// Retain validates an envelope and atomically retains a redacted projection.
+// Retain validates the direction-selected contract and atomically retains a
+// redacted projection.
 func (registry *TeslaTEDAPISemanticRegistry) Retain(spec TeslaTEDAPIObservationSpec) error {
 	if registry == nil || !validIdentity(spec.ID) {
 		return fmt.Errorf("tesla TEDAPI observation identity is invalid")
 	}
-	envelope, err := DecodeTeslaHSCEnvelope(spec.Function, spec.Payload)
+	var (
+		function modbus.PrivateFunctionCode
+		payload  []byte
+		err      error
+	)
+	switch spec.Direction {
+	case TeslaTEDAPIRequest:
+		var envelope TeslaHSCEnvelope
+		envelope, err = DecodeTeslaHSCRequestEnvelope(spec.Function, spec.Payload)
+		function, payload = envelope.Function(), envelope.Payload()
+	case TeslaTEDAPIResponse:
+		var response TeslaHSCResponse
+		response, err = DecodeTeslaHSCResponse(spec.Function, spec.Payload)
+		function, payload = response.Function(), response.Payload()
+	default:
+		return fmt.Errorf("tesla TEDAPI observation direction is invalid")
+	}
 	if err != nil {
 		return err
 	}
@@ -66,12 +94,12 @@ func (registry *TeslaTEDAPISemanticRegistry) Retain(spec TeslaTEDAPIObservationS
 	provenance := NewTeslaHSCProvenance(
 		TeslaHSCCompatibilityV1,
 		spec.Profile.Node(),
-		envelope.Function(),
-		envelope.Payload(),
+		function,
+		payload,
 	)
 	admission := spec.Profile.OperationAdmission()
 	record := TeslaTEDAPIRedactedRecord{
-		ID: spec.ID, State: state, OperationAdmission: admission.State, Function: byte(envelope.Function()),
+		ID: spec.ID, State: state, OperationAdmission: admission.State, Direction: spec.Direction, Function: byte(function),
 		PayloadLength: provenance.PayloadLength(), PayloadDigest: provenance.PayloadDigest(),
 		OutboundAllowed: false,
 	}

--- a/tesla_tedapi_registry_test.go
+++ b/tesla_tedapi_registry_test.go
@@ -16,10 +16,11 @@ func TestTeslaTEDAPIRegistryRetainsOnlyRedactedOpaqueObservations(t *testing.T) 
 	}
 	registry := NewTeslaTEDAPISemanticRegistry()
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
-		ID:       "sample-1",
-		Profile:  profile,
-		Function: teslaHSCFunction100,
-		Payload:  []byte{2, 0xaa, 0xbb},
+		ID:        "sample-1",
+		Profile:   profile,
+		Direction: TeslaTEDAPIResponse,
+		Function:  teslaHSCFunction100,
+		Payload:   []byte{2, 0xaa, 0xbb},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +47,7 @@ func TestTeslaTEDAPIRegistryFailsClosedForUnqualifiedOrMalformedInput(t *testing
 		t.Fatal(err)
 	}
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
-		ID: "sample-2", Profile: profile, Function: teslaHSCFunction101, Payload: []byte{0},
+		ID: "sample-2", Profile: profile, Direction: TeslaTEDAPIRequest, Function: teslaHSCFunction101, Payload: []byte{0},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +58,7 @@ func TestTeslaTEDAPIRegistryFailsClosedForUnqualifiedOrMalformedInput(t *testing
 		t.Fatalf("unqualified record = %#v", record)
 	}
 	if err := registry.Retain(TeslaTEDAPIObservationSpec{
-		ID: "bad", Profile: profile, Function: teslaHSCFunction102, Payload: []byte{1},
+		ID: "bad", Profile: profile, Direction: TeslaTEDAPIRequest, Function: teslaHSCFunction102, Payload: []byte{1},
 	}); err == nil {
 		t.Fatal("malformed payload accepted")
 	}


### PR DESCRIPTION
Closes #56

## Scope

Make Tesla HSC envelope handling direction-specific after the merged protocol contract.

- FC100 keeps exact bounded envelope decoding;
- FC101/FC102 validate the envelope only as requests and retain normal responses raw;
- observations require explicit direction;
- all Tesla outbound operations remain denied.

## Safety

No generic Modbus change, no typed fields/units, no capability promotion, no operation admission, and no live I/O or serial transmission.

## TDD

The first commit is intentionally RED: it requires the directional decoder and observation direction contract before implementation.

Docs prerequisite: Project-Helianthus/helianthus-docs-modbus#16 (merged).