### PR TITLE
REG-SUNSPEC-V2-713: add static DER storage decoder

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 ## SunSpec/models
 
-The V2 offline decoder definitions for Models 701/153 and 702/50 in
+The V2 offline decoder definitions for Models 701/153, 702/50, and 713/7 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -119,6 +119,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 702, ModelLength: 50, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 		}
 		if !reflect.DeepEqual(v2Keys, wantV2) {
 			t.Fatalf("V2 keys=%#v want=%#v", v2Keys, wantV2)
@@ -126,7 +127,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved V1 compatibility Common")
 		}
-		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 714, ModelLength: 18, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved a DER model before its split")
 		}
 		for _, key := range registries[SunSpecModelsRevisionV1].DecoderKeys() {

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -57,6 +57,7 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 	}{
 		{701, 153, derMeasureACV2SunSpecPoints()},
 		{702, 50, derCapacityV2SunSpecPoints()},
+		{713, 7, derStorageCapacityV2SunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -58,13 +58,14 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 3 {
+	if len(definitions) != 4 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
 	want := []SunSpecDecoderKey{
 		{ModelID: 1, ModelLength: 66, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 701, ModelLength: 153, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 702, ModelLength: 50, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 	}
 	for index, key := range want {
 		if definitions[index].key != key || definitions[index].compatibility {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -110,6 +110,20 @@ func derCapacityV2SunSpecPoints() []sunSpecPointDefinition {
 	return points
 }
 
+func derStorageCapacityV2SunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		v2DERPoint("713", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("713", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("713", "WHRtg", SunSpecTypeUint16, "Wh", "WH_SF", false),
+		v2DERPoint("713", "WHAvail", SunSpecTypeUint16, "Wh", "WH_SF", false),
+		v2DERPoint("713", "SoC", SunSpecTypeUint16, "", "Pct_SF", false),
+		v2DERPoint("713", "SoH", SunSpecTypeUint16, "", "Pct_SF", false),
+		v2DERPoint("713", "Sta", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("713", "WH_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("713", "Pct_SF", SunSpecTypeScaleFactor, "", "", false),
+	}
+}
+
 func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
 	symbols := map[uint64]string(nil)
 	if model == "701" && name == "ACType" {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -16,7 +16,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"SunSpec/models",
 			"https://github.com/sunspec/models",
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
-			"Models 701/153 and 702/50",
+			"Models 701/153, 702/50, and 713/7",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -40,6 +40,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 		}{
 			{701, 153, 72, []string{"ID", "L", "ACType"}, "MnAlrmInfo"},
 			{702, 50, 51, []string{"ID", "L", "WMaxRtg"}, "S_SF"},
+			{713, 7, 9, []string{"ID", "L", "WHRtg"}, "Pct_SF"},
 		} {
 			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
 			if !ok || len(definition.points) != want.points {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -87,6 +87,49 @@ func TestSunSpecV2DERMeasurePreservesScaledUnsignedCounter(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2DERStoragePreservesValueOrderAndScale(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	words := v2DERModelWords(t, registry, 713, 7, map[string][]uint16{
+		"WHRtg":   {100},
+		"WHAvail": {50},
+		"SoC":     {75},
+		"SoH":     {95},
+		"Sta":     {3},
+		"WH_SF":   {0},
+		"Pct_SF":  {0xffff},
+	})
+	key := SunSpecDecoderKey{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{
+		Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 713, ModelLength: 7}, SchemaRevision: SunSpecModelsRevisionV2,
+		Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []struct {
+		field       string
+		coefficient int64
+		exponent    int16
+	}{
+		{"sunspec.der.v2.713.WHRtg", 100, 0},
+		{"sunspec.der.v2.713.WHAvail", 50, 0},
+		{"sunspec.der.v2.713.SoC", 75, -1},
+		{"sunspec.der.v2.713.SoH", 95, -1},
+	} {
+		fact, ok := decoded.Fact(want.field)
+		if !ok {
+			t.Fatalf("fact %q absent", want.field)
+		}
+		value, ok := fact.Value.Decimal()
+		if !ok || value != (SunSpecDecimal{Coefficient: want.coefficient, Exponent: want.exponent}) {
+			t.Fatalf("fact %q decimal=%#v present=%v", want.field, value, ok)
+		}
+	}
+}
+
 func v2DERModelWords(t *testing.T, registry SunSpecDecoderRegistry, id, length uint16, values map[string][]uint16) []uint16 {
 	t.Helper()
 	key := SunSpecDecoderKey{ModelID: id, ModelLength: length, SchemaRevision: SunSpecModelsRevisionV2}


### PR DESCRIPTION
## RED evidence

Initial tests intentionally fail because V2 Model 713/7 and its Apache notice attribution are absent.

## Scope

V2-only static 713/7, synthetic tests, V1 and 701/702 preserved, and Model 714 opaque. Docs gate: `9bd6e87cecb82800b40c0620dbffd8c54c405fba`.

No JSON fixtures, Model 714 geometry, vendor/profile/catalog admission, runtime, transport, gateway, or live I/O.