### PR TITLE
REG-TESLA-03: pin opaque normal response codec boundary

### DIFF
--- a/tesla_hsc_direction_test.go
+++ b/tesla_hsc_direction_test.go
@@ -76,6 +76,25 @@ func TestTeslaHSCResponseDecodingKeepsFC101And102Raw(t *testing.T) {
 	}
 }
 
+func TestTeslaHSCQualifiedFunctionKeepsFC101And102NormalResponsesRaw(t *testing.T) {
+	profile := testTeslaDirectionalProfile(t)
+	for _, test := range []struct {
+		function modbus.PrivateFunctionCode
+		payload  []byte
+	}{
+		{function: teslaHSCFunction101, payload: []byte{1}},
+		{function: teslaHSCFunction102, payload: []byte{2, 0}},
+	} {
+		result, err := profile.DecodeQualifiedFunction("offline-replay", test.function, test.payload)
+		if err != nil {
+			t.Fatalf("function %d: %v", test.function, err)
+		}
+		if got := result.Payload; !bytes.Equal(got, test.payload) {
+			t.Fatalf("function %d payload = %x, want %x", test.function, got, test.payload)
+		}
+	}
+}
+
 func TestTeslaTEDAPIRegistryRequiresDirectionAndPreservesRawResponse(t *testing.T) {
 	profile := testTeslaDirectionalProfile(t)
 	registry := NewTeslaTEDAPISemanticRegistry()


### PR DESCRIPTION
Closes #61

Adds regression coverage only for the selected Tesla codec boundary: FC101/102 normal responses that look invalid as requests remain raw opaque bytes.

Frozen write-set: `tesla_hsc_direction_test.go` only.

No RED phase: the test locks existing behavior; it introduces no behavior or implementation.

Validation: focused test and `./scripts/ci_local.sh` pass.