### PR TITLE
SunSpec V2: add offline Flow Battery Stack Model 809

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -4,7 +4,7 @@
 
 The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
 714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
-geometry, 805/42, 806/1, 807/34, and 808/1 in
+geometry, 805/42, 806/1, 807/34, 808/1, and 809/1 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:
 
 - Project: `SunSpec/models`

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -419,6 +419,45 @@ func TestSunSpecV2ChainRetainsFixedFlowBatteryModuleBlock(t *testing.T) {
 	}
 }
 
+func TestSunSpecV2ChainRetainsFixedFlowBatteryStackBlock(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 2},
+		DecoderKeys:    registry.DecoderKeys(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	if _, err := admitNext(t, chain, &id, []uint16{0x5375, 0x6e53}); err != nil {
+		t.Fatal(err)
+	}
+	words := append([]uint16{1, 66}, make([]uint16, 66)...)
+	words = append(words, 809, 1, 11)
+	for len(words) > 0 {
+		request := chain.NextRequests()[0]
+		chunk := words[:request.WordCount()]
+		words = words[request.WordCount():]
+		if _, err := admitNext(t, chain, &id, chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admitNext(t, chain, &id, []uint16{0xffff, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) != 2 || occurrences[1].Disposition != SunSpecChainDispositionAdmitted || occurrences[1].WireKey != (SunSpecWireKey{ModelID: 809, ModelLength: 1}) {
+		t.Fatalf("flow battery stack occurrence=%#v", occurrences)
+	}
+}
+
 func TestSunSpecV2ChainRetainsDistinctBESSBankOccurrences(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -127,6 +127,7 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+			{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		}
 		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))

--- a/sunspec_model_catalog.go
+++ b/sunspec_model_catalog.go
@@ -65,6 +65,7 @@ func standardSunSpecModelDefinitionsV2(revision SunSpecSchemaRevision) ([]sunSpe
 		{806, 1, flowBatteryV2SunSpecPoints()},
 		{807, 34, flowBatteryStringV2SunSpecPoints()},
 		{808, 1, flowBatteryModuleV2SunSpecPoints()},
+		{809, 1, flowBatteryStackV2SunSpecPoints()},
 	} {
 		definitions, err = appendSunSpecDefinition(definitions, revision, model.id, model.length, SunSpecTopologyNone, false, model.points)
 		if err != nil {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -74,7 +74,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("V2 catalog: %v", err)
 	}
-	if len(definitions) != 11 {
+	if len(definitions) != 12 {
 		t.Fatalf("V2 definitions=%d", len(definitions))
 	}
 	want := []SunSpecDecoderKey{
@@ -89,6 +89,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 806, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 807, ModelLength: 34, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 	}
 	for index, key := range want {
 		if definitions[index].key != key || definitions[index].compatibility {

--- a/sunspec_model_catalog_test.go
+++ b/sunspec_model_catalog_test.go
@@ -111,7 +111,7 @@ func TestSunSpecV2CatalogContainsOnlyCurrentAdmittedModels(t *testing.T) {
 		{ModelID: 806, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 807, ModelLength: 33, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 808, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
-		{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
+		{ModelID: 809, ModelLength: 2, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 704, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2},
 		{ModelID: 712, ModelLength: 14, SchemaRevision: SunSpecModelsRevisionV2},
 	} {

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -499,6 +499,14 @@ func flowBatteryModuleV2SunSpecPoints() []sunSpecPointDefinition {
 	}
 }
 
+func flowBatteryStackV2SunSpecPoints() []sunSpecPointDefinition {
+	return []sunSpecPointDefinition{
+		v2DERPoint("809", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("809", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("809", "StackTBD", SunSpecTypeUint16, "", "", false),
+	}
+}
+
 func v2DERPoint(model, name string, pointType SunSpecPointType, unit, scale string, mandatory bool) sunSpecPointDefinition {
 	symbols := map[uint64]string(nil)
 	if model == "701" && name == "ACType" {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -20,7 +20,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
 			"Models 701/153, 702/50, 703/17, 713/7,",
 			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
-			"geometry, 805/42, 806/1, 807/34, and 808/1",
+			"geometry, 805/42, 806/1, 807/34, 808/1, and 809/1",
 			"modified by Helianthus",
 			"Apache License",
 			"Version 2.0, January 2004",
@@ -52,6 +52,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			{806, 1, 3, []string{"ID", "L", "BatTBD"}, "BatTBD"},
 			{807, 34, 32, []string{"ID", "L", "Idx"}, "Pad1"},
 			{808, 1, 3, []string{"ID", "L", "ModuleTBD"}, "ModuleTBD"},
+			{809, 1, 3, []string{"ID", "L", "StackTBD"}, "StackTBD"},
 		} {
 			definition, ok := registry.definition(SunSpecDecoderKey{ModelID: want.id, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2})
 			if !ok || len(definition.points) != want.points {
@@ -224,6 +225,37 @@ func TestSunSpecV2FlowBatteryModuleRetainsObservedStaticBase(t *testing.T) {
 	}
 	if _, ok := decoded.Fact("sunspec.der.v2.808.StackTBD"); ok {
 		t.Fatal("Model 808 zero-count stack field materialized")
+	}
+}
+
+func TestSunSpecV2FlowBatteryStackRetainsObservedStaticBase(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 809/1 definition absent")
+	}
+	want := []string{"ID:uint16:1::0:false", "L:uint16:1::0:false", "StackTBD:uint16:1::0:false"}
+	got := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		got[index] = fmt.Sprintf("%s:%s:%d:%s:%d:%t", point.name, point.pointType, point.size, point.scaleFactor, point.repeatIndex, point.repeated)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Model 809 signature=%q want=%q", got, want)
+	}
+	words := v2DERModelWords(t, registry, 809, 1, map[string][]uint16{"StackTBD": {11}})
+	key := SunSpecDecoderKey{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 809, ModelLength: 1}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() {
+		t.Fatalf("Model 809 observed state geometry=%t qualifies=%t err=%v", decoded.GeometryValid(), decoded.Qualifies(), err)
+	}
+	if _, ok := decoded.Fact("sunspec.der.v2.809.StackTBD"); !ok {
+		t.Fatal("Model 809 structural observed fact absent")
+	}
+	if _, ok := decoded.Fact("sunspec.der.v2.809.CellTBD"); ok {
+		t.Fatal("Model 809 zero-count cell field materialized")
 	}
 }
 


### PR DESCRIPTION
Closes #89

## Docs gate
`8012dd0ada8abe6f1944068ef7b499655db5c993`

## RED evidence
`HEAD` contains tests only and fails locally because 809/1 is not defined, catalog-admitted, or retained by the chain.

## Scope
V2-only Model 809/1 structural observation. The zero-count cell group must not materialize; no relationship to 803 through 808.

## Excluded
Control/send, runtime/catalog admission, vendor behavior, transport, gateway, and live I/O.