### PR TITLE
SunSpec V2: add offline BESS module Model 805

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,8 +3,8 @@
 ## SunSpec/models
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
-714 variable geometry, 715/7, 802/62, 803 variable geometry, and 804 variable
-geometry in
+714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
+geometry, and 805/42 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -261,6 +261,46 @@ func TestSunSpecV2ChainRetainsFixedBESSBaseBlock(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2ChainRetainsFixedBESSModuleBlock(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 256, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 805, 42)
+	words = append(words, make([]uint16, 42)...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 805, ModelLength: 42}) {
+		t.Fatalf("BESS module occurrence=%#v", occurrences)
+	}
+}
+
 func TestSunSpecV2ChainRetainsDistinctBESSBankOccurrences(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -123,6 +123,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 715, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
 		}
 		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -61,6 +61,7 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 		{713, 7, derStorageCapacityV2SunSpecPoints()},
 		{715, 7, derControlV2SunSpecPoints()},
 		{802, 62, bessBaseV2SunSpecPoints()},
+		{805, 42, bessModuleV2SunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -74,7 +74,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 7 {
+	if len(definitions) != 8 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
 	want := []SunSpecDecoderKey{
@@ -85,6 +85,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 713, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 715, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
 	}
 	for index, key := range want {
 		if definitions[index].key != key || definitions[index].compatibility {
@@ -102,6 +103,8 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 801, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 802, ModelLength: 61, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 805, ModelLength: 41, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -413,6 +413,39 @@ func bessBaseV2SunSpecPoints() []sunSpecPointDefinition {
 	}
 }
 
+func bessModuleV2SunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		v2DERPoint("805", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("805", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("805", "StrIdx", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "ModIdx", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "NCell", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "SoC", SunSpecTypeUint16, "%", "SoC_SF", false),
+		v2DERPoint("805", "DoD", SunSpecTypeUint16, "%", "DoD_SF", false),
+		v2DERPoint("805", "SoH", SunSpecTypeUint16, "%", "SoH_SF", false),
+		v2DERPoint("805", "NCyc", SunSpecTypeUint32, "", "", false),
+		v2DERPoint("805", "V", SunSpecTypeUint16, "V", "V_SF", false),
+		v2DERPoint("805", "CellVMax", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("805", "CellVMaxCell", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "CellVMin", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("805", "CellVMinCell", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "CellVAvg", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("805", "CellTmpMax", SunSpecTypeInt16, "C", "Tmp_SF", false),
+		v2DERPoint("805", "CellTmpMaxCell", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "CellTmpMin", SunSpecTypeInt16, "C", "Tmp_SF", false),
+		v2DERPoint("805", "CellTmpMinCell", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("805", "CellTmpAvg", SunSpecTypeInt16, "C", "Tmp_SF", false),
+		v2DERPoint("805", "NCellBal", SunSpecTypeUint16, "", "", false),
+		v2DERStringPoint("805", "SN", 16),
+		v2DERPoint("805", "SoC_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("805", "SoH_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("805", "DoD_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("805", "V_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("805", "CellV_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("805", "Tmp_SF", SunSpecTypeScaleFactor, "", "", false),
+	}
+}
+
 func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
 	symbols := map[uint64]string(nil)
 	if model == "701" && name == "ACType" {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -47,6 +47,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			{713, 7, 9, []string{"ID", "L", "WHRtg"}, "Pct_SF"},
 			{715, 7, 7, []string{"ID", "L", "LocRemCtl"}, "OpCtl"},
 			{802, 62, 58, []string{"ID", "L", "AHRtg"}, "W_SF"},
+			{805, 42, 28, []string{"ID", "L", "StrIdx"}, "Tmp_SF"},
 		} {
 			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
 			if !ok || len(definition.points) != want.points {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -19,7 +19,8 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"https://github.com/sunspec/models",
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
-			"714 variable geometry, 715/7, 802/62, 803 variable geometry, and 804 variable",
+			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
+			"geometry, and 805/42",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -81,6 +82,39 @@ func TestSunSpecV2BESSBaseRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Model 802 signature=%q want=%q", got, want)
+	}
+}
+
+func TestSunSpecV2BESSModuleRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 805/42 definition absent")
+	}
+	want := strings.Split("ID:uint16:1:,L:uint16:1:,StrIdx:uint16:1:,ModIdx:uint16:1:,NCell:uint16:1:,SoC:uint16:1:SoC_SF,DoD:uint16:1:DoD_SF,SoH:uint16:1:SoH_SF,NCyc:uint32:2:,V:uint16:1:V_SF,CellVMax:uint16:1:CellV_SF,CellVMaxCell:uint16:1:,CellVMin:uint16:1:CellV_SF,CellVMinCell:uint16:1:,CellVAvg:uint16:1:CellV_SF,CellTmpMax:int16:1:Tmp_SF,CellTmpMaxCell:uint16:1:,CellTmpMin:int16:1:Tmp_SF,CellTmpMinCell:uint16:1:,CellTmpAvg:int16:1:Tmp_SF,NCellBal:uint16:1:,SN:string:16:,SoC_SF:sunssf:1:,SoH_SF:sunssf:1:,DoD_SF:sunssf:1:,V_SF:sunssf:1:,CellV_SF:sunssf:1:,Tmp_SF:sunssf:1:", ",")
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s", point.name, point.pointType, point.size, point.scaleFactor)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 805 signature=%q want=%q", got, want)
+	}
+	words := v2DERModelWords(t, registry, 805, 42, map[string][]uint16{
+		"StrIdx": {1}, "ModIdx": {2}, "NCell": {12}, "SoC": {74}, "SoC_SF": {0},
+		"SN": stringWords("synthetic", 16),
+	})
+	key := SunSpecDecoderKey{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 805, ModelLength: 42}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 805 observed state geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	for _, fieldID := range []string{"sunspec.der.v2.805.StrIdx", "sunspec.der.v2.805.ModIdx", "sunspec.der.v2.805.SN"} {
+		if _, ok := decoded.Fact(fieldID); !ok {
+			t.Fatalf("Model 805 observed fact %q absent", fieldID)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #81

## RED-first checkpoint

The initial test requires V2 Model 805/42. It fails on the base because the fixed decoder definition is absent.

## Docs gate

Merged docs gate: `254898e197f5f5f39aad74b45f857a0d62e3ae48`.

## Frozen scope

- `sunspec_models_der_v2.go`
- `sunspec_models_der_v2_test.go`
- `sunspec_model_catalog.go`
- `sunspec_model_catalog_test.go`
- `sunspec_decoder_test.go`
- `sunspec_chain_plan_test.go`
- `THIRD_PARTY_NOTICES.md`

V2-only, offline observed state. No runtime/profile/catalog admission, vendor, transport, gateway, live I/O, write, or send behavior. Models 806-809 remain opaque.