### PR TITLE
SunSpec V2: add offline BESS string Model 804 geometry

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,8 @@
 ## SunSpec/models
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
-714 variable geometry, 715/7, 802/62, and 803 variable geometry in
+714 variable geometry, 715/7, 802/62, 803 variable geometry, and 804 variable
+geometry in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -346,3 +346,89 @@ func TestSunSpecV2ChainKeepsWrongBESSBankGeometryOpaque(t *testing.T) {
 		t.Fatalf("wrong V2 803 geometry has decoder key: %#v", occurrences[1])
 	}
 }
+
+func TestSunSpecV2ChainRetainsDistinctBESSStringOccurrences(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 256, MaxOccurrences: 3},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	stringZero := append([]uint16{804, 46}, make([]uint16, 46)...)
+	stringTwo := append([]uint16{804, 78}, make([]uint16, 78)...)
+	stringTwo[3] = 2
+	words = append(words, stringZero...)
+	words = append(words, stringTwo...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 3 || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 804, ModelLength: 46}) || occurrences[2].WireKey != (SunSpecWireKey{ModelID: 804, ModelLength: 78}) || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[2].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].Ordinal == occurrences[2].Ordinal {
+		t.Fatalf("BESS string occurrences=%#v", occurrences)
+	}
+}
+
+func TestSunSpecV2ChainKeepsWrongBESSStringGeometryOpaque(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 804, 47)
+	words = append(words, make([]uint16, 47)...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionUnsupportedLength {
+		t.Fatalf("wrong V2 804 geometry occurrences=%#v", occurrences)
+	}
+	if _, ok := occurrences[1].DecoderKey(); ok {
+		t.Fatalf("wrong V2 804 geometry has decoder key: %#v", occurrences[1])
+	}
+}

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -109,7 +109,7 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	case SunSpecModelsRevisionV1:
 		capacity += 3277 + 89561
 	case SunSpecModelsRevisionV2:
-		capacity += int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1
+		capacity += int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1 + int(maxSunSpecBESSModules) + 1
 	}
 	keys := make([]SunSpecDecoderKey, 0, capacity)
 	for _, definition := range definitions {
@@ -127,6 +127,9 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 		}
 		for strings := uint32(0); strings <= maxSunSpecBESSStrings; strings++ {
 			keys = append(keys, SunSpecDecoderKey{ModelID: 803, ModelLength: uint16(26 + 32*strings), SchemaRevision: revision})
+		}
+		for modules := uint32(0); modules <= maxSunSpecBESSModules; modules++ {
+			keys = append(keys, SunSpecDecoderKey{ModelID: 804, ModelLength: uint16(46 + 16*modules), SchemaRevision: revision})
 		}
 	}
 	sort.Slice(keys, func(i, j int) bool {
@@ -164,6 +167,8 @@ func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelD
 			resolved, err = derDCMeasureV2SunSpecDefinition(key.ModelLength)
 		case 803:
 			resolved, err = bessBankV2SunSpecDefinition(key.ModelLength)
+		case 804:
+			resolved, err = bessStringV2SunSpecDefinition(key.ModelLength)
 		default:
 			return sunSpecModelDefinition{}, false
 		}
@@ -209,7 +214,9 @@ func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (
 		if point.pointType != SunSpecTypeScaleFactor {
 			continue
 		}
-		scales[point.name] = decodeSunSpecValue(point, words[point.offset:point.offset+point.size], nil)
+		start := int(point.offset)
+		end := start + int(point.size)
+		scales[point.name] = decodeSunSpecValue(point, words[start:end], nil)
 	}
 	for _, point := range definition.points {
 		if point.offset < 2 {
@@ -226,7 +233,9 @@ func (r SunSpecDecoderRegistry) DecodeOccurrence(occurrence SunSpecOccurrence) (
 			value := SunSpecValue{pointType: SunSpecTypeScaleFactor, state: SunSpecValueValid, signed: int64(*point.fixedScale), hasSigned: true}
 			scale = &value
 		}
-		value := decodeSunSpecValue(point, words[point.offset:point.offset+point.size], scale)
+		start := int(point.offset)
+		end := start + int(point.size)
+		value := decodeSunSpecValue(point, words[start:end], scale)
 		if point.mandatory && !mandatorySunSpecValueQualifies(value) {
 			model.qualifies = false
 		}

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -124,14 +124,14 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 715, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
 		}
-		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1 {
+		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))
 		}
 		static := make(map[SunSpecDecoderKey]bool, len(wantV2Static))
 		for _, key := range wantV2Static {
 			static[key] = true
 		}
-		dynamicDER, dynamicBESS := 0, 0
+		dynamicDER, dynamicBESSBanks, dynamicBESSStrings := 0, 0, 0
 		for _, key := range v2Keys {
 			if key.ModelID == 714 {
 				if key.ModelLength < 18 || (key.ModelLength-18)%25 != 0 {
@@ -144,7 +144,14 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 				if key.ModelLength < 26 || (key.ModelLength-26)%32 != 0 {
 					t.Fatalf("V2 dynamic key=%#v", key)
 				}
-				dynamicBESS++
+				dynamicBESSBanks++
+				continue
+			}
+			if key.ModelID == 804 {
+				if key.ModelLength < 46 || (key.ModelLength-46)%16 != 0 {
+					t.Fatalf("V2 dynamic key=%#v", key)
+				}
+				dynamicBESSStrings++
 				continue
 			}
 			if !static[key] {
@@ -152,8 +159,8 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			}
 			delete(static, key)
 		}
-		if dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESS != int(maxSunSpecBESSStrings)+1 || len(static) != 0 {
-			t.Fatalf("V2 DER dynamic=%d BESS dynamic=%d missing static=%#v", dynamicDER, dynamicBESS, static)
+		if dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESSBanks != int(maxSunSpecBESSStrings)+1 || dynamicBESSStrings != int(maxSunSpecBESSModules)+1 || len(static) != 0 {
+			t.Fatalf("V2 DER dynamic=%d BESS banks=%d strings=%d missing static=%#v", dynamicDER, dynamicBESSBanks, dynamicBESSStrings, static)
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved V1 compatibility Common")
@@ -163,6 +170,9 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved a non-geometric BESS bank length")
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 804, ModelLength: 47, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+			t.Fatal("V2 resolved a non-geometric BESS string length")
 		}
 		for _, key := range registries[SunSpecModelsRevisionV1].DecoderKeys() {
 			if key.SchemaRevision != SunSpecModelsRevisionV1 {

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -155,7 +155,9 @@ func appendSunSpecDefinition(values []sunSpecModelDefinition, revision SunSpecSc
 		if points[index].size == 0 {
 			return nil, fmt.Errorf("SunSpec point size is zero")
 		}
-		if extent > 65535 || extent+uint32(points[index].size) > 65535 {
+		// Point starts remain uint16. A final one-word point may therefore start
+		// at 65535 and bring an isolated offline extent to exactly 65536 words.
+		if extent > 65535 || extent+uint32(points[index].size) > 65536 {
 			return nil, fmt.Errorf("SunSpec model %d/%d catalog exceeds addressable point offsets", id, length)
 		}
 		points[index].offset = uint16(extent)

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -53,6 +53,22 @@ func TestSunSpecModelCatalogMatchesPinnedAuthoritativeShapes(t *testing.T) {
 	}
 }
 
+func TestSunSpecModelCatalogAllowsOnlyFinalAddressableWordAtMaximumExtent(t *testing.T) {
+	points := []sunSpecPointDefinition{
+		sunSpecPoint("Prefix", "test.prefix", SunSpecTypeUint16, 65535, "", "", false, nil, 0),
+		sunSpecPoint("Final", "test.final", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+	}
+	definitions, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV2, 999, 65534, SunSpecTopologyNone, false, points)
+	if err != nil || len(definitions) != 1 || definitions[0].points[1].offset != 65535 {
+		t.Fatalf("maximum catalog definitions=%#v err=%v", definitions, err)
+	}
+	overflow := append([]sunSpecPointDefinition(nil), points...)
+	overflow[1].size = 2
+	if _, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV2, 999, 65535, SunSpecTopologyNone, false, overflow); err == nil {
+		t.Fatal("catalog accepted an extent beyond the addressable maximum")
+	}
+}
+
 func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	definitions, err := standardSunSpecModelDefinitions(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -86,7 +86,6 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 801, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 802, ModelLength: 61, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2},
-		{ModelID: 804, ModelLength: 46, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -4,6 +4,7 @@ import "fmt"
 
 const maxSunSpecDERPorts uint32 = (65535 - 18) / 25
 const maxSunSpecBESSStrings uint32 = (65535 - 26) / 32
+const maxSunSpecBESSModules uint32 = (65535 - 46) / 16
 
 func derDCMeasureV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
 	if length < 18 || (uint32(length)-18)%25 != 0 {
@@ -106,6 +107,91 @@ func bessBankV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) 
 	definition := definitions[0]
 	definition.geometry = func(words []uint16) bool {
 		return len(words) == int(length)+2 && len(words) > 2 && words[2] != 0xffff && uint32(length) == 26+32*uint32(words[2])
+	}
+	return definition, nil
+}
+
+func bessStringV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
+	if length < 46 || (uint32(length)-46)%16 != 0 {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 804 geometry is invalid")
+	}
+	modules := (uint32(length) - 46) / 16
+	if modules > maxSunSpecBESSModules {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 804 module count exceeds geometry")
+	}
+	points := []sunSpecPointDefinition{
+		v2DERPoint("804", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("804", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("804", "Idx", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("804", "NMod", SunSpecTypeCount, "", "", false),
+		v2DERPoint("804", "St", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("804", "ConFail", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("804", "NCellBal", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("804", "SoC", SunSpecTypeUint16, "%", "SoC_SF", false),
+		v2DERPoint("804", "DoD", SunSpecTypeUint16, "%", "DoD_SF", false),
+		v2DERPoint("804", "NCyc", SunSpecTypeUint32, "", "", false),
+		v2DERPoint("804", "SoH", SunSpecTypeUint16, "%", "SoH_SF", false),
+		v2DERPoint("804", "A", SunSpecTypeInt16, "A", "A_SF", false),
+		v2DERPoint("804", "V", SunSpecTypeUint16, "V", "V_SF", false),
+		v2DERPoint("804", "CellVMax", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("804", "CellVMaxMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("804", "CellVMin", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("804", "CellVMinMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("804", "CellVAvg", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("804", "ModTmpMax", SunSpecTypeInt16, "C", "ModTmp_SF", false),
+		v2DERPoint("804", "ModTmpMaxMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("804", "ModTmpMin", SunSpecTypeInt16, "C", "ModTmp_SF", false),
+		v2DERPoint("804", "ModTmpMinMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("804", "ModTmpAvg", SunSpecTypeInt16, "C", "ModTmp_SF", false),
+		v2DERPoint("804", "Pad1", SunSpecTypePad, "", "", false),
+		v2DERPoint("804", "ConSt", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("804", "Evt1", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("804", "Evt2", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("804", "EvtVnd1", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("804", "EvtVnd2", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("804", "SetEna", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("804", "SetCon", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("804", "SoC_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "SoH_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "DoD_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "A_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "V_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "CellV_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "ModTmp_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("804", "Pad2", SunSpecTypePad, "", "", false),
+		v2DERPoint("804", "Pad3", SunSpecTypePad, "", "", false),
+		v2DERPoint("804", "Pad4", SunSpecTypePad, "", "", false),
+	}
+	for i := uint32(1); i <= modules; i++ {
+		for _, point := range []struct {
+			name string
+			typ  SunSpecPointType
+			unit string
+			sf   string
+		}{
+			{"ModNCell", SunSpecTypeUint16, "", ""}, {"ModSoC", SunSpecTypeUint16, "%", "SoC_SF"},
+			{"ModSoH", SunSpecTypeUint16, "%", "SoH_SF"}, {"ModCellVMax", SunSpecTypeUint16, "V", "CellV_SF"},
+			{"ModCellVMaxCell", SunSpecTypeUint16, "", ""}, {"ModCellVMin", SunSpecTypeUint16, "V", "CellV_SF"},
+			{"ModCellVMinCell", SunSpecTypeUint16, "", ""}, {"ModCellVAvg", SunSpecTypeUint16, "V", "CellV_SF"},
+			{"ModCellTmpMax", SunSpecTypeInt16, "C", "ModTmp_SF"}, {"ModCellTmpMaxCell", SunSpecTypeUint16, "", ""},
+			{"ModCellTmpMin", SunSpecTypeInt16, "C", "ModTmp_SF"}, {"ModCellTmpMinCell", SunSpecTypeUint16, "", ""},
+			{"ModCellTmpAvg", SunSpecTypeInt16, "C", "ModTmp_SF"}, {"Pad5", SunSpecTypePad, "", ""},
+			{"Pad6", SunSpecTypePad, "", ""}, {"Pad7", SunSpecTypePad, "", ""},
+		} {
+			pointDefinition := v2DERPoint("804", point.name, point.typ, point.unit, point.sf, false)
+			pointDefinition.groupID = "module"
+			pointDefinition.repeatIndex = uint16(i)
+			pointDefinition.repeated = true
+			points = append(points, pointDefinition)
+		}
+	}
+	definitions, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV2, 804, length, SunSpecTopologyNone, false, points)
+	if err != nil {
+		return sunSpecModelDefinition{}, err
+	}
+	definition := definitions[0]
+	definition.geometry = func(words []uint16) bool {
+		return len(words) == int(length)+2 && len(words) > 3 && words[3] != 0xffff && uint32(length) == 46+16*uint32(words[3])
 	}
 	return definition, nil
 }

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -19,7 +19,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"https://github.com/sunspec/models",
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
-			"714 variable geometry, 715/7, 802/62, and 803 variable geometry",
+			"714 variable geometry, 715/7, 802/62, 803 variable geometry, and 804 variable",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -140,9 +140,6 @@ func TestSunSpecV2BESSBankRequiresExactDynamicDefinitions(t *testing.T) {
 			}
 		})
 	}
-	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 804, ModelLength: 46, SchemaRevision: SunSpecModelsRevisionV2}); ok {
-		t.Fatal("Model 804 became available before its separate node")
-	}
 }
 
 func TestSunSpecV2BESSStringRequiresExactDynamicDefinitions(t *testing.T) {
@@ -155,15 +152,11 @@ func TestSunSpecV2BESSStringRequiresExactDynamicDefinitions(t *testing.T) {
 	}{
 		{0, 46},
 		{2, 78},
-		{4093, 65534},
 	} {
 		key := SunSpecDecoderKey{ModelID: 804, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
 		definition, ok := registry.definition(key)
 		if !ok || len(definition.points) == 0 {
 			t.Fatalf("Model 804/%d dynamic definition=%t points=%d", want.length, ok, len(definition.points))
-		}
-		if want.modules == 4093 {
-			continue
 		}
 		words := make([]uint16, int(want.length)+2)
 		words[0], words[1], words[3] = 804, want.length, want.modules
@@ -200,6 +193,85 @@ func TestSunSpecV2BESSStringRequiresExactDynamicDefinitions(t *testing.T) {
 				t.Fatalf("Model 804 %s geometry=%t qualifies=%t facts=%d err=%v", want.name, decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
 			}
 		})
+	}
+}
+
+func TestSunSpecV2BESSStringDecodesFullMaximumOfflineOccurrence(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := SunSpecDecoderKey{ModelID: 804, ModelLength: 65534, SchemaRevision: SunSpecModelsRevisionV2}
+	if _, ok := registry.definition(key); !ok {
+		t.Fatal("Model 804/65534 definition absent")
+	}
+	words := make([]uint16, 65536)
+	words[0], words[1], words[3] = 804, 65534, 4093
+	spans := make([]SunSpecSourceSpan, 0, (len(words)+124)/125)
+	for remaining := len(words); remaining > 0; {
+		count := min(remaining, 125)
+		spans = append(spans, SunSpecSourceSpan{LogicalViewID: uint64(len(spans) + 1), PDUOffset: 0, WordCount: uint16(count)})
+		remaining -= count
+	}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 804, ModelLength: 65534}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: spans})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 804 maximum geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	var extent uint32
+	for _, span := range decoded.SourceSpans() {
+		if span.WordCount == 0 || span.WordCount > 125 {
+			t.Fatalf("maximum span=%#v", span)
+		}
+		extent += uint32(span.WordCount)
+	}
+	if len(decoded.SourceSpans()) < 2 || extent != 65536 {
+		t.Fatalf("maximum spans=%d extent=%d", len(decoded.SourceSpans()), extent)
+	}
+	moduleFacts := map[uint16]int{}
+	for _, fact := range decoded.Facts() {
+		if fact.Repeated && fact.GroupID == "module" {
+			moduleFacts[fact.RepeatIndex]++
+		}
+	}
+	if moduleFacts[1] != 16 || moduleFacts[4093] != 16 || len(moduleFacts) != 4093 {
+		t.Fatalf("maximum module facts first=%d last=%d groups=%d", moduleFacts[1], moduleFacts[4093], len(moduleFacts))
+	}
+	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 803, ModelLength: 26, SchemaRevision: SunSpecModelsRevisionV2}); !ok {
+		t.Fatal("Model 803 lost independent V2 definition")
+	}
+}
+
+func TestSunSpecV2BESSStringRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 804, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 804/62 definition absent")
+	}
+	want := strings.Split("ID:uint16:1::0:false,L:uint16:1::0:false,Idx:uint16:1::0:false,NMod:count:1::0:false,St:bitfield32:2::0:false,ConFail:enum16:1::0:false,NCellBal:uint16:1::0:false,SoC:uint16:1:SoC_SF:0:false,DoD:uint16:1:DoD_SF:0:false,NCyc:uint32:2::0:false,SoH:uint16:1:SoH_SF:0:false,A:int16:1:A_SF:0:false,V:uint16:1:V_SF:0:false,CellVMax:uint16:1:CellV_SF:0:false,CellVMaxMod:uint16:1::0:false,CellVMin:uint16:1:CellV_SF:0:false,CellVMinMod:uint16:1::0:false,CellVAvg:uint16:1:CellV_SF:0:false,ModTmpMax:int16:1:ModTmp_SF:0:false,ModTmpMaxMod:uint16:1::0:false,ModTmpMin:int16:1:ModTmp_SF:0:false,ModTmpMinMod:uint16:1::0:false,ModTmpAvg:int16:1:ModTmp_SF:0:false,Pad1:pad:1::0:false,ConSt:bitfield32:2::0:false,Evt1:bitfield32:2::0:false,Evt2:bitfield32:2::0:false,EvtVnd1:bitfield32:2::0:false,EvtVnd2:bitfield32:2::0:false,SetEna:enum16:1::0:false,SetCon:enum16:1::0:false,SoC_SF:sunssf:1::0:false,SoH_SF:sunssf:1::0:false,DoD_SF:sunssf:1::0:false,A_SF:sunssf:1::0:false,V_SF:sunssf:1::0:false,CellV_SF:sunssf:1::0:false,ModTmp_SF:sunssf:1::0:false,Pad2:pad:1::0:false,Pad3:pad:1::0:false,Pad4:pad:1::0:false,ModNCell:uint16:1::1:true,ModSoC:uint16:1:SoC_SF:1:true,ModSoH:uint16:1:SoH_SF:1:true,ModCellVMax:uint16:1:CellV_SF:1:true,ModCellVMaxCell:uint16:1::1:true,ModCellVMin:uint16:1:CellV_SF:1:true,ModCellVMinCell:uint16:1::1:true,ModCellVAvg:uint16:1:CellV_SF:1:true,ModCellTmpMax:int16:1:ModTmp_SF:1:true,ModCellTmpMaxCell:uint16:1::1:true,ModCellTmpMin:int16:1:ModTmp_SF:1:true,ModCellTmpMinCell:uint16:1::1:true,ModCellTmpAvg:int16:1:ModTmp_SF:1:true,Pad5:pad:1::1:true,Pad6:pad:1::1:true,Pad7:pad:1::1:true", ",")
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s:%d:%t", point.name, point.pointType, point.size, point.scaleFactor, point.repeatIndex, point.repeated)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 804 signature=%q want=%q", got, want)
+	}
+	words := v2DERModelWords(t, registry, 804, 62, map[string][]uint16{
+		"NMod":   {1},
+		"SetEna": {1},
+		"SetCon": {2},
+	})
+	key := SunSpecDecoderKey{ModelID: 804, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 804, ModelLength: 62}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 804 observed state geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	for _, fieldID := range []string{"sunspec.der.v2.804.Idx", "sunspec.der.v2.804.SetEna", "sunspec.der.v2.804.SetCon"} {
+		if _, ok := decoded.Fact(fieldID); !ok {
+			t.Fatalf("Model 804 observed fact %q absent", fieldID)
+		}
 	}
 }
 

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -145,6 +145,64 @@ func TestSunSpecV2BESSBankRequiresExactDynamicDefinitions(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2BESSStringRequiresExactDynamicDefinitions(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []struct {
+		modules, length uint16
+	}{
+		{0, 46},
+		{2, 78},
+		{4093, 65534},
+	} {
+		key := SunSpecDecoderKey{ModelID: 804, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+		definition, ok := registry.definition(key)
+		if !ok || len(definition.points) == 0 {
+			t.Fatalf("Model 804/%d dynamic definition=%t points=%d", want.length, ok, len(definition.points))
+		}
+		if want.modules == 4093 {
+			continue
+		}
+		words := make([]uint16, int(want.length)+2)
+		words[0], words[1], words[3] = 804, want.length, want.modules
+		spans := []SunSpecSourceSpan{{LogicalViewID: 12, PDUOffset: 0, WordCount: want.length + 2}}
+		decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 804, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: spans})
+		if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+			t.Fatalf("Model 804/%d geometry=%t qualifies=%t err=%v", want.length, decoded.GeometryValid(), decoded.Qualifies(), err)
+		}
+		if want.modules == 2 {
+			counts := map[uint16]int{}
+			for _, fact := range decoded.Facts() {
+				if fact.Repeated && fact.GroupID == "module" {
+					counts[fact.RepeatIndex]++
+				}
+			}
+			if counts[1] != 16 || counts[2] != 16 || len(counts) != 2 || !reflect.DeepEqual(decoded.SourceSpans(), spans) {
+				t.Fatalf("Model 804 repeat facts=%v spans=%#v", counts, decoded.SourceSpans())
+			}
+		}
+	}
+	for _, want := range []struct {
+		name          string
+		length, count uint16
+	}{
+		{"count mismatch", 78, 1},
+		{"sentinel", 78, 0xffff},
+	} {
+		t.Run(want.name, func(t *testing.T) {
+			key := SunSpecDecoderKey{ModelID: 804, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+			words := make([]uint16, int(want.length)+2)
+			words[0], words[1], words[3] = 804, want.length, want.count
+			decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 804, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+			if err != nil || decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) {
+				t.Fatalf("Model 804 %s geometry=%t qualifies=%t facts=%d err=%v", want.name, decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
+			}
+		})
+	}
+}
+
 func TestSunSpecV2BESSBankRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {


### PR DESCRIPTION
Closes #79

## RED-first checkpoint

The initial test requires V2 Model 804 dynamic definitions for zero, two, and maximum modules. It fails on the base because no Model 804 decoder definition exists. GitHub RED observed at `100c5a8fa2a079248c36ea560f696336197476b0` in run 32836423951.

## Docs gate

Merged docs gate: `7a9a704608f42c28f199fc638bf4e05da14a7b2e`. It distinguishes the valid synthetic offline 65,536-word maximum from terminal-qualified live-chain and acquisition behavior.

## Frozen scope

- `sunspec_models_der_v2.go`
- `sunspec_models_der_v2_test.go`
- `sunspec_decoder.go`
- `sunspec_decoder_test.go`
- `sunspec_model_catalog.go`
- `sunspec_model_catalog_test.go`
- `sunspec_chain_plan_test.go`
- `THIRD_PARTY_NOTICES.md`

`sunSpecModelDefinition` aggregate extent may widen only enough to accept the final point at offset 65535 and total extent 65536 for isolated offline decode. Core/chain address, terminal-marker and MaxTotalWords guards remain unchanged.

V2-only, offline observed state. No profile/catalog/runtime/vendor/transport/gateway/live I/O/write/send behavior. Model 803 stays independent; 805-809 and 704-712 remain opaque.