### PR TITLE
SunSpec V2: add offline Flow Battery Model 806

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,7 +4,7 @@
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
 714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
-geometry, and 805/42 in
+geometry, 805/42, and 806/1 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -301,6 +301,45 @@ func TestSunSpecV2ChainRetainsFixedBESSModuleBlock(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2ChainRetainsFixedFlowBatteryBlock(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 806, 1, 7)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 806, ModelLength: 1}) {
+		t.Fatalf("flow battery occurrence=%#v", occurrences)
+	}
+}
+
 func TestSunSpecV2ChainRetainsDistinctBESSBankOccurrences(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -124,6 +124,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 715, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		}
 		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -62,6 +62,7 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 		{715, 7, derControlV2SunSpecPoints()},
 		{802, 62, bessBaseV2SunSpecPoints()},
 		{805, 42, bessModuleV2SunSpecPoints()},
+		{806, 1, flowBatteryV2SunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -74,7 +74,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 8 {
+	if len(definitions) != 9 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
 	want := []SunSpecDecoderKey{
@@ -86,6 +86,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 715, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 	}
 	for index, key := range want {
 		if definitions[index].key != key || definitions[index].compatibility {
@@ -104,7 +105,8 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 802, ModelLength: 61, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 805, ModelLength: 41, SchemaRevision: SunSpecModelsRevisionV2},
-		{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 806, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -446,6 +446,14 @@ func bessModuleV2SunSpecPoints() []sunSpecPointDefinition {
 	}
 }
 
+func flowBatteryV2SunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		v2DERPoint("806", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("806", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("806", "BatTBD", SunSpecTypeUint16, "", "", false),
+	}
+}
+
 func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
 	symbols := map[uint64]string(nil)
 	if model == "701" && name == "ACType" {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -49,6 +49,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			{715, 7, 7, []string{"ID", "L", "LocRemCtl"}, "OpCtl"},
 			{802, 62, 58, []string{"ID", "L", "AHRtg"}, "W_SF"},
 			{805, 42, 28, []string{"ID", "L", "StrIdx"}, "Tmp_SF"},
+			{806, 1, 3, []string{"ID", "L", "BatTBD"}, "BatTBD"},
 		} {
 			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
 			if !ok || len(definition.points) != want.points {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -20,7 +20,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
 			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
-			"geometry, and 805/42",
+			"geometry, 805/42, and 806/1",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -116,6 +116,34 @@ func TestSunSpecV2BESSModuleRetainsPinnedPointOrderTypesAndScales(t *testing.T) 
 		if _, ok := decoded.Fact(fieldID); !ok {
 			t.Fatalf("Model 805 observed fact %q absent", fieldID)
 		}
+	}
+}
+
+func TestSunSpecV2FlowBatteryRetainsStructuralObservedState(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 806/1 definition absent")
+	}
+	want := []string{"ID:uint16:1::0:false", "L:uint16:1::0:false", "BatTBD:uint16:1::0:false"}
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s:%d:%t", point.name, point.pointType, point.size, point.scaleFactor, point.repeatIndex, point.repeated)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 806 signature=%q want=%q", got, want)
+	}
+	words := v2DERModelWords(t, registry, 806, 1, map[string][]uint16{"BatTBD": {7}})
+	key := SunSpecDecoderKey{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 806, ModelLength: 1}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 806 observed state geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	if _, ok := decoded.Fact("sunspec.der.v2.806.BatTBD"); !ok {
+		t.Fatal("Model 806 structural observed fact absent")
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the V2-only offline decoder definition for standard SunSpec Flow Battery Model 806/1, behind docs merge `0c4e674ea69aeef89f69b6d2e4184fdde421e1d1`.

## TDD

RED commit requires `806/1` before its definition is added.

## Boundary

Structural observed state only. No repeated group, parent-child inference, write/send, runtime, vendor/catalog activation, transport, gateway, or live I/O.

## Validation

- `HELIANTHUS_EXTERNAL_LINT_JOB=1 ./scripts/ci_local.sh`
- Fresh exact-HEAD review before merge.