### PR TITLE
REG-SUNSPEC-V2-701-702: add bounded DER offline decoders

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,221 @@
+# Third-Party Notices
+
+## SunSpec/models
+
+The V2 offline decoder definitions for Models 701/153 and 702/50 in
+`sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
+
+- Project: `SunSpec/models`
+- URL: <https://github.com/sunspec/models>
+- Source revision: `90b4a331dcca1d6eac69c1bead952fddcc5852e0`
+- License: Apache-2.0
+
+The definitions were modified by Helianthus for its bounded, offline-only
+decoder representation. They do not include vendor material, device support,
+runtime admission, or control behavior.
+
+### Apache License
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+```

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -99,6 +99,10 @@ func TestSunSpecV2ChainKeepsCompatibilityAndDERBlocksOpaque(t *testing.T) {
 	words := append([]uint16{1, 65}, make([]uint16, 65)...)
 	words = append(words, 701, 153)
 	words = append(words, make([]uint16, 153)...)
+	words = append(words, 701, 153)
+	words = append(words, make([]uint16, 153)...)
+	words = append(words, 702, 49)
+	words = append(words, make([]uint16, 49)...)
 	for len(words) > 0 {
 		request := chain.NextRequests()[0]
 		chunk := words[:request.WordCount()]
@@ -112,12 +116,17 @@ func TestSunSpecV2ChainKeepsCompatibilityAndDERBlocksOpaque(t *testing.T) {
 		t.Fatal(err)
 	}
 	occurrences := snapshot.Occurrences()
-	if len(occurrences) != 2 || occurrences[0].Disposition != SunSpecChainDispositionUnsupportedLength || occurrences[1].Disposition != SunSpecChainDispositionUnknownModel {
+	if len(occurrences) != 4 || occurrences[0].Disposition != SunSpecChainDispositionUnsupportedLength || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[2].Disposition != SunSpecChainDispositionAdmitted || occurrences[3].Disposition != SunSpecChainDispositionUnsupportedLength {
 		t.Fatalf("V2 opaque dispositions=%#v", occurrences)
 	}
-	for _, occurrence := range occurrences {
+	for _, occurrence := range []SunSpecOccurrence{occurrences[0], occurrences[3]} {
 		if _, ok := occurrence.DecoderKey(); ok {
 			t.Fatalf("opaque V2 occurrence has a decoder key: %#v", occurrence)
+		}
+	}
+	for index, occurrence := range occurrences[1:3] {
+		if key, ok := occurrence.DecoderKey(); !ok || key.ModelID != 701 || key.ModelLength != 153 || occurrence.Ordinal != uint32(index+2) {
+			t.Fatalf("exact V2 DER occurrence is not retained: %#v", occurrence)
 		}
 	}
 }

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -115,14 +115,18 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			registries[revision] = registry
 		}
 		v2Keys := registries[SunSpecModelsRevisionV2].DecoderKeys()
-		wantV2 := []SunSpecDecoderKey{{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2}}
+		wantV2 := []SunSpecDecoderKey{
+			{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 702, ModelLength: 50, SchemaRevision: SunSpecModelsRevisionV2},
+		}
 		if !reflect.DeepEqual(v2Keys, wantV2) {
 			t.Fatalf("V2 keys=%#v want=%#v", v2Keys, wantV2)
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved V1 compatibility Common")
 		}
-		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved a DER model before its split")
 		}
 		for _, key := range registries[SunSpecModelsRevisionV1].DecoderKeys() {

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -51,6 +51,18 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 	if err != nil {
 		return nil, err
 	}
+	for _, model := range []struct {
+		id, length uint16
+		points     []sunSpecPointDefinition
+	}{
+		{701, 153, derMeasureACV2SunSpecPoints()},
+		{702, 50, derCapacityV2SunSpecPoints()},
+	} {
+		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return definitions, nil
 }
 

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -53,17 +53,23 @@ func TestSunSpecModelCatalogMatchesPinnedAuthoritativeShapes(t *testing.T) {
 	}
 }
 
-func TestSunSpecV2CatalogContainsOnlyCurrentCommonModel(t *testing.T) {
+func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	definitions, err := standardSunSpecModelDefinitions(SunSpecModelsRevisionV2)
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 1 {
+	if len(definitions) != 3 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
-	definition := definitions[0]
-	if definition.key != (SunSpecDecoderKey{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2}) || definition.compatibility {
-		t.Fatalf("unexpected V2 Common definition: %#v", definition.key)
+	want := []SunSpecDecoderKey{
+		{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 702, ModelLength: 50, SchemaRevision: SunSpecModelsRevisionV2},
+	}
+	for index, key := range want {
+		if definitions[index].key != key || definitions[index].compatibility {
+			t.Fatalf("unexpected V2 definition %d: %#v", index, definitions[index].key)
+		}
 	}
 	for _, candidate := range definitions {
 		if candidate.key == (SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}) {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -1,0 +1,132 @@
+package modbusreg
+
+func derMeasureACV2SunSpecPoints() []sunSpecPointDefinition {
+	points := []sunSpecPointDefinition{
+		v2DERPoint("701", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("701", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("701", "ACType", SunSpecTypeEnum16, "", "", true),
+		v2DERPoint("701", "St", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("701", "InvSt", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("701", "ConnSt", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("701", "Alrm", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("701", "DERMode", SunSpecTypeBitfield32, "", "", false),
+	}
+	for _, point := range []struct {
+		name string
+		typ  SunSpecPointType
+		unit string
+		sf   string
+	}{
+		{"W", SunSpecTypeInt16, "W", "W_SF"}, {"VA", SunSpecTypeInt16, "VA", "VA_SF"},
+		{"Var", SunSpecTypeInt16, "Var", "Var_SF"}, {"PF", SunSpecTypeInt16, "", "PF_SF"},
+		{"A", SunSpecTypeInt16, "A", "A_SF"}, {"LLV", SunSpecTypeUint16, "V", "V_SF"},
+		{"LNV", SunSpecTypeUint16, "V", "V_SF"}, {"Hz", SunSpecTypeUint32, "Hz", "Hz_SF"},
+		{"TotWhInj", SunSpecTypeUint64, "Wh", "TotWh_SF"}, {"TotWhAbs", SunSpecTypeUint64, "Wh", "TotWh_SF"},
+		{"TotVarhInj", SunSpecTypeUint64, "Varh", "TotVarh_SF"}, {"TotVarhAbs", SunSpecTypeUint64, "Varh", "TotVarh_SF"},
+		{"TmpAmb", SunSpecTypeInt16, "C", "Tmp_SF"}, {"TmpCab", SunSpecTypeInt16, "C", "Tmp_SF"},
+		{"TmpSnk", SunSpecTypeInt16, "C", "Tmp_SF"}, {"TmpTrns", SunSpecTypeInt16, "C", "Tmp_SF"},
+		{"TmpSw", SunSpecTypeInt16, "C", "Tmp_SF"}, {"TmpOt", SunSpecTypeInt16, "C", "Tmp_SF"},
+	} {
+		points = append(points, v2DERPoint("701", point.name, point.typ, point.unit, point.sf, false))
+	}
+	for _, phase := range []struct {
+		suffix, line, voltage string
+	}{
+		{"L1", "VL1L2", "VL1"}, {"L2", "VL2L3", "VL2"}, {"L3", "VL3L1", "VL3"},
+	} {
+		for _, point := range []struct {
+			name string
+			typ  SunSpecPointType
+			unit string
+			sf   string
+		}{
+			{"W" + phase.suffix, SunSpecTypeInt16, "W", "W_SF"}, {"VA" + phase.suffix, SunSpecTypeInt16, "VA", "VA_SF"},
+			{"Var" + phase.suffix, SunSpecTypeInt16, "Var", "Var_SF"}, {"PF" + phase.suffix, SunSpecTypeInt16, "", "PF_SF"},
+			{"A" + phase.suffix, SunSpecTypeInt16, "A", "A_SF"}, {phase.line, SunSpecTypeUint16, "V", "V_SF"},
+			{phase.voltage, SunSpecTypeUint16, "V", "V_SF"}, {"TotWhInj" + phase.suffix, SunSpecTypeUint64, "Wh", "TotWh_SF"},
+			{"TotWhAbs" + phase.suffix, SunSpecTypeUint64, "Wh", "TotWh_SF"}, {"TotVarhInj" + phase.suffix, SunSpecTypeUint64, "Varh", "TotVarh_SF"},
+			{"TotVarhAbs" + phase.suffix, SunSpecTypeUint64, "Varh", "TotVarh_SF"},
+		} {
+			points = append(points, v2DERPoint("701", point.name, point.typ, point.unit, point.sf, false))
+		}
+	}
+	for _, point := range []struct {
+		name string
+		typ  SunSpecPointType
+	}{
+		{"ThrotPct", SunSpecTypeUint16}, {"ThrotSrc", SunSpecTypeBitfield32},
+		{"A_SF", SunSpecTypeScaleFactor}, {"V_SF", SunSpecTypeScaleFactor}, {"Hz_SF", SunSpecTypeScaleFactor},
+		{"W_SF", SunSpecTypeScaleFactor}, {"PF_SF", SunSpecTypeScaleFactor}, {"VA_SF", SunSpecTypeScaleFactor},
+		{"Var_SF", SunSpecTypeScaleFactor}, {"TotWh_SF", SunSpecTypeScaleFactor}, {"TotVarh_SF", SunSpecTypeScaleFactor},
+		{"Tmp_SF", SunSpecTypeScaleFactor}, {"MnAlrmInfo", SunSpecTypeString},
+	} {
+		points = append(points, v2DERPoint("701", point.name, point.typ, "", "", false))
+	}
+	return points
+}
+
+func derCapacityV2SunSpecPoints() []sunSpecPointDefinition {
+	points := []sunSpecPointDefinition{
+		v2DERPoint("702", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("702", "L", SunSpecTypeUint16, "", "", true),
+	}
+	for _, point := range []struct {
+		name, unit, sf string
+	}{
+		{"WMaxRtg", "W", "W_SF"}, {"WOvrExtRtg", "W", "W_SF"}, {"WOvrExtRtgPF", "", "PF_SF"},
+		{"WUndExtRtg", "W", "W_SF"}, {"WUndExtRtgPF", "", "PF_SF"}, {"VAMaxRtg", "VA", "VA_SF"},
+		{"VarMaxInjRtg", "Var", "Var_SF"}, {"VarMaxAbsRtg", "Var", "Var_SF"}, {"WChaRteMaxRtg", "W", "W_SF"},
+		{"WDisChaRteMaxRtg", "W", "W_SF"}, {"VAChaRteMaxRtg", "VA", "VA_SF"}, {"VADisChaRteMaxRtg", "VA", "VA_SF"},
+		{"VNomRtg", "V", "V_SF"}, {"VMaxRtg", "V", "V_SF"}, {"VMinRtg", "V", "V_SF"}, {"AMaxRtg", "A", "A_SF"},
+		{"PFOvrExtRtg", "", "PF_SF"}, {"PFUndExtRtg", "", "PF_SF"}, {"ReactSusceptRtg", "S", "S_SF"},
+	} {
+		points = append(points, v2DERPoint("702", point.name, SunSpecTypeUint16, point.unit, point.sf, false))
+	}
+	for _, point := range []struct {
+		name string
+		typ  SunSpecPointType
+	}{
+		{"NorOpCatRtg", SunSpecTypeEnum16}, {"AbnOpCatRtg", SunSpecTypeEnum16}, {"CtrlModes", SunSpecTypeBitfield32},
+		{"IntIslandCatRtg", SunSpecTypeBitfield16},
+	} {
+		points = append(points, v2DERPoint("702", point.name, point.typ, "", "", false))
+	}
+	for _, point := range []struct {
+		name, unit, sf string
+	}{
+		{"WMax", "W", "W_SF"}, {"WMaxOvrExt", "W", "W_SF"}, {"WOvrExtPF", "", "PF_SF"},
+		{"WMaxUndExt", "W", "W_SF"}, {"WUndExtPF", "", "PF_SF"}, {"VAMax", "VA", "VA_SF"},
+		{"VarMaxInj", "Var", "Var_SF"}, {"VarMaxAbs", "Var", "Var_SF"}, {"WChaRteMax", "W", "W_SF"},
+		{"WDisChaRteMax", "W", "W_SF"}, {"VAChaRteMax", "VA", "VA_SF"}, {"VADisChaRteMax", "VA", "VA_SF"},
+		{"VNom", "V", "V_SF"}, {"VMax", "V", "V_SF"}, {"VMin", "V", "V_SF"}, {"AMax", "A", "A_SF"},
+		{"PFOvrExt", "", "PF_SF"}, {"PFUndExt", "", "PF_SF"},
+	} {
+		points = append(points, v2DERPoint("702", point.name, SunSpecTypeUint16, point.unit, point.sf, false))
+	}
+	points = append(points, v2DERPoint("702", "IntIslandCat", SunSpecTypeBitfield16, "", "", false))
+	for _, name := range []string{"W_SF", "PF_SF", "VA_SF", "Var_SF", "V_SF", "A_SF", "S_SF"} {
+		points = append(points, v2DERPoint("702", name, SunSpecTypeScaleFactor, "", "", false))
+	}
+	return points
+}
+
+func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
+	symbols := map[uint64]string(nil)
+	if model == "701" && name == "ACType" {
+		symbols = map[uint64]string{0: "SINGLE_PHASE", 1: "SPLIT_PHASE", 2: "THREE_PHASE"}
+	}
+	return sunSpecPoint(name, "sunspec.der.v2."+model+"."+name, pointType, v2DERPointWords(pointType), unit, scale, mandatory, symbols, sunSpecKnownMask(symbols))
+}
+
+func v2DERPointWords(pointType SunSpecPointType) uint16 {
+	switch pointType {
+	case SunSpecTypeUint32, SunSpecTypeBitfield32:
+		return 2
+	case SunSpecTypeUint64:
+		return 4
+	case SunSpecTypeString:
+		return 32
+	default:
+		return 1
+	}
+}

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -1,0 +1,58 @@
+package modbusreg
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
+	t.Run("Apache attribution", func(t *testing.T) {
+		contents, err := os.ReadFile("THIRD_PARTY_NOTICES.md")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, want := range []string{
+			"SunSpec/models",
+			"https://github.com/sunspec/models",
+			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
+			"Models 701/153 and 702/50",
+			"modified by Helianthus",
+			"Apache License",
+			"Version 2.0, January 2004",
+		} {
+			if !strings.Contains(string(contents), want) {
+				t.Fatalf("third-party notice lacks %q", want)
+			}
+		}
+	})
+
+	t.Run("exact V2 shapes", func(t *testing.T) {
+		registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, want := range []struct {
+			id, length uint16
+			points     int
+			first      []string
+			last       string
+		}{
+			{701, 153, 72, []string{"ID", "L", "ACType"}, "MnAlrmInfo"},
+			{702, 50, 51, []string{"ID", "L", "WMaxRtg"}, "S_SF"},
+		} {
+			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
+			if !ok || len(definition.points) != want.points {
+				t.Fatalf("Model %d/%d definition=%v points=%d", want.id, want.length, ok, len(definition.points))
+			}
+			for index, name := range want.first {
+				if definition.points[index].name != name {
+					t.Fatalf("Model %d point %d=%q want=%q", want.id, index, definition.points[index].name, name)
+				}
+			}
+			if definition.points[len(definition.points)-1].name != want.last {
+				t.Fatalf("Model %d last=%q want=%q", want.id, definition.points[len(definition.points)-1].name, want.last)
+			}
+		}
+	})
+}

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -56,3 +56,54 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 		}
 	})
 }
+
+func TestSunSpecV2DERMeasurePreservesScaledUnsignedCounter(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	words := v2DERModelWords(t, registry, 701, 153, map[string][]uint16{
+		"ACType":     {2},
+		"TotWhInj":   {0x8000, 0, 0, 1},
+		"TotWh_SF":   {0xffff},
+		"MnAlrmInfo": {0x0080, 0},
+	})
+	key := SunSpecDecoderKey{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{
+		Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 701, ModelLength: 153}, SchemaRevision: SunSpecModelsRevisionV2,
+		Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fact, ok := decoded.Fact("sunspec.der.v2.701.TotWhInj")
+	if !ok {
+		t.Fatal("scaled unsigned counter absent")
+	}
+	decimal, ok := fact.Value.UnsignedDecimal()
+	if !ok || decimal != (SunSpecUnsignedDecimal{Coefficient: 0x8000000000000001, Exponent: -1}) {
+		t.Fatalf("unsigned decimal=%#v present=%v", decimal, ok)
+	}
+}
+
+func v2DERModelWords(t *testing.T, registry SunSpecDecoderRegistry, id, length uint16, values map[string][]uint16) []uint16 {
+	t.Helper()
+	key := SunSpecDecoderKey{ModelID: id, ModelLength: length, SchemaRevision: SunSpecModelsRevisionV2}
+	definition, ok := registry.definition(key)
+	if !ok {
+		t.Fatalf("definition %d/%d absent", id, length)
+	}
+	words := make([]uint16, int(length)+2)
+	words[0], words[1] = id, length
+	for _, point := range definition.points {
+		value, exists := values[point.name]
+		if !exists || point.name == "ID" || point.name == "L" {
+			continue
+		}
+		if len(value) > int(point.size) {
+			t.Fatalf("point %s words=%d exceeds=%d", point.name, len(value), point.size)
+		}
+		copy(words[point.offset:point.offset+point.size], value)
+	}
+	return words
+}

--- a/sunspec_value.go
+++ b/sunspec_value.go
@@ -168,17 +168,11 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 		if bits == math.MaxUint16 {
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
 		}
-		if bits > math.MaxInt16 {
-			return value
-		}
 		setSunSpecBitfield(&value, bits, def, 15)
 	case SunSpecTypeBitfield32:
 		bits := uint64(uint32(words[0])<<16 | uint32(words[1]))
 		if bits == math.MaxUint32 {
 			return invalidSunSpecValue(def.pointType, words, SunSpecValueNotImplemented)
-		}
-		if bits > math.MaxInt32 {
-			return value
 		}
 		setSunSpecBitfield(&value, bits, def, 31)
 	case SunSpecTypeString:
@@ -199,7 +193,7 @@ func decodeSunSpecValue(def sunSpecPointDefinition, words []uint16, scale *SunSp
 
 func setSunSpecBitfield(value *SunSpecValue, bits uint64, def sunSpecPointDefinition, width uint64) {
 	value.bits, value.unknown, value.hasBits = bits, bits&^def.knownMask, true
-	for bit := uint64(0); bit < width; bit++ {
+	for bit := uint64(0); bit <= width; bit++ {
 		mask := uint64(1) << bit
 		if bits&mask != 0 && def.knownMask&mask != 0 && def.symbols[bit] != "" {
 			value.bitSymbols = append(value.bitSymbols, def.symbols[bit])

--- a/sunspec_value_test.go
+++ b/sunspec_value_test.go
@@ -98,13 +98,15 @@ func TestSunSpecValueFloatEnumBitfieldAndStringAreLossless(t *testing.T) {
 
 func TestSunSpecBitfield32DomainBoundary(t *testing.T) {
 	definition := sizedSunSpecPoint(SunSpecTypeBitfield32, 2)
+	definition.knownMask = uint64(1) << 31
+	definition.symbols = map[uint64]string{31: "HIGH_FLAG"}
 	valid := decodeSunSpecValue(definition, []uint16{0x7fff, 0xffff}, nil)
 	if bits, unknown, ok := valid.Bitfield(); valid.State() != SunSpecValueValid || !ok || bits != 0x7fffffff || unknown != 0x7fffffff {
 		t.Fatalf("valid boundary state=%s bits=%x unknown=%x ok=%v", valid.State(), bits, unknown, ok)
 	}
-	invalid := decodeSunSpecValue(definition, []uint16{0x8000, 0}, nil)
-	if _, _, ok := invalid.Bitfield(); invalid.State() != SunSpecValueInvalidEncoding || ok || !reflect.DeepEqual(invalid.RawWords(), []uint16{0x8000, 0}) {
-		t.Fatalf("invalid boundary=%#v", invalid)
+	high := decodeSunSpecValue(definition, []uint16{0x8000, 0}, nil)
+	if bits, unknown, ok := high.Bitfield(); high.State() != SunSpecValueValid || !ok || bits != 0x80000000 || unknown != 0 || !reflect.DeepEqual(high.BitfieldSymbols(), []string{"HIGH_FLAG"}) {
+		t.Fatalf("high boundary state=%s bits=%x unknown=%x symbols=%v ok=%v", high.State(), bits, unknown, high.BitfieldSymbols(), ok)
 	}
 	sentinel := decodeSunSpecValue(definition, []uint16{0xffff, 0xffff}, nil)
 	if sentinel.State() != SunSpecValueNotImplemented || !reflect.DeepEqual(sentinel.RawWords(), []uint16{0xffff, 0xffff}) {
@@ -129,14 +131,15 @@ func TestSunSpecExtendedValueTypesRetainExactState(t *testing.T) {
 		t.Fatalf("count sentinel state=%s", got.State())
 	}
 	definition := sizedSunSpecPoint(SunSpecTypeBitfield16, 1)
-	definition.knownMask = 0x000f
+	definition.knownMask = 0x800f
+	definition.symbols = map[uint64]string{15: "HIGH_FLAG"}
 	valid := decodeSunSpecValue(definition, []uint16{0x4011}, nil)
 	if bits, unknown, ok := valid.Bitfield(); valid.State() != SunSpecValueValid || !ok || bits != 0x4011 || unknown != 0x4010 {
 		t.Fatalf("bitfield16 state=%s bits=%x unknown=%x ok=%v", valid.State(), bits, unknown, ok)
 	}
-	invalid := decodeSunSpecValue(definition, []uint16{0x8000}, nil)
-	if invalid.State() != SunSpecValueInvalidEncoding || !reflect.DeepEqual(invalid.RawWords(), []uint16{0x8000}) {
-		t.Fatalf("bitfield16 invalid boundary=%#v", invalid)
+	high := decodeSunSpecValue(definition, []uint16{0x8000}, nil)
+	if bits, unknown, ok := high.Bitfield(); high.State() != SunSpecValueValid || !ok || bits != 0x8000 || unknown != 0 || !reflect.DeepEqual(high.BitfieldSymbols(), []string{"HIGH_FLAG"}) {
+		t.Fatalf("bitfield16 high boundary state=%s bits=%x unknown=%x symbols=%v ok=%v", high.State(), bits, unknown, high.BitfieldSymbols(), ok)
 	}
 	sentinel := decodeSunSpecValue(definition, []uint16{0xffff}, nil)
 	if sentinel.State() != SunSpecValueNotImplemented {


### PR DESCRIPTION
## RED evidence

Initial test-only commit is intentionally red: V2 Models 701/153 and 702/50 plus the required Apache-2.0 attribution are absent.

## Contract

V2-only offline definitions, synthetic test evidence, exact unsigned scaling, retained opaque wrong lengths/repeats. Docs gate: `9bd6e87cecb82800b40c0620dbffd8c54c405fba`.

## Scope

Frozen: catalog, new DER V2 model/test files, decoder/chain tests, and `THIRD_PARTY_NOTICES.md`.

Excluded: 713/714, JSON fixtures, vendor/runtime/catalog admission, transport, gateway, live I/O.