### PR TITLE
SunSpec V2: add offline Flow Battery Module Model 808

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,7 +4,7 @@
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
 714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
-geometry, 805/42, 806/1, and 807/34 in
+geometry, 805/42, 806/1, 807/34, and 808/1 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -380,6 +380,45 @@ func TestSunSpecV2ChainRetainsFixedFlowBatteryStringBlock(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2ChainRetainsFixedFlowBatteryModuleBlock(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 808, 1, 9)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 808, ModelLength: 1}) {
+		t.Fatalf("flow battery module occurrence=%#v", occurrences)
+	}
+}
+
 func TestSunSpecV2ChainRetainsDistinctBESSBankOccurrences(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -126,6 +126,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		}
 		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -64,6 +64,7 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 		{805, 42, bessModuleV2SunSpecPoints()},
 		{806, 1, flowBatteryV2SunSpecPoints()},
 		{807, 34, flowBatteryStringV2SunSpecPoints()},
+		{808, 1, flowBatteryModuleV2SunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -74,7 +74,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 10 {
+	if len(definitions) != 11 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
 	want := []SunSpecDecoderKey{
@@ -88,6 +88,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 805, ModelLength: 42, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 	}
 	for index, key := range want {
 		if definitions[index].key != key || definitions[index].compatibility {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -109,7 +109,8 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 805, ModelLength: 41, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 806, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 807, ModelLength: 33, SchemaRevision: SunSpecModelsRevisionV2},
-		{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 808, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -491,6 +491,14 @@ func flowBatteryStringV2SunSpecPoints() []sunSpecPointDefinition {
 	}
 }
 
+func flowBatteryModuleV2SunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		v2DERPoint("808", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("808", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("808", "ModuleTBD", SunSpecTypeUint16, "", "", false),
+	}
+}
+
 func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
 	symbols := map[uint64]string(nil)
 	if model == "701" && name == "ACType" {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -20,7 +20,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
 			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
-			"geometry, 805/42, 806/1, and 807/34",
+			"geometry, 805/42, 806/1, 807/34, and 808/1",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -51,6 +51,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			{805, 42, 28, []string{"ID", "L", "StrIdx"}, "Tmp_SF"},
 			{806, 1, 3, []string{"ID", "L", "BatTBD"}, "BatTBD"},
 			{807, 34, 32, []string{"ID", "L", "Idx"}, "Pad1"},
+			{808, 1, 3, []string{"ID", "L", "ModuleTBD"}, "ModuleTBD"},
 		} {
 			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
 			if !ok || len(definition.points) != want.points {
@@ -192,6 +193,37 @@ func TestSunSpecV2FlowBatteryStringRetainsObservedStaticBase(t *testing.T) {
 		if _, ok := decoded.Fact(fieldID); ok {
 			t.Fatalf("Model 807 zero-count module field %q materialized", fieldID)
 		}
+	}
+}
+
+func TestSunSpecV2FlowBatteryModuleRetainsObservedStaticBase(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 808/1 definition absent")
+	}
+	want := []string{"ID:uint16:1::0:false", "L:uint16:1::0:false", "ModuleTBD:uint16:1::0:false"}
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s:%d:%t", point.name, point.pointType, point.size, point.scaleFactor, point.repeatIndex, point.repeated)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 808 signature=%q want=%q", got, want)
+	}
+	words := v2DERModelWords(t, registry, 808, 1, map[string][]uint16{"ModuleTBD": {9}})
+	key := SunSpecDecoderKey{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 808, ModelLength: 1}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 808 observed state geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	if _, ok := decoded.Fact("sunspec.der.v2.808.ModuleTBD"); !ok {
+		t.Fatal("Model 808 structural observed fact absent")
+	}
+	if _, ok := decoded.Fact("sunspec.der.v2.808.StackTBD"); ok {
+		t.Fatal("Model 808 zero-count stack field materialized")
 	}
 }
 


### PR DESCRIPTION
Closes #87

## Docs gate
`af70911de20dca952d04399380e83164070583de`

## RED evidence
`HEAD` contains tests only and fails locally because 808/1 is not defined, not admitted in the static registry, and not retained by the chain.

## Scope
V2-only Model 808/1 structural observation. The zero-count stack group must not materialize. Model 809 remains opaque.

## Excluded
Control/send paths, runtime/catalog admission, vendor behavior, transport, gateway, and live I/O.