### PR TITLE
Add bounded offline SunSpec V2 Model 707 decoder

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 ## SunSpec/models
 
-The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 713/7,
+The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 707 variable geometry, 713/7,
 714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
 geometry, 805/42, 806/1, 807/34, 808/1, and 809/1 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -109,7 +109,7 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	case SunSpecModelsRevisionV1:
 		capacity += 3277 + 89561
 	case SunSpecModelsRevisionV2:
-		capacity += int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1 + int(maxSunSpecBESSModules) + 1
+		capacity += int(maxSunSpecDERTripLVCurves) + 1 + int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1 + int(maxSunSpecBESSModules) + 1
 	}
 	keys := make([]SunSpecDecoderKey, 0, capacity)
 	for _, definition := range definitions {
@@ -122,6 +122,9 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 		}
 		keys = append(keys, environmentalSunSpecDecoderKeys(revision)...)
 	case SunSpecModelsRevisionV2:
+		for curves := uint32(0); curves <= maxSunSpecDERTripLVCurves; curves++ {
+			keys = append(keys, SunSpecDecoderKey{ModelID: 707, ModelLength: uint16(7 + curves), SchemaRevision: revision})
+		}
 		for ports := uint32(0); ports <= maxSunSpecDERPorts; ports++ {
 			keys = append(keys, SunSpecDecoderKey{ModelID: 714, ModelLength: uint16(18 + 25*ports), SchemaRevision: revision})
 		}
@@ -163,6 +166,8 @@ func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelD
 		var resolved sunSpecModelDefinition
 		var err error
 		switch key.ModelID {
+		case 707:
+			resolved, err = derTripLVV2SunSpecDefinition(key.ModelLength)
 		case 714:
 			resolved, err = derDCMeasureV2SunSpecDefinition(key.ModelLength)
 		case 803:

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -129,15 +129,22 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		}
-		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
+		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERTripLVCurves)+1+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))
 		}
 		static := make(map[SunSpecDecoderKey]bool, len(wantV2Static))
 		for _, key := range wantV2Static {
 			static[key] = true
 		}
-		dynamicDER, dynamicBESSBanks, dynamicBESSStrings := 0, 0, 0
+		dynamicTripLV, dynamicDER, dynamicBESSBanks, dynamicBESSStrings := 0, 0, 0, 0
 		for _, key := range v2Keys {
+			if key.ModelID == 707 {
+				if key.ModelLength < 7 || uint32(key.ModelLength)-7 > maxSunSpecDERTripLVCurves {
+					t.Fatalf("V2 Model 707 dynamic key=%#v", key)
+				}
+				dynamicTripLV++
+				continue
+			}
 			if key.ModelID == 714 {
 				if key.ModelLength < 18 || (key.ModelLength-18)%25 != 0 {
 					t.Fatalf("V2 dynamic key=%#v", key)
@@ -164,8 +171,11 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			}
 			delete(static, key)
 		}
-		if dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESSBanks != int(maxSunSpecBESSStrings)+1 || dynamicBESSStrings != int(maxSunSpecBESSModules)+1 || len(static) != 0 {
-			t.Fatalf("V2 DER dynamic=%d BESS banks=%d strings=%d missing static=%#v", dynamicDER, dynamicBESSBanks, dynamicBESSStrings, static)
+		if dynamicTripLV != int(maxSunSpecDERTripLVCurves)+1 || dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESSBanks != int(maxSunSpecBESSStrings)+1 || dynamicBESSStrings != int(maxSunSpecBESSModules)+1 || len(static) != 0 {
+			t.Fatalf("V2 Model 707=%d DER=%d BESS banks=%d strings=%d missing static=%#v", dynamicTripLV, dynamicDER, dynamicBESSBanks, dynamicBESSStrings, static)
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 707, ModelLength: 65535, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+			t.Fatal("V2 resolved Model 707 above the offline extent boundary")
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved V1 compatibility Common")

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -6,6 +6,48 @@ const maxSunSpecDERPorts uint32 = (65535 - 18) / 25
 const maxSunSpecBESSStrings uint32 = (65535 - 26) / 32
 const maxSunSpecBESSModules uint32 = (65535 - 46) / 16
 
+// Model 707 with NCrvSet=65528 has 65537 words including its header. The
+// bounded offline decoder intentionally stops one word earlier.
+const maxSunSpecDERTripLVCurves uint32 = 65534 - 7
+
+func derTripLVV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
+	if length < 7 {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 707 geometry is invalid")
+	}
+	curves := uint32(length) - 7
+	if curves > maxSunSpecDERTripLVCurves {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 707 curve count exceeds offline geometry")
+	}
+	points := make([]sunSpecPointDefinition, 0, 9+int(curves))
+	points = append(points,
+		v2DERPoint("707", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("707", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("707", "Ena", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("707", "AdptCrvReq", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("707", "AdptCrvRslt", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("707", "NPt", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("707", "NCrvSet", SunSpecTypeCount, "", "", false),
+		v2DERPoint("707", "V_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("707", "Tms_SF", SunSpecTypeScaleFactor, "", "", false),
+	)
+	for curve := uint32(1); curve <= curves; curve++ {
+		point := v2DERPoint("707", "ReadOnly", SunSpecTypeEnum16, "", "", false)
+		point.groupID = "curve"
+		point.repeatIndex = uint16(curve)
+		point.repeated = true
+		points = append(points, point)
+	}
+	definitions, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV2, 707, length, SunSpecTopologyNone, false, points)
+	if err != nil {
+		return sunSpecModelDefinition{}, err
+	}
+	definition := definitions[0]
+	definition.geometry = func(words []uint16) bool {
+		return len(words) == int(length)+2 && len(words) > 6 && words[6] != 0xffff && uint32(words[6]) <= maxSunSpecDERTripLVCurves && uint32(length) == 7+uint32(words[6])
+	}
+	return definition, nil
+}
+
 func derDCMeasureV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
 	if length < 18 || (uint32(length)-18)%25 != 0 {
 		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 714 geometry is invalid")

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -18,7 +18,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"SunSpec/models",
 			"https://github.com/sunspec/models",
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
-			"Models 701/153, 702/50, 703/17, 713/7,",
+			"Models 701/153, 702/50, 703/17, 707 variable geometry, 713/7,",
 			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
 			"geometry, 805/42, 806/1, 807/34, 808/1, and 809/1",
 			"modified by Helianthus",
@@ -624,6 +624,82 @@ func TestSunSpecV2DERPortGeometryIsBoundedAndRawOnlyOnMismatch(t *testing.T) {
 				t.Fatalf("geometry=%v qualifies=%v facts=%d err=%v", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
 			}
 		})
+	}
+}
+
+func TestSunSpecV2DERTripLVGeometryIsBoundedAndOfflineOnly(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []struct {
+		curves, length uint16
+		points, facts  int
+	}{
+		{0, 7, 9, 7},
+		{2, 9, 11, 9},
+		{uint16(maxSunSpecDERTripLVCurves), 65534, 65536, 65534},
+	} {
+		key := SunSpecDecoderKey{ModelID: 707, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+		definition, ok := registry.definition(key)
+		if !ok || len(definition.points) != want.points {
+			t.Fatalf("N=%d definition=%v points=%d", want.curves, ok, len(definition.points))
+		}
+		if uint32(want.curves) == maxSunSpecDERTripLVCurves {
+			continue
+		}
+		words := make([]uint16, int(want.length)+2)
+		words[0], words[1], words[6] = 707, want.length, want.curves
+		decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 707, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: []SunSpecSourceSpan{{LogicalViewID: 7, PDUOffset: 0, WordCount: want.length + 2}}})
+		if err != nil || !decoded.GeometryValid() || len(decoded.Facts()) != want.facts {
+			t.Fatalf("N=%d geometry=%v facts=%d err=%v", want.curves, decoded.GeometryValid(), len(decoded.Facts()), err)
+		}
+	}
+
+	for _, want := range []struct {
+		name          string
+		length, count uint16
+	}{
+		{name: "count mismatch", length: 9, count: 1},
+		{name: "unavailable count", length: 9, count: 0xffff},
+		{name: "partial curve group", length: 8, count: 2},
+	} {
+		t.Run(want.name, func(t *testing.T) {
+			key := SunSpecDecoderKey{ModelID: 707, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+			words := make([]uint16, int(want.length)+2)
+			words[0], words[1], words[6] = 707, want.length, want.count
+			decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 707, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
+			if err != nil || decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) {
+				t.Fatalf("geometry=%v qualifies=%v facts=%d err=%v", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
+			}
+		})
+	}
+
+	maxKey := SunSpecDecoderKey{ModelID: 707, ModelLength: 65534, SchemaRevision: SunSpecModelsRevisionV2}
+	words := make([]uint16, 65536)
+	words[0], words[1], words[6] = 707, 65534, uint16(maxSunSpecDERTripLVCurves)
+	spans := make([]SunSpecSourceSpan, 0, (len(words)+124)/125)
+	for remaining := len(words); remaining > 0; {
+		count := min(remaining, 125)
+		spans = append(spans, SunSpecSourceSpan{LogicalViewID: uint64(len(spans) + 1), PDUOffset: 0, WordCount: uint16(count)})
+		remaining -= count
+	}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 707, ModelLength: 65534}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &maxKey, words: words, spans: spans})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() || len(decoded.Facts()) != 65534 {
+		t.Fatalf("maximum geometry=%t qualifies=%t facts=%d err=%v", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
+	}
+	var extent uint32
+	for _, span := range decoded.SourceSpans() {
+		if span.WordCount == 0 || span.WordCount > 125 {
+			t.Fatalf("maximum span=%#v", span)
+		}
+		extent += uint32(span.WordCount)
+	}
+	if extent != 65536 {
+		t.Fatalf("maximum span extent=%d", extent)
+	}
+	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 707, ModelLength: 65535, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+		t.Fatal("over-boundary Model 707 must remain opaque")
 	}
 }
 

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -668,8 +668,9 @@ func TestSunSpecV2DERTripLVGeometryIsBoundedAndOfflineOnly(t *testing.T) {
 			key := SunSpecDecoderKey{ModelID: 707, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
 			words := make([]uint16, int(want.length)+2)
 			words[0], words[1], words[6] = 707, want.length, want.count
-			decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 707, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words})
-			if err != nil || decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) {
+			spans := []SunSpecSourceSpan{{LogicalViewID: 7, PDUOffset: 0, WordCount: want.length + 2}}
+			decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 707, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: spans})
+			if err != nil || decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) || !reflect.DeepEqual(decoded.SourceSpans(), spans) {
 				t.Fatalf("geometry=%v qualifies=%v facts=%d err=%v", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
 			}
 		})


### PR DESCRIPTION
## Summary

Adds a V2-only offline Model 707 decoder after the docs gate `b637f207f9e7b479ee0d87bc30f0d7d1c65e3803`. Dynamic keys are bounded to `707/(7+N)` for `N=0..65527`; `N=65528` remains opaque because it needs 65,537 total words.

## TDD

RED commit contains only tests and currently fails to compile because `maxSunSpecDERTripLVCurves` and Model 707 definitions are absent.

## Scope

`sunspec_models_der_v2.go`, `sunspec_decoder.go`, their tests, and `THIRD_PARTY_NOTICES.md`. No chain/acquisition, runtime, vendor/catalog admission, transport, gateway, or live I/O.

Closes #91.