### PR TITLE
REG-SUNSPEC-V2-PRIMITIVES: preserve exact unsigned values

### DIFF
--- a/sunspec_value.go
+++ b/sunspec_value.go
@@ -13,6 +13,7 @@ const (
 	SunSpecTypeInt32         SunSpecPointType = "int32"
 	SunSpecTypeUint16        SunSpecPointType = "uint16"
 	SunSpecTypeUint32        SunSpecPointType = "uint32"
+	SunSpecTypeUint64        SunSpecPointType = "uint64"
 	SunSpecTypeAccumulator32 SunSpecPointType = "acc32"
 	SunSpecTypeAccumulator64 SunSpecPointType = "acc64"
 	SunSpecTypeCount         SunSpecPointType = "count"
@@ -39,33 +40,45 @@ type SunSpecDecimal struct {
 	Exponent    int16
 }
 
-type SunSpecValue struct {
-	pointType   SunSpecPointType
-	state       SunSpecValueState
-	raw         []uint16
-	decimal     SunSpecDecimal
-	hasDecimal  bool
-	float32     float32
-	hasFloat    bool
-	signed      int64
-	hasSigned   bool
-	unsigned    uint64
-	hasUnsigned bool
-	text        string
-	hasText     bool
-	enumNumber  uint64
-	enumSymbol  string
-	hasEnum     bool
-	bits        uint64
-	unknown     uint64
-	bitSymbols  []string
-	hasBits     bool
+// SunSpecUnsignedDecimal preserves an unsigned coefficient without narrowing it
+// through a signed or floating-point representation.
+type SunSpecUnsignedDecimal struct {
+	Coefficient uint64
+	Exponent    int16
 }
 
-func (v SunSpecValue) PointType() SunSpecPointType      { return v.pointType }
-func (v SunSpecValue) State() SunSpecValueState         { return v.state }
-func (v SunSpecValue) RawWords() []uint16               { return append([]uint16(nil), v.raw...) }
-func (v SunSpecValue) Decimal() (SunSpecDecimal, bool)  { return v.decimal, v.hasDecimal }
+type SunSpecValue struct {
+	pointType          SunSpecPointType
+	state              SunSpecValueState
+	raw                []uint16
+	decimal            SunSpecDecimal
+	hasDecimal         bool
+	unsignedDecimal    SunSpecUnsignedDecimal
+	hasUnsignedDecimal bool
+	float32            float32
+	hasFloat           bool
+	signed             int64
+	hasSigned          bool
+	unsigned           uint64
+	hasUnsigned        bool
+	text               string
+	hasText            bool
+	enumNumber         uint64
+	enumSymbol         string
+	hasEnum            bool
+	bits               uint64
+	unknown            uint64
+	bitSymbols         []string
+	hasBits            bool
+}
+
+func (v SunSpecValue) PointType() SunSpecPointType     { return v.pointType }
+func (v SunSpecValue) State() SunSpecValueState        { return v.state }
+func (v SunSpecValue) RawWords() []uint16              { return append([]uint16(nil), v.raw...) }
+func (v SunSpecValue) Decimal() (SunSpecDecimal, bool) { return v.decimal, v.hasDecimal }
+func (v SunSpecValue) UnsignedDecimal() (SunSpecUnsignedDecimal, bool) {
+	return v.unsignedDecimal, v.hasUnsignedDecimal
+}
 func (v SunSpecValue) Float32() (float32, bool)         { return v.float32, v.hasFloat }
 func (v SunSpecValue) Signed() (int64, bool)            { return v.signed, v.hasSigned }
 func (v SunSpecValue) Unsigned() (uint64, bool)         { return v.unsigned, v.hasUnsigned }
@@ -105,6 +118,12 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 	case SunSpecTypeUint32:
 		raw := uint64(uint32(words[0])<<16 | uint32(words[1]))
 		if raw == math.MaxUint32 {
+			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
+		}
+		value.unsigned, value.hasUnsigned = raw, true
+	case SunSpecTypeUint64:
+		raw := uint64(words[0])<<48 | uint64(words[1])<<32 | uint64(words[2])<<16 | uint64(words[3])
+		if raw == math.MaxUint64 {
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
 		}
 		value.unsigned, value.hasUnsigned = raw, true
@@ -201,6 +220,11 @@ func applySunSpecScale(value SunSpecValue, scale *SunSpecValue) SunSpecValue {
 	}
 	coefficient := value.signed
 	if !value.hasSigned {
+		if value.pointType == SunSpecTypeUint64 && value.hasUnsigned {
+			value.unsignedDecimal = SunSpecUnsignedDecimal{Coefficient: value.unsigned, Exponent: int16(scale.signed)}
+			value.hasUnsignedDecimal = true
+			return value
+		}
 		if !value.hasUnsigned || value.unsigned > math.MaxInt64 {
 			value.state = SunSpecValueInvalidEncoding
 			return value

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -149,7 +149,7 @@ func TestSunSpecUint64PreservesExactUnsignedScaling(t *testing.T) {
 	definition := sizedSunSpecPoint(SunSpecTypeUint64, 4)
 	definition.scaleFactor = "TotWh_SF"
 
-	value := decodeSunSpecValue(definition, []uint16{0x8000, 0, 0, 1}, &scale)
+	value := decodeSunSpecValue(definition, []uint16{0x8000, 0, 0, 0}, &scale)
 	if value.State() != SunSpecValueValid {
 		t.Fatalf("state=%s", value.State())
 	}
@@ -181,9 +181,9 @@ func TestSunSpecUint64PreservesExactUnsignedScaling(t *testing.T) {
 	}
 
 	for name, invalidScale := range map[string]*SunSpecValue{
-		"missing":      nil,
-		"unavailable":  &SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueNotImplemented},
-		"invalid":      &SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueInvalidEncoding},
+		"missing":     nil,
+		"unavailable": &SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueNotImplemented},
+		"invalid":     &SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueInvalidEncoding},
 	} {
 		t.Run(name, func(t *testing.T) {
 			got := decodeSunSpecValue(definition, []uint16{0, 0, 0, 1}, invalidScale)

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -144,6 +144,61 @@ func TestSunSpecExtendedValueTypesRetainExactState(t *testing.T) {
 	}
 }
 
+func TestSunSpecUint64PreservesExactUnsignedScaling(t *testing.T) {
+	scale := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeScaleFactor, 1), []uint16{0xfffe}, nil)
+	definition := sizedSunSpecPoint(SunSpecTypeUint64, 4)
+	definition.scaleFactor = "TotWh_SF"
+
+	value := decodeSunSpecValue(definition, []uint16{0x8000, 0, 0, 1}, &scale)
+	if value.State() != SunSpecValueValid {
+		t.Fatalf("state=%s", value.State())
+	}
+	if raw, ok := value.Unsigned(); !ok || raw != math.MaxInt64+1 {
+		t.Fatalf("unsigned=%d ok=%v", raw, ok)
+	}
+	if _, ok := value.Decimal(); ok {
+		t.Fatal("uint64 scaling was narrowed through signed decimal")
+	}
+	decimal, ok := value.UnsignedDecimal()
+	if !ok || decimal != (SunSpecUnsignedDecimal{Coefficient: math.MaxInt64 + 1, Exponent: -2}) {
+		t.Fatalf("unsigned decimal=%#v ok=%v", decimal, ok)
+	}
+
+	zero := decodeSunSpecValue(definition, []uint16{0, 0, 0, 0}, &scale)
+	if raw, ok := zero.Unsigned(); zero.State() != SunSpecValueValid || !ok || raw != 0 {
+		t.Fatalf("zero=%#v raw=%d ok=%v", zero, raw, ok)
+	}
+	if decimal, ok := zero.UnsignedDecimal(); !ok || decimal != (SunSpecUnsignedDecimal{Coefficient: 0, Exponent: -2}) {
+		t.Fatalf("zero decimal=%#v ok=%v", decimal, ok)
+	}
+
+	allOnes := decodeSunSpecValue(definition, []uint16{0xffff, 0xffff, 0xffff, 0xffff}, &scale)
+	if allOnes.State() != SunSpecValueNotImplemented {
+		t.Fatalf("all-ones state=%s", allOnes.State())
+	}
+	if _, ok := allOnes.UnsignedDecimal(); ok {
+		t.Fatal("all-ones uint64 produced a scaled value")
+	}
+
+	for name, invalidScale := range map[string]*SunSpecValue{
+		"missing":      nil,
+		"unavailable":  &SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueNotImplemented},
+		"invalid":      &SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueInvalidEncoding},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := decodeSunSpecValue(definition, []uint16{0, 0, 0, 1}, invalidScale)
+			if _, ok := got.UnsignedDecimal(); ok {
+				t.Fatalf("invalid scale produced unsigned decimal: %#v", got)
+			}
+		})
+	}
+
+	accumulator := decodeSunSpecValue(sizedSunSpecPoint(SunSpecTypeAccumulator64, 4), []uint16{0, 0, 0, 0}, nil)
+	if accumulator.State() != SunSpecValueNotAccumulated {
+		t.Fatalf("acc64 zero state=%s", accumulator.State())
+	}
+}
+
 func sizedSunSpecPoint(pointType SunSpecPointType, size uint16) sunSpecPointDefinition {
 	return sunSpecPointDefinition{pointType: pointType, size: size}
 }


### PR DESCRIPTION
Closes #63

## Scope

Frozen two-file primitive-only split: `sunspec_value.go` and `sunspec_value_test.go`.

## RED

Exact public RED requires `SunSpecTypeUint64`, `SunSpecUnsignedDecimal`, and `UnsignedDecimal()`. Current code does not compile because none exist.

## Boundaries

No V2 model/schema key/catalog/fixture/runtime/vendor/gateway/transport/live I/O. Docs gate: docs-modbus `9bd6e87cecb82800b40c0620dbffd8c54c405fba`.