### PR TITLE
SunSpec V2: add offline Flow Battery String Model 807

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,7 +4,7 @@
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
 714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
-geometry, 805/42, and 806/1 in
+geometry, 805/42, 806/1, and 807/34 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -340,6 +340,46 @@ func TestSunSpecV2ChainRetainsFixedFlowBatteryBlock(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2ChainRetainsFixedFlowBatteryStringBlock(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 807, 34)
+	words = append(words, make([]uint16, 34)...)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 807, ModelLength: 34}) {
+		t.Fatalf("flow battery string occurrence=%#v", occurrences)
+	}
+}
+
 func TestSunSpecV2ChainRetainsDistinctBESSBankOccurrences(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -125,6 +125,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
 		}
 		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -63,6 +63,7 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 		{802, 62, bessBaseV2SunSpecPoints()},
 		{805, 42, bessModuleV2SunSpecPoints()},
 		{806, 1, flowBatteryV2SunSpecPoints()},
+		{807, 34, flowBatteryStringV2SunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -74,7 +74,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 9 {
+	if len(definitions) != 10 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
 	want := []SunSpecDecoderKey{
@@ -87,6 +87,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 802, ModelLength: 62, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
 	}
 	for index, key := range want {
 		if definitions[index].key != key || definitions[index].compatibility {
@@ -106,7 +107,8 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 803, ModelLength: 27, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 805, ModelLength: 41, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 806, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
-		{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 807, ModelLength: 33, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -454,6 +454,43 @@ func flowBatteryV2SunSpecPoints() []sunSpecPointDefinition {
 	}
 }
 
+func flowBatteryStringV2SunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		v2DERPoint("807", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("807", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("807", "Idx", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "NMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "NModCon", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "ModVMax", SunSpecTypeUint16, "V", "ModV_SF", false),
+		v2DERPoint("807", "ModVMaxMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "ModVMin", SunSpecTypeUint16, "V", "ModV_SF", false),
+		v2DERPoint("807", "ModVMinMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "ModVAvg", SunSpecTypeUint16, "V", "ModV_SF", false),
+		v2DERPoint("807", "CellVMax", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("807", "CellVMaxMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "CellVMaxStk", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "CellVMin", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("807", "CellVMinMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "CellVMinStk", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "CellVAvg", SunSpecTypeUint16, "V", "CellV_SF", false),
+		v2DERPoint("807", "TmpMax", SunSpecTypeInt16, "C", "Tmp_SF", false),
+		v2DERPoint("807", "TmpMaxMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "TmpMin", SunSpecTypeInt16, "C", "Tmp_SF", false),
+		v2DERPoint("807", "TmpMinMod", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("807", "TmpAvg", SunSpecTypeInt16, "C", "Tmp_SF", false),
+		v2DERPoint("807", "Evt1", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("807", "Evt2", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("807", "EvtVnd1", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("807", "EvtVnd2", SunSpecTypeBitfield32, "", "", false),
+		v2DERPoint("807", "ModV_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("807", "CellV_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("807", "Tmp_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("807", "SoC_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("807", "OCV_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("807", "Pad1", SunSpecTypePad, "", "", false),
+	}
+}
+
 func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
 	symbols := map[uint64]string(nil)
 	if model == "701" && name == "ACType" {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -20,7 +20,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
 			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
-			"geometry, 805/42, and 806/1",
+			"geometry, 805/42, 806/1, and 807/34",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -145,6 +145,53 @@ func TestSunSpecV2FlowBatteryRetainsStructuralObservedState(t *testing.T) {
 	}
 	if _, ok := decoded.Fact("sunspec.der.v2.806.BatTBD"); !ok {
 		t.Fatal("Model 806 structural observed fact absent")
+	}
+}
+
+func TestSunSpecV2FlowBatteryStringRetainsObservedStaticBase(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 807/34 definition absent")
+	}
+	if len(definition.points) != 32 {
+		t.Fatalf("Model 807 points=%d", len(definition.points))
+	}
+	want := strings.Split("ID:uint16:1:,L:uint16:1:,Idx:uint16:1:,NMod:uint16:1:,NModCon:uint16:1:,ModVMax:uint16:1:ModV_SF,ModVMaxMod:uint16:1:,ModVMin:uint16:1:ModV_SF,ModVMinMod:uint16:1:,ModVAvg:uint16:1:ModV_SF,CellVMax:uint16:1:CellV_SF,CellVMaxMod:uint16:1:,CellVMaxStk:uint16:1:,CellVMin:uint16:1:CellV_SF,CellVMinMod:uint16:1:,CellVMinStk:uint16:1:,CellVAvg:uint16:1:CellV_SF,TmpMax:int16:1:Tmp_SF,TmpMaxMod:uint16:1:,TmpMin:int16:1:Tmp_SF,TmpMinMod:uint16:1:,TmpAvg:int16:1:Tmp_SF,Evt1:bitfield32:2:,Evt2:bitfield32:2:,EvtVnd1:bitfield32:2:,EvtVnd2:bitfield32:2:,ModV_SF:sunssf:1:,CellV_SF:sunssf:1:,Tmp_SF:sunssf:1:,SoC_SF:sunssf:1:,OCV_SF:sunssf:1:,Pad1:pad:1:", ",")
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s", point.name, point.pointType, point.size, point.scaleFactor)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 807 signature=%q want=%q", got, want)
+	}
+	for _, point := range definition.points {
+		if point.repeated || point.repeatIndex != 0 {
+			t.Fatalf("Model 807 materialized group point=%#v", point)
+		}
+	}
+	words := v2DERModelWords(t, registry, 807, 34, map[string][]uint16{
+		"Idx": {1}, "NMod": {2}, "NModCon": {1}, "ModVMax": {600}, "ModVMin": {500},
+		"TmpMax": {25}, "TmpMin": {10}, "TmpAvg": {18}, "Evt1": {0x8000, 0},
+		"ModV_SF": {0}, "CellV_SF": {0}, "Tmp_SF": {0}, "SoC_SF": {0}, "OCV_SF": {0},
+	})
+	key := SunSpecDecoderKey{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 807, ModelLength: 34}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 807 observed state geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	for _, fieldID := range []string{"sunspec.der.v2.807.Idx", "sunspec.der.v2.807.NMod", "sunspec.der.v2.807.ModVMax", "sunspec.der.v2.807.Evt1"} {
+		if _, ok := decoded.Fact(fieldID); !ok {
+			t.Fatalf("Model 807 observed fact %q absent", fieldID)
+		}
+	}
+	for _, fieldID := range []string{"sunspec.der.v2.807.ModSetEna", "sunspec.der.v2.807.ModSetCon"} {
+		if _, ok := decoded.Fact(fieldID); ok {
+			t.Fatalf("Model 807 zero-count module field %q materialized", fieldID)
+		}
 	}
 }
 

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -50,6 +50,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			{802, 62, 58, []string{"ID", "L", "AHRtg"}, "W_SF"},
 			{805, 42, 28, []string{"ID", "L", "StrIdx"}, "Tmp_SF"},
 			{806, 1, 3, []string{"ID", "L", "BatTBD"}, "BatTBD"},
+			{807, 34, 32, []string{"ID", "L", "Idx"}, "Pad1"},
 		} {
 			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
 			if !ok || len(definition.points) != want.points {


### PR DESCRIPTION
## Summary

Implements the V2-only offline static decoder definition for standard SunSpec Flow Battery String Model 807/34, behind docs merge `041a9b8f1aa3d94840e22df199321b074f47acc3`.

## TDD

RED commit requires `807/34` before its definition is added.

## Boundary

Static base only. The zero-count module group remains unmaterialized; no hierarchy, control, write/send, runtime, vendor/catalog activation, transport, gateway, or live I/O.

## Validation

- `HELIANTHUS_EXTERNAL_LINT_JOB=1 ./scripts/ci_local.sh`
- Fresh exact-HEAD review before merge.