### PR TITLE
Add bounded offline SunSpec V2 Model 708 decoder

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,7 +2,7 @@
 
 ## SunSpec/models
 
-The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 707 variable geometry, 713/7,
+The V2 offline decoder definitions for Models 701/153, 702/50, 703/17, 707 variable geometry, 708 variable geometry, 713/7,
 714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable
 geometry, 805/42, 806/1, 807/34, 808/1, and 809/1 in
 `sunspec_models_der_v2.go` are derived from the SunSpec model catalogue:

--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -109,7 +109,7 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	case SunSpecModelsRevisionV1:
 		capacity += 3277 + 89561
 	case SunSpecModelsRevisionV2:
-		capacity += int(maxSunSpecDERTripLVCurves) + 1 + int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1 + int(maxSunSpecBESSModules) + 1
+		capacity += int(maxSunSpecDERTripLVCurves) + 1 + int(maxSunSpecDERTripHVCurves) + 1 + int(maxSunSpecDERPorts) + 1 + int(maxSunSpecBESSStrings) + 1 + int(maxSunSpecBESSModules) + 1
 	}
 	keys := make([]SunSpecDecoderKey, 0, capacity)
 	for _, definition := range definitions {
@@ -124,6 +124,9 @@ func standardSunSpecDecoderKeys(revision SunSpecSchemaRevision, definitions []su
 	case SunSpecModelsRevisionV2:
 		for curves := uint32(0); curves <= maxSunSpecDERTripLVCurves; curves++ {
 			keys = append(keys, SunSpecDecoderKey{ModelID: 707, ModelLength: uint16(7 + curves), SchemaRevision: revision})
+		}
+		for curves := uint32(0); curves <= maxSunSpecDERTripHVCurves; curves++ {
+			keys = append(keys, SunSpecDecoderKey{ModelID: 708, ModelLength: uint16(7 + curves), SchemaRevision: revision})
 		}
 		for ports := uint32(0); ports <= maxSunSpecDERPorts; ports++ {
 			keys = append(keys, SunSpecDecoderKey{ModelID: 714, ModelLength: uint16(18 + 25*ports), SchemaRevision: revision})
@@ -168,6 +171,8 @@ func (r SunSpecDecoderRegistry) definition(key SunSpecDecoderKey) (sunSpecModelD
 		switch key.ModelID {
 		case 707:
 			resolved, err = derTripLVV2SunSpecDefinition(key.ModelLength)
+		case 708:
+			resolved, err = derTripHVV2SunSpecDefinition(key.ModelLength)
 		case 714:
 			resolved, err = derDCMeasureV2SunSpecDefinition(key.ModelLength)
 		case 803:

--- a/sunspec_decoder_test.go
+++ b/sunspec_decoder_test.go
@@ -129,20 +129,27 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			{ModelID: 808, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 			{ModelID: 809, ModelLength: 1, SchemaRevision: SunSpecModelsRevisionV2},
 		}
-		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERTripLVCurves)+1+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
+		if len(v2Keys) != len(wantV2Static)+int(maxSunSpecDERTripLVCurves)+1+int(maxSunSpecDERTripHVCurves)+1+int(maxSunSpecDERPorts)+1+int(maxSunSpecBESSStrings)+1+int(maxSunSpecBESSModules)+1 {
 			t.Fatalf("V2 key count=%d", len(v2Keys))
 		}
 		static := make(map[SunSpecDecoderKey]bool, len(wantV2Static))
 		for _, key := range wantV2Static {
 			static[key] = true
 		}
-		dynamicTripLV, dynamicDER, dynamicBESSBanks, dynamicBESSStrings := 0, 0, 0, 0
+		dynamicTripLV, dynamicTripHV, dynamicDER, dynamicBESSBanks, dynamicBESSStrings := 0, 0, 0, 0, 0
 		for _, key := range v2Keys {
 			if key.ModelID == 707 {
 				if key.ModelLength < 7 || uint32(key.ModelLength)-7 > maxSunSpecDERTripLVCurves {
 					t.Fatalf("V2 Model 707 dynamic key=%#v", key)
 				}
 				dynamicTripLV++
+				continue
+			}
+			if key.ModelID == 708 {
+				if key.ModelLength < 7 || uint32(key.ModelLength)-7 > maxSunSpecDERTripHVCurves {
+					t.Fatalf("V2 Model 708 dynamic key=%#v", key)
+				}
+				dynamicTripHV++
 				continue
 			}
 			if key.ModelID == 714 {
@@ -171,11 +178,20 @@ func TestSunSpecDecoderRegistryKeepsV2RevisionCacheIsolated(t *testing.T) {
 			}
 			delete(static, key)
 		}
-		if dynamicTripLV != int(maxSunSpecDERTripLVCurves)+1 || dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESSBanks != int(maxSunSpecBESSStrings)+1 || dynamicBESSStrings != int(maxSunSpecBESSModules)+1 || len(static) != 0 {
-			t.Fatalf("V2 Model 707=%d DER=%d BESS banks=%d strings=%d missing static=%#v", dynamicTripLV, dynamicDER, dynamicBESSBanks, dynamicBESSStrings, static)
+		if dynamicTripLV != int(maxSunSpecDERTripLVCurves)+1 || dynamicTripHV != int(maxSunSpecDERTripHVCurves)+1 || dynamicDER != int(maxSunSpecDERPorts)+1 || dynamicBESSBanks != int(maxSunSpecBESSStrings)+1 || dynamicBESSStrings != int(maxSunSpecBESSModules)+1 || len(static) != 0 {
+			t.Fatalf("V2 Model 707=%d Model 708=%d DER=%d BESS banks=%d strings=%d missing static=%#v", dynamicTripLV, dynamicTripHV, dynamicDER, dynamicBESSBanks, dynamicBESSStrings, static)
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definitions[SunSpecDecoderKey{ModelID: 707, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2}]; ok {
+			t.Fatal("V2 eagerly materialized Model 707 dynamic definition")
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definitions[SunSpecDecoderKey{ModelID: 708, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2}]; ok {
+			t.Fatal("V2 eagerly materialized Model 708 dynamic definition")
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 707, ModelLength: 65535, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved Model 707 above the offline extent boundary")
+		}
+		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 708, ModelLength: 65535, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+			t.Fatal("V2 resolved Model 708 above the offline extent boundary")
 		}
 		if _, ok := registries[SunSpecModelsRevisionV2].definition(SunSpecDecoderKey{ModelID: 1, ModelLength: 65, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 			t.Fatal("V2 resolved V1 compatibility Common")

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -10,6 +10,10 @@ const maxSunSpecBESSModules uint32 = (65535 - 46) / 16
 // bounded offline decoder intentionally stops one word earlier.
 const maxSunSpecDERTripLVCurves uint32 = 65534 - 7
 
+// Model 708 with NCrvSet=65528 has 65537 words including its header. The
+// bounded offline decoder intentionally stops one word earlier.
+const maxSunSpecDERTripHVCurves uint32 = 65534 - 7
+
 func derTripLVV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
 	if length < 7 {
 		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 707 geometry is invalid")
@@ -44,6 +48,44 @@ func derTripLVV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error)
 	definition := definitions[0]
 	definition.geometry = func(words []uint16) bool {
 		return len(words) == int(length)+2 && len(words) > 6 && words[6] != 0xffff && uint32(words[6]) <= maxSunSpecDERTripLVCurves && uint32(length) == 7+uint32(words[6])
+	}
+	return definition, nil
+}
+
+func derTripHVV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {
+	if length < 7 {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 708 geometry is invalid")
+	}
+	curves := uint32(length) - 7
+	if curves > maxSunSpecDERTripHVCurves {
+		return sunSpecModelDefinition{}, fmt.Errorf("SunSpec V2 Model 708 curve count exceeds offline geometry")
+	}
+	points := make([]sunSpecPointDefinition, 0, 9+int(curves))
+	points = append(points,
+		v2DERPoint("708", "ID", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("708", "L", SunSpecTypeUint16, "", "", true),
+		v2DERPoint("708", "Ena", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("708", "AdptCrvReq", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("708", "AdptCrvRslt", SunSpecTypeEnum16, "", "", false),
+		v2DERPoint("708", "NPt", SunSpecTypeUint16, "", "", false),
+		v2DERPoint("708", "NCrvSet", SunSpecTypeCount, "", "", false),
+		v2DERPoint("708", "V_SF", SunSpecTypeScaleFactor, "", "", false),
+		v2DERPoint("708", "Tms_SF", SunSpecTypeScaleFactor, "", "", false),
+	)
+	for curve := uint32(1); curve <= curves; curve++ {
+		point := v2DERPoint("708", "ReadOnly", SunSpecTypeEnum16, "", "", false)
+		point.groupID = "curve"
+		point.repeatIndex = uint16(curve)
+		point.repeated = true
+		points = append(points, point)
+	}
+	definitions, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV2, 708, length, SunSpecTopologyNone, false, points)
+	if err != nil {
+		return sunSpecModelDefinition{}, err
+	}
+	definition := definitions[0]
+	definition.geometry = func(words []uint16) bool {
+		return len(words) == int(length)+2 && len(words) > 6 && words[6] != 0xffff && uint32(words[6]) <= maxSunSpecDERTripHVCurves && uint32(length) == 7+uint32(words[6])
 	}
 	return definition, nil
 }

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -18,7 +18,7 @@ func TestSunSpecV2DERDefinitionsAndApacheNotice(t *testing.T) {
 			"SunSpec/models",
 			"https://github.com/sunspec/models",
 			"90b4a331dcca1d6eac69c1bead952fddcc5852e0",
-			"Models 701/153, 702/50, 703/17, 707 variable geometry, 713/7,",
+			"Models 701/153, 702/50, 703/17, 707 variable geometry, 708 variable geometry, 713/7,",
 			"714 variable geometry, 715/7, 802/62, 803 variable geometry, 804 variable",
 			"geometry, 805/42, 806/1, 807/34, 808/1, and 809/1",
 			"modified by Helianthus",
@@ -701,6 +701,96 @@ func TestSunSpecV2DERTripLVGeometryIsBoundedAndOfflineOnly(t *testing.T) {
 	}
 	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 707, ModelLength: 65535, SchemaRevision: SunSpecModelsRevisionV2}); ok {
 		t.Fatal("over-boundary Model 707 must remain opaque")
+	}
+}
+
+func TestSunSpecV2DERTripHVGeometryIsBoundedAndOfflineOnly(t *testing.T) {
+	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	definition, ok := registry.definition(SunSpecDecoderKey{ModelID: 708, ModelLength: 7, SchemaRevision: SunSpecModelsRevisionV2})
+	if !ok {
+		t.Fatal("Model 708/7 definition absent")
+	}
+	wantBase := strings.Split("ID:uint16:1:,L:uint16:1:,Ena:enum16:1:,AdptCrvReq:uint16:1:,AdptCrvRslt:enum16:1:,NPt:uint16:1:,NCrvSet:count:1:,V_SF:sunssf:1:,Tms_SF:sunssf:1:", ",")
+	gotBase := make([]string, len(definition.points))
+	for index, point := range definition.points {
+		gotBase[index] = fmt.Sprintf("%s:%s:%d:%s", point.name, point.pointType, point.size, point.scaleFactor)
+	}
+	if !reflect.DeepEqual(gotBase, wantBase) {
+		t.Fatalf("Model 708 base=%q want=%q", gotBase, wantBase)
+	}
+
+	for _, want := range []struct {
+		curves, length uint16
+		points, facts  int
+	}{
+		{0, 7, 9, 7},
+		{2, 9, 11, 9},
+		{uint16(maxSunSpecDERTripHVCurves), 65534, 65536, 65534},
+	} {
+		key := SunSpecDecoderKey{ModelID: 708, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+		resolved, ok := registry.definition(key)
+		if !ok || len(resolved.points) != want.points {
+			t.Fatalf("N=%d definition=%v points=%d", want.curves, ok, len(resolved.points))
+		}
+		if uint32(want.curves) == maxSunSpecDERTripHVCurves {
+			continue
+		}
+		words := make([]uint16, int(want.length)+2)
+		words[0], words[1], words[6] = 708, want.length, want.curves
+		decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 708, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: []SunSpecSourceSpan{{LogicalViewID: 8, PDUOffset: 0, WordCount: want.length + 2}}})
+		if err != nil || !decoded.GeometryValid() || len(decoded.Facts()) != want.facts {
+			t.Fatalf("N=%d geometry=%v facts=%d err=%v", want.curves, decoded.GeometryValid(), len(decoded.Facts()), err)
+		}
+	}
+
+	for _, want := range []struct {
+		name          string
+		length, count uint16
+	}{
+		{name: "count mismatch", length: 9, count: 1},
+		{name: "unavailable count", length: 9, count: 0xffff},
+		{name: "partial curve group", length: 8, count: 2},
+	} {
+		t.Run(want.name, func(t *testing.T) {
+			key := SunSpecDecoderKey{ModelID: 708, ModelLength: want.length, SchemaRevision: SunSpecModelsRevisionV2}
+			words := make([]uint16, int(want.length)+2)
+			words[0], words[1], words[6] = 708, want.length, want.count
+			spans := []SunSpecSourceSpan{{LogicalViewID: 8, PDUOffset: 0, WordCount: want.length + 2}}
+			decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 708, ModelLength: want.length}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &key, words: words, spans: spans})
+			if err != nil || decoded.GeometryValid() || decoded.Qualifies() || len(decoded.Facts()) != 0 || !reflect.DeepEqual(decoded.RawWords(), words) || !reflect.DeepEqual(decoded.SourceSpans(), spans) {
+				t.Fatalf("geometry=%v qualifies=%t facts=%d err=%v", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
+			}
+		})
+	}
+
+	maxKey := SunSpecDecoderKey{ModelID: 708, ModelLength: 65534, SchemaRevision: SunSpecModelsRevisionV2}
+	words := make([]uint16, 65536)
+	words[0], words[1], words[6] = 708, 65534, uint16(maxSunSpecDERTripHVCurves)
+	spans := make([]SunSpecSourceSpan, 0, (len(words)+124)/125)
+	for remaining := len(words); remaining > 0; {
+		count := min(remaining, 125)
+		spans = append(spans, SunSpecSourceSpan{LogicalViewID: uint64(len(spans) + 1), PDUOffset: 0, WordCount: uint16(count)})
+		remaining -= count
+	}
+	decoded, err := registry.DecodeOccurrence(SunSpecOccurrence{Ordinal: 1, WireKey: SunSpecWireKey{ModelID: 708, ModelLength: 65534}, SchemaRevision: SunSpecModelsRevisionV2, Disposition: SunSpecChainDispositionAdmitted, decoderKey: &maxKey, words: words, spans: spans})
+	if err != nil || !decoded.GeometryValid() || !decoded.Qualifies() || len(decoded.Facts()) != 65534 {
+		t.Fatalf("maximum geometry=%t qualifies=%t facts=%d err=%v", decoded.GeometryValid(), decoded.Qualifies(), len(decoded.Facts()), err)
+	}
+	var extent uint32
+	for _, span := range decoded.SourceSpans() {
+		if span.WordCount == 0 || span.WordCount > 125 {
+			t.Fatalf("maximum span=%#v", span)
+		}
+		extent += uint32(span.WordCount)
+	}
+	if extent != 65536 {
+		t.Fatalf("maximum span extent=%d", extent)
+	}
+	if _, ok := registry.definition(SunSpecDecoderKey{ModelID: 708, ModelLength: 65535, SchemaRevision: SunSpecModelsRevisionV2}); ok {
+		t.Fatal("over-boundary Model 708 must remain opaque")
 	}
 }
 

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -735,6 +735,12 @@ func TestSunSpecV2DERTripHVGeometryIsBoundedAndOfflineOnly(t *testing.T) {
 		if !ok || len(resolved.points) != want.points {
 			t.Fatalf("N=%d definition=%v points=%d", want.curves, ok, len(resolved.points))
 		}
+		if want.curves == 2 {
+			curve := resolved.points[len(resolved.points)-1]
+			if curve.name != "ReadOnly" || curve.pointType != SunSpecTypeEnum16 || curve.groupID != "curve" || !curve.repeated || curve.repeatIndex != 2 {
+				t.Fatalf("Model 708 repeated curve=%#v", curve)
+			}
+		}
 		if uint32(want.curves) == maxSunSpecDERTripHVCurves {
 			continue
 		}


### PR DESCRIPTION
## Summary

Adds a V2-only, bounded offline decoder for SunSpec Model 708.

## TDD

RED commit requires the 708 dynamic bound, cache keys and definition. It currently fails to compile because those symbols do not exist.

## Scope

`sunspec_models_der_v2.go`, `sunspec_decoder.go`, their tests, and `THIRD_PARTY_NOTICES.md`; no static catalog, chain/acquisition, runtime, vendor, transport, gateway, or live I/O.

Docs gate: `5c3cc6857ef12c578e8b1eed705719da618a2448`.

Closes #93.