### PR TITLE
SunSpec V2: add offline BESS bank Model 803 geometry

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 ## SunSpec/models
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
-714 variable geometry, 715/7, and 802/62 in
+714 variable geometry, 715/7, 802/62, and 803 variable geometry in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -260,3 +260,89 @@ func TestSunSpecV2ChainRetainsFixedBESSBaseBlock(t *testing.T) {
 		t.Fatalf("BESS base occurrence=%#v", occurrences)
 	}
 }
+
+func TestSunSpecV2ChainRetainsDistinctBESSBankOccurrences(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 256, MaxOccurrences: 3},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	bankZero := append([]uint16{803, 26}, make([]uint16, 26)...)
+	bankTwo := append([]uint16{803, 90}, make([]uint16, 90)...)
+	bankTwo[2] = 2
+	words = append(words, bankZero...)
+	words = append(words, bankTwo...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 3 || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 803, ModelLength: 26}) || occurrences[2].WireKey != (SunSpecWireKey{ModelID: 803, ModelLength: 90}) || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[2].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].Ordinal == occurrences[2].Ordinal {
+		t.Fatalf("BESS bank occurrences=%#v", occurrences)
+	}
+}
+
+func TestSunSpecV2ChainKeepsWrongBESSBankGeometryOpaque(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 803, 27)
+	words = append(words, make([]uint16, 27)...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionUnsupportedLength {
+		t.Fatalf("wrong V2 803 geometry occurrences=%#v", occurrences)
+	}
+	if _, ok := occurrences[1].DecoderKey(); ok {
+		t.Fatalf("wrong V2 803 geometry has decoder key: %#v", occurrences[1])
+	}
+}

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -109,7 +109,7 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	case SunSpecModelsRevisionV1:
 		capacity += 3277 + 89561
 	case SunSpecModelsRevisionV2:
-		capacity += int(maxSunSpecDERPorts) + 1
+		capacity += int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1
 	}
 	keys := make([]SunSpecDecoderKey, 0, capacity)
 	for _, definition := range definitions {
@@ -124,6 +124,9 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	case SunSpecModelsRevisionV2:
 		for ports := uint32(0); ports <= maxSunSpecDERPorts; ports++ {
 			keys = append(keys, SunSpecDecoderKey{ModelID: 714, ModelLength: uint16(18 + 25*ports), SchemaRevision: revision})
+		}
+		for strings := uint32(0); strings <= maxSunSpecBESSStrings; strings++ {
+			keys = append(keys, SunSpecDecoderKey{ModelID: 803, ModelLength: uint16(26 + 32*strings), SchemaRevision: revision})
 		}
 	}
 	sort.Slice(keys, func(i, j int) bool {
@@ -153,8 +156,17 @@ func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelD
 	if key.SchemaRevision != r.revision {
 		return sunSpecModelDefinition{}, false
 	}
-	if key.SchemaRevision == SunSpecModelsRevisionV2 && key.ModelID == 714 {
-		resolved, err := derDCMeasureV2SunSpecDefinition(key.ModelLength)
+	if key.SchemaRevision == SunSpecModelsRevisionV2 {
+		var resolved sunSpecModelDefinition
+		var err error
+		switch key.ModelID {
+		case 714:
+			resolved, err = derDCMeasureV2SunSpecDefinition(key.ModelLength)
+		case 803:
+			resolved, err = bessBankV2SunSpecDefinition(key.ModelLength)
+		default:
+			return sunSpecModelDefinition{}, false
+		}
 		return resolved, err == nil
 	}
 	if key.SchemaRevision != SunSpecModelsRevisionV1 {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -124,20 +124,27 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 715, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
 		}
-		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1 {
+		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))
 		}
 		static := make(map[SunSpecDecoderKey]bool, len(wantV2Static))
 		for _, key := range wantV2Static {
 			static[key] = true
 		}
-		dynamic := 0
+		dynamicDER, dynamicBESS := 0, 0
 		for _, key := range v2Keys {
 			if key.ModelID == 714 {
 				if key.ModelLength < 18 || (key.ModelLength-18)%25 != 0 {
 					t.Fatalf("V2 dynamic key=%#v", key)
 				}
-				dynamic++
+				dynamicDER++
+				continue
+			}
+			if key.ModelID == 803 {
+				if key.ModelLength < 26 || (key.ModelLength-26)%32 != 0 {
+					t.Fatalf("V2 dynamic key=%#v", key)
+				}
+				dynamicBESS++
 				continue
 			}
 			if !static[key] {
@@ -145,14 +152,17 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			}
 			delete(static, key)
 		}
-		if dynamic != int(maxSunSpecDERPorts)+1 || len(static) != 0 {
-			t.Fatalf("V2 dynamic=%d missing static=%#v", dynamic, static)
+		if dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESS != int(maxSunSpecBESSStrings)+1 || len(static) != 0 {
+			t.Fatalf("V2 DER dynamic=%d BESS dynamic=%d missing static=%#v", dynamicDER, dynamicBESS, static)
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved V1 compatibility Common")
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 714, ModelLength: 19, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved a non-geometric DER length")
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+			t.Fatal("V2 resolved a non-geometric BESS bank length")
 		}
 		for _, key := range registries[SunSpecModelsRevisionV1].DecoderKeys() {
 			if key.SchemaRevision != SunSpecModelsRevisionV1 {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -85,7 +85,8 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 715, ModelLength: 8, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 801, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 802, ModelLength: 61, SchemaRevision: SunSpecModelsRevisionV2},
-		{ModelID: 803, ModelLength: 26, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 804, ModelLength: 46, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -3,6 +3,7 @@ package modbusreg
 import "fmt"
 
 const maxSunSpecDERPorts uint32 = (65535 - 18) / 25
+const maxSunSpecBESSStrings uint32 = (65535 - 26) / 32
 
 func derDCMeasureV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
 	if length < 18 || (uint32(length)-18)%25 != 0 {
@@ -30,6 +31,83 @@ func derDCMeasureV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, err
 		return len(words) == int(length)+2 && len(words) > 4 && words[4] != 0xffff && uint32(length) == 18+25*uint32(words[4])
 	}
 	return d, nil
+}
+
+func bessBankV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
+	if length < 26 || (uint32(length)-26)%32 != 0 {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 803 geometry is invalid")
+	}
+	strings := (uint32(length) - 26) / 32
+	if strings > maxSunSpecBESSStrings {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 803 string count exceeds geometry")
+	}
+	points := []sunSpecPointDefinition{
+		v2DERPoint("803", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("803", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("803", "NStr", SunSpecTypeCount, "", "", false),
+		v2DERPoint("803", "NStrCon", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "ModTmpMax", SunSpecTypeInt16, "C", "ModTmp_SF", false),
+		v2DERPoint("803", "ModTmpMaxStr", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "ModTmpMaxMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "ModTmpMin", SunSpecTypeInt16, "C", "ModTmp_SF", false),
+		v2DERPoint("803", "ModTmpMinStr", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "ModTmpMinMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "ModTmpAvg", SunSpecTypeInt16, "C", "ModTmp_SF", false),
+		v2DERPoint("803", "StrVMax", SunSpecTypeUint16, "V", "V_SF", false),
+		v2DERPoint("803", "StrVMaxStr", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "StrVMin", SunSpecTypeUint16, "V", "V_SF", false),
+		v2DERPoint("803", "StrVMinStr", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "StrVAvg", SunSpecTypeUint16, "V", "V_SF", false),
+		v2DERPoint("803", "StrAMax", SunSpecTypeInt16, "A", "A_SF", false),
+		v2DERPoint("803", "StrAMaxStr", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "StrAMin", SunSpecTypeInt16, "A", "A_SF", false),
+		v2DERPoint("803", "StrAMinStr", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "StrAAvg", SunSpecTypeInt16, "A", "A_SF", false),
+		v2DERPoint("803", "NCellBal", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("803", "CellV_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("803", "ModTmp_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("803", "A_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("803", "SoH_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("803", "SoC_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("803", "V_SF", SunSpecTypeScaleFactor, "", "", false),
+	}
+	for i := uint32(1); i <= strings; i++ {
+		for _, point := range []struct {
+			name string
+			typ  SunSpecPointType
+			unit string
+			sf   string
+		}{
+			{"StrNMod", SunSpecTypeUint16, "", ""}, {"StrSt", SunSpecTypeBitfield32, "", ""},
+			{"StrConFail", SunSpecTypeEnum16, "", ""}, {"StrSoC", SunSpecTypeUint16, "", "SoC_SF"},
+			{"StrSoH", SunSpecTypeUint16, "", "SoH_SF"}, {"StrA", SunSpecTypeInt16, "A", "A_SF"},
+			{"StrCellVMax", SunSpecTypeUint16, "V", "CellV_SF"}, {"StrCellVMaxMod", SunSpecTypeUint16, "", ""},
+			{"StrCellVMin", SunSpecTypeUint16, "V", "CellV_SF"}, {"StrCellVMinMod", SunSpecTypeUint16, "", ""},
+			{"StrCellVAvg", SunSpecTypeUint16, "V", "CellV_SF"}, {"StrModTmpMax", SunSpecTypeInt16, "C", "ModTmp_SF"},
+			{"StrModTmpMaxMod", SunSpecTypeUint16, "", ""}, {"StrModTmpMin", SunSpecTypeInt16, "C", "ModTmp_SF"},
+			{"StrModTmpMinMod", SunSpecTypeUint16, "", ""}, {"StrModTmpAvg", SunSpecTypeInt16, "C", "ModTmp_SF"},
+			{"StrDisRsn", SunSpecTypeEnum16, "", ""}, {"StrConSt", SunSpecTypeBitfield32, "", ""},
+			{"StrEvt1", SunSpecTypeBitfield32, "", ""}, {"StrEvt2", SunSpecTypeBitfield32, "", ""},
+			{"StrEvtVnd1", SunSpecTypeBitfield32, "", ""}, {"StrEvtVnd2", SunSpecTypeBitfield32, "", ""},
+			{"StrSetEna", SunSpecTypeEnum16, "", ""}, {"StrSetCon", SunSpecTypeEnum16, "", ""},
+			{"Pad1", SunSpecTypePad, "", ""}, {"Pad2", SunSpecTypePad, "", ""},
+		} {
+			pointDefinition := v2DERPoint("803", point.name, point.typ, point.unit, point.sf, false)
+			pointDefinition.groupID = "string"
+			pointDefinition.repeatIndex = uint16(i)
+			pointDefinition.repeated = true
+			points = append(points, pointDefinition)
+		}
+	}
+	definitions, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV2, 803, length, SunSpecTopologyNone, false, points)
+	if err != nil {
+		return sunSpecModelDefinition{}, err
+	}
+	definition := definitions[0]
+	definition.geometry = func(words []uint16) bool {
+		return len(words) == int(length)+2 && len(words) > 2 && words[2] != 0xffff && uint32(length) == 26+32*uint32(words[2])
+	}
+	return definition, nil
 }
 
 func derMeasureACV2SunSpecPoints() []sunSpecPointDefinition {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -19,7 +19,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"https://github.com/sunspec/models",
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
-			"714 variable geometry, 715/7, and 802/62",
+			"714 variable geometry, 715/7, 802/62, and 803 variable geometry",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -88,14 +88,79 @@ func TestSunSpecV2BESSBankRequiresExactDynamicDefinitions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, length := range []uint16{26, 90, 65530} {
-		key := SunSpecDecoderKey{ModelID: 803, ModelLength: length, SchemaRevision: SunSpecModelsRevisionV2}
-		if _, ok := registry.definition(key); !ok {
-			t.Fatalf("Model 803/%d dynamic definition absent", length)
+	for _, want := range []struct {
+		strings, length uint16
+		points          int
+	}{
+		{0, 26, 28},
+		{2, 90, 80},
+		{2047, 65530, 28 + 26*2047},
+	} {
+		key := SunSpecDecoderKey{ModelID: 803, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+		definition, ok := registry.definition(key)
+		if !ok || len(definition.points) != want.points {
+			t.Fatalf("Model 803/%d dynamic definition=%t points=%d", want.length, ok, len(definition.points))
 		}
+		if want.strings == 2047 {
+			continue
+		}
+		words := make([]uint16, int(want.length)+2)
+		words[0], words[1], words[2] = 803, want.length, want.strings
+		spans := []SunSpecSourceSpan{{LogicalViewID: 11, PDUOffset: 0, WordCount: want.length + 2}}
+		decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 803, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: spans})
+		if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+			t.Fatalf("Model 803/%d geometry=%t qualifies=%t err=%v", want.length, decoded.GeometryValid(), decoded.Qualifies(), err)
+		}
+		if want.strings == 2 {
+			counts := map[uint16]int{}
+			for _, fact := range decoded.Facts() {
+				if fact.Repeated && fact.GroupID == "string" {
+					counts[fact.RepeatIndex]++
+				}
+			}
+			if counts[1] != 26 || counts[2] != 26 || len(counts) != 2 || !reflect.DeepEqual(decoded.SourceSpans(), spans) {
+				t.Fatalf("Model 803 repeat facts=%v spans=%#v", counts, decoded.SourceSpans())
+			}
+		}
+	}
+	for _, want := range []struct {
+		name          string
+		length, count uint16
+	}{
+		{"count mismatch", 90, 1},
+		{"sentinel", 90, 0xffff},
+	} {
+		t.Run(want.name, func(t *testing.T) {
+			key := SunSpecDecoderKey{ModelID: 803, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+			words := make([]uint16, int(want.length)+2)
+			words[0], words[1], words[2] = 803, want.length, want.count
+			decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 803, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+			if err != nil || decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) {
+				t.Fatalf("Model 803 %s geometry=%t qualifies=%t facts=%d err=%v", want.name, decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
+			}
+		})
 	}
 	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 804, ModelLength: 46, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 		t.Fatal("Model 804 became available before its separate node")
+	}
+}
+
+func TestSunSpecV2BESSBankRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 803, ModelLength: 58, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 803/58 definition absent")
+	}
+	want := strings.Split("ID:uint16:1::0:false,L:uint16:1::0:false,NStr:count:1::0:false,NStrCon:uint16:1::0:false,ModTmpMax:int16:1:ModTmp_SF:0:false,ModTmpMaxStr:uint16:1::0:false,ModTmpMaxMod:uint16:1::0:false,ModTmpMin:int16:1:ModTmp_SF:0:false,ModTmpMinStr:uint16:1::0:false,ModTmpMinMod:uint16:1::0:false,ModTmpAvg:int16:1:ModTmp_SF:0:false,StrVMax:uint16:1:V_SF:0:false,StrVMaxStr:uint16:1::0:false,StrVMin:uint16:1:V_SF:0:false,StrVMinStr:uint16:1::0:false,StrVAvg:uint16:1:V_SF:0:false,StrAMax:int16:1:A_SF:0:false,StrAMaxStr:uint16:1::0:false,StrAMin:int16:1:A_SF:0:false,StrAMinStr:uint16:1::0:false,StrAAvg:int16:1:A_SF:0:false,NCellBal:uint16:1::0:false,CellV_SF:sunssf:1::0:false,ModTmp_SF:sunssf:1::0:false,A_SF:sunssf:1::0:false,SoH_SF:sunssf:1::0:false,SoC_SF:sunssf:1::0:false,V_SF:sunssf:1::0:false,StrNMod:uint16:1::1:true,StrSt:bitfield32:2::1:true,StrConFail:enum16:1::1:true,StrSoC:uint16:1:SoC_SF:1:true,StrSoH:uint16:1:SoH_SF:1:true,StrA:int16:1:A_SF:1:true,StrCellVMax:uint16:1:CellV_SF:1:true,StrCellVMaxMod:uint16:1::1:true,StrCellVMin:uint16:1:CellV_SF:1:true,StrCellVMinMod:uint16:1::1:true,StrCellVAvg:uint16:1:CellV_SF:1:true,StrModTmpMax:int16:1:ModTmp_SF:1:true,StrModTmpMaxMod:uint16:1::1:true,StrModTmpMin:int16:1:ModTmp_SF:1:true,StrModTmpMinMod:uint16:1::1:true,StrModTmpAvg:int16:1:ModTmp_SF:1:true,StrDisRsn:enum16:1::1:true,StrConSt:bitfield32:2::1:true,StrEvt1:bitfield32:2::1:true,StrEvt2:bitfield32:2::1:true,StrEvtVnd1:bitfield32:2::1:true,StrEvtVnd2:bitfield32:2::1:true,StrSetEna:enum16:1::1:true,StrSetCon:enum16:1::1:true,Pad1:pad:1::1:true,Pad2:pad:1::1:true", ",")
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s:%d:%t", point.name, point.pointType, point.size, point.scaleFactor, point.repeatIndex, point.repeated)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 803 signature=%q want=%q", got, want)
 	}
 }
 

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -83,6 +83,22 @@ func TestSunSpecV2BESSBaseRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2BESSBankRequiresExactDynamicDefinitions(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, length := range []uint16{26, 90, 65530} {
+		key := SunSpecDecoderKey{ModelID: 803, ModelLength: length, SchemaRevision: SunSpecModelsRevisionV2}
+		if _, ok := registry.definition(key); !ok {
+			t.Fatalf("Model 803/%d dynamic definition absent", length)
+		}
+	}
+	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 804, ModelLength: 46, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+		t.Fatal("Model 804 became available before its separate node")
+	}
+}
+
 func TestSunSpecV2ControlObservabilityDecodesStateOnly(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {


### PR DESCRIPTION
Closes #77

## RED-first checkpoint

The initial test requires V2 Model 803 dynamic definitions for zero, two, and maximum strings. It fails on the base because no Model 803 decoder definition exists.

## Frozen scope

- `sunspec_models_der_v2.go`
- `sunspec_models_der_v2_test.go`
- `sunspec_decoder.go`
- `sunspec_decoder_test.go`
- `sunspec_model_catalog_test.go`
- `sunspec_chain_plan_test.go`
- `THIRD_PARTY_NOTICES.md`

V2-only, offline observed state. No profile/catalog/runtime/vendor/transport/gateway/live I/O/write/send behavior. Model 804 remains opaque.