### PR TITLE
REG-SUNSPEC-V2-REVISION-COMMON: isolate Common decoder revision

### DIFF
--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -76,3 +76,48 @@ func TestSunSpecChainPlanRejectsAddressAndAggregateOverflow(t *testing.T) {
 		t.Fatal("address overflow was admitted")
 	}
 }
+
+func TestSunSpecV2ChainKeepsCompatibilityAndDERBlocksOpaque(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 512, MaxOccurrences: 4},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 65}, make([]uint16, 65)...)
+	words = append(words, 701, 153)
+	words = append(words, make([]uint16, 153)...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[0].Disposition != SunSpecChainDispositionUnsupportedLength || occurrences[1].Disposition != SunSpecChainDispositionUnknownModel {
+		t.Fatalf("V2 opaque dispositions=%#v", occurrences)
+	}
+	for _, occurrence := range occurrences {
+		if _, ok := occurrence.DecoderKey(); ok {
+			t.Fatalf("opaque V2 occurrence has a decoder key: %#v", occurrence)
+		}
+	}
+}

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -104,7 +104,11 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	if keys, ok := standardSunSpecDecoderKeysCache.keys[revision]; ok {
 		return append([]SunSpecDecoderKey(nil), keys...)
 	}
-	keys := make([]SunSpecDecoderKey, 0, len(definitions)+3277+89561)
+	capacity := len(definitions)
+	if revision == SunSpecModelsRevisionV1 {
+		capacity += 3277 + 89561
+	}
+	keys := make([]SunSpecDecoderKey, 0, capacity)
 	for _, definition := range definitions {
 		keys = append(keys, definition.key)
 	}

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -78,8 +78,8 @@ type SunSpecDecoderRegistry struct {
 }
 
 var standardSunSpecDecoderKeysCache struct {
-	sync.Once
-	keys []SunSpecDecoderKey
+	sync.Mutex
+	keys map[SunSpecSchemaRevision][]SunSpecDecoderKey
 }
 
 func NewStandardSunSpecDecoderRegistry(revision SunSpecSchemaRevision) (SunSpecDecoderRegistry, error) {
@@ -94,28 +94,40 @@ func NewStandardSunSpecDecoderRegistry(revision SunSpecSchemaRevision) (SunSpecD
 		}
 		registry.definitions[definition.key] = definition
 	}
-	standardSunSpecDecoderKeysCache.Do(func() {
-		keys := make([]SunSpecDecoderKey, 0, len(definitions)+3277+89561)
-		for _, definition := range definitions {
-			keys = append(keys, definition.key)
-		}
+	registry.keys = standardSunSpecDecoderKeys(revision, definitions)
+	return registry, nil
+}
+
+func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []sunSpecModelDefinition) []SunSpecDecoderKey {
+	standardSunSpecDecoderKeysCache.Lock()
+	defer standardSunSpecDecoderKeysCache.Unlock()
+	if keys, ok := standardSunSpecDecoderKeysCache.keys[revision]; ok {
+		return append([]SunSpecDecoderKey(nil), keys...)
+	}
+	keys := make([]SunSpecDecoderKey, 0, len(definitions)+3277+89561)
+	for _, definition := range definitions {
+		keys = append(keys, definition.key)
+	}
+	if revision == SunSpecModelsRevisionV1 {
 		for modules := uint32(0); modules <= maxSunSpecMPPTModules; modules++ {
 			keys = append(keys, SunSpecDecoderKey{ModelID: 160, ModelLength: uint16(8 + 20*modules), SchemaRevision: revision})
 		}
 		keys = append(keys, environmentalSunSpecDecoderKeys(revision)...)
-		sort.Slice(keys, func(i, j int) bool {
-			if keys[i].ModelID != keys[j].ModelID {
-				return keys[i].ModelID < keys[j].ModelID
-			}
-			if keys[i].ModelLength != keys[j].ModelLength {
-				return keys[i].ModelLength < keys[j].ModelLength
-			}
-			return keys[i].SchemaRevision < keys[j].SchemaRevision
-		})
-		standardSunSpecDecoderKeysCache.keys = keys
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ModelID != keys[j].ModelID {
+			return keys[i].ModelID < keys[j].ModelID
+		}
+		if keys[i].ModelLength != keys[j].ModelLength {
+			return keys[i].ModelLength < keys[j].ModelLength
+		}
+		return keys[i].SchemaRevision < keys[j].SchemaRevision
 	})
-	registry.keys = standardSunSpecDecoderKeysCache.keys
-	return registry, nil
+	if standardSunSpecDecoderKeysCache.keys == nil {
+		standardSunSpecDecoderKeysCache.keys = make(map[SunSpecSchemaRevision][]SunSpecDecoderKey)
+	}
+	standardSunSpecDecoderKeysCache.keys[revision] = append([]SunSpecDecoderKey(nil), keys...)
+	return append([]SunSpecDecoderKey(nil), keys...)
 }
 
 func (r SunSpecDecoderRegistry) DecoderKeys() []SunSpecDecoderKey {
@@ -127,6 +139,9 @@ func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelD
 		return definition, true
 	}
 	if key.SchemaRevision != r.revision {
+		return sunSpecModelDefinition{}, false
+	}
+	if key.SchemaRevision != SunSpecModelsRevisionV1 {
 		return sunSpecModelDefinition{}, false
 	}
 	var resolved sunSpecModelDefinition

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -89,6 +89,38 @@ func TestSunSpecDecoderRegistryUsesExactImmutableKeys(t *testing.T) {
 	}
 }
 
+func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
+	for _, revisions := range [][]SunSpecSchemaRevision{
+		{SunSpecModelsRevisionV1, SunSpecModelsRevisionV2},
+		{SunSpecModelsRevisionV2, SunSpecModelsRevisionV1},
+	} {
+		registries := make(map[SunSpecSchemaRevision]SunSpecDecoderRegistry, len(revisions))
+		for _, revision := range revisions {
+			registry, err := NewStandardSunSpecDecoderRegistry(revision)
+			if err != nil {
+				t.Fatalf("registry %q: %v", revision, err)
+			}
+			registries[revision] = registry
+		}
+		v2Keys := registries[SunSpecModelsRevisionV2].DecoderKeys()
+		wantV2 := []SunSpecDecoderKey{{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2}}
+		if !reflect.DeepEqual(v2Keys, wantV2) {
+			t.Fatalf("V2 keys=%#v want=%#v", v2Keys, wantV2)
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+			t.Fatal("V2 resolved V1 compatibility Common")
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+			t.Fatal("V2 resolved a DER model before its split")
+		}
+		for _, key := range registries[SunSpecModelsRevisionV1].DecoderKeys() {
+			if key.SchemaRevision != SunSpecModelsRevisionV1 {
+				t.Fatalf("V1 cache leaked key %#v", key)
+			}
+		}
+	}
+}
+
 func TestSunSpecDecodedModelsAreDefensiveAndReadOnly(t *testing.T) {
 	typ := reflect.TypeFor[SunSpecDecoderRegistry]()
 	for index := 0; index < typ.NumMethod(); index++ {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -90,10 +90,22 @@ func TestSunSpecDecoderRegistryUsesExactImmutableKeys(t *testing.T) {
 }
 
 func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
+	standardSunSpecDecoderKeysCache.Lock()
+	priorCache := standardSunSpecDecoderKeysCache.keys
+	standardSunSpecDecoderKeysCache.keys = nil
+	standardSunSpecDecoderKeysCache.Unlock()
+	t.Cleanup(func() {
+		standardSunSpecDecoderKeysCache.Lock()
+		standardSunSpecDecoderKeysCache.keys = priorCache
+		standardSunSpecDecoderKeysCache.Unlock()
+	})
 	for _, revisions := range [][]SunSpecSchemaRevision{
 		{SunSpecModelsRevisionV1, SunSpecModelsRevisionV2},
 		{SunSpecModelsRevisionV2, SunSpecModelsRevisionV1},
 	} {
+		standardSunSpecDecoderKeysCache.Lock()
+		standardSunSpecDecoderKeysCache.keys = nil
+		standardSunSpecDecoderKeysCache.Unlock()
 		registries := make(map[SunSpecSchemaRevision]SunSpecDecoderRegistry, len(revisions))
 		for _, revision := range revisions {
 			registry, err := NewStandardSunSpecDecoderRegistry(revision)
@@ -117,6 +129,40 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			if key.SchemaRevision != SunSpecModelsRevisionV1 {
 				t.Fatalf("V1 cache leaked key %#v", key)
 			}
+		}
+	}
+	standardSunSpecDecoderKeysCache.Lock()
+	standardSunSpecDecoderKeysCache.keys = nil
+	standardSunSpecDecoderKeysCache.Unlock()
+	const workers = 32
+	errors := make(chan error, workers)
+	var wait sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wait.Add(1)
+		go func(worker int) {
+			defer wait.Done()
+			revision := SunSpecModelsRevisionV1
+			if worker%2 == 1 {
+				revision = SunSpecModelsRevisionV2
+			}
+			registry, err := NewStandardSunSpecDecoderRegistry(revision)
+			if err != nil {
+				errors <- err
+				return
+			}
+			for _, key := range registry.DecoderKeys() {
+				if key.SchemaRevision != revision {
+					errors <- errUnexpectedConcurrentDecode
+					return
+				}
+			}
+		}(worker)
+	}
+	wait.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			t.Fatal(err)
 		}
 	}
 }

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -2,7 +2,10 @@ package modbusreg
 
 import "fmt"
 
-const SunSpecModelsRevisionV1 SunSpecSchemaRevision = "sunspec.models@7abdf898-v1"
+const (
+	SunSpecModelsRevisionV1 SunSpecSchemaRevision = "sunspec.models@7abdf898-v1"
+	SunSpecModelsRevisionV2 SunSpecSchemaRevision = "sunspec.models@90b4a331-v2"
+)
 
 type SunSpecTopology string
 
@@ -33,9 +36,25 @@ type sunSpecModelDefinition struct {
 }
 
 func standardSunSpecModelDefinitions(revision SunSpecSchemaRevision) ([]sunSpecModelDefinition, error) {
-	if revision != SunSpecModelsRevisionV1 {
+	switch revision {
+	case SunSpecModelsRevisionV1:
+		return standardSunSpecModelDefinitionsV1(revision)
+	case SunSpecModelsRevisionV2:
+		return standardSunSpecModelDefinitionsV2(revision)
+	default:
 		return nil, fmt.Errorf("SunSpec schema revision is unsupported")
 	}
+}
+
+func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpecModelDefinition, error) {
+	definitions, err := appendSunSpecDefinition(nil, revision, 1, 66, SunSpecTopologyNone, false, commonSunSpecPoints())
+	if err != nil {
+		return nil, err
+	}
+	return definitions, nil
+}
+
+func standardSunSpecModelDefinitionsV1(revision SunSpecSchemaRevision) ([]sunSpecModelDefinition, error) {
 	common := commonSunSpecPoints()
 	definitions := make([]sunSpecModelDefinition, 0, 27)
 	var err error

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -53,6 +53,25 @@ func TestSunSpecModelCatalogMatchesPinnedAuthoritativeShapes(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2CatalogContainsOnlyCurrentCommonModel(t *testing.T) {
+	definitions, err := standardSunSpecModelDefinitions(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatalf("V2 catalog: %v", err)
+	}
+	if len(definitions) != 1 {
+		t.Fatalf("V2 definitions=%d", len(definitions))
+	}
+	definition := definitions[0]
+	if definition.key != (SunSpecDecoderKey{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2}) || definition.compatibility {
+		t.Fatalf("unexpected V2 Common definition: %#v", definition.key)
+	}
+	for _, candidate := range definitions {
+		if candidate.key == (SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}) {
+			t.Fatal("V1 compatibility Common was admitted under V2")
+		}
+	}
+}
+
 func TestSunSpecPinnedPointOrderAndTypes(t *testing.T) {
 	common := "ID:uint16:1,L:uint16:1,Mn:string:16,Md:string:16,Opt:string:8,Vr:string:8,SN:string:16,DA:uint16:1,Pad:pad:1"
 	integer := "ID:uint16:1,L:uint16:1,A:uint16:1,AphA:uint16:1,AphB:uint16:1,AphC:uint16:1,A_SF:sunssf:1,PPVphAB:uint16:1,PPVphBC:uint16:1,PPVphCA:uint16:1,PhVphA:uint16:1,PhVphB:uint16:1,PhVphC:uint16:1,V_SF:sunssf:1,W:int16:1,W_SF:sunssf:1,Hz:uint16:1,Hz_SF:sunssf:1,VA:int16:1,VA_SF:sunssf:1,VAr:int16:1,VAr_SF:sunssf:1,PF:int16:1,PF_SF:sunssf:1,WH:acc32:2,WH_SF:sunssf:1,DCA:uint16:1,DCA_SF:sunssf:1,DCV:uint16:1,DCV_SF:sunssf:1,DCW:int16:1,DCW_SF:sunssf:1,TmpCab:int16:1,TmpSnk:int16:1,TmpTrns:int16:1,TmpOt:int16:1,Tmp_SF:sunssf:1,St:enum16:1,StVnd:enum16:1,Evt1:bitfield32:2,Evt2:bitfield32:2,EvtVnd1:bitfield32:2,EvtVnd2:bitfield32:2,EvtVnd3:bitfield32:2,EvtVnd4:bitfield32:2"


### PR DESCRIPTION
## RED evidence

This initial commit adds the frozen contract tests and is intentionally red because `sunspec.models@90b4a331-v2` does not exist yet.

## Scope

V2 must cache independently from V1, structurally admit only Common 1/66, and retain Common 1/65 plus DER blocks as opaque/non-admitted. V1 behavior remains unchanged.

Docs gate: `9bd6e87cecb82800b40c0620dbffd8c54c405fba`.

No DER definitions, V2 JSON fixtures/catalog, vendor, runtime, transport, gateway, or live changes.