### PR TITLE
Add nested SunSpec fact path primitives

### DIFF
--- a/sunspec_nested_layout.go
+++ b/sunspec_nested_layout.go
@@ -5,7 +5,7 @@ import "fmt"
 const maxSunSpecOccurrenceWords uint32 = 65536
 
 // SunSpecFactPathSegment identifies one ordered group in a nested fact path.
-// Indexed distinguishes a named group from a repeated group at a one-based index.
+// Indexed distinguishes a named group from a repeated group with an explicit index.
 type SunSpecFactPathSegment struct {
 	Name    string
 	Index   uint32
@@ -22,9 +22,6 @@ func NewSunSpecFactPath(segments []SunSpecFactPathSegment) (SunSpecFactPath, err
 	for _, segment := range segments {
 		if segment.Name == "" {
 			return SunSpecFactPath{}, fmt.Errorf("SunSpec fact path segment has no name")
-		}
-		if segment.Indexed && segment.Index == 0 {
-			return SunSpecFactPath{}, fmt.Errorf("SunSpec indexed fact path segment has zero index")
 		}
 		if !segment.Indexed && segment.Index != 0 {
 			return SunSpecFactPath{}, fmt.Errorf("SunSpec unindexed fact path segment has an index")

--- a/sunspec_nested_layout.go
+++ b/sunspec_nested_layout.go
@@ -1,0 +1,74 @@
+package modbusreg
+
+import "fmt"
+
+const maxSunSpecOccurrenceWords uint32 = 65536
+
+// SunSpecFactPathSegment identifies one ordered group in a nested fact path.
+// Indexed distinguishes a named group from a repeated group at a one-based index.
+type SunSpecFactPathSegment struct {
+	Name    string
+	Index   uint32
+	Indexed bool
+}
+
+// SunSpecFactPath is an immutable ordered hierarchy for a nested SunSpec fact.
+type SunSpecFactPath struct{ segments []SunSpecFactPathSegment }
+
+func NewSunSpecFactPath(segments []SunSpecFactPathSegment) (SunSpecFactPath, error) {
+	if len(segments) == 0 {
+		return SunSpecFactPath{}, fmt.Errorf("SunSpec fact path has no segments")
+	}
+	for _, segment := range segments {
+		if segment.Name == "" {
+			return SunSpecFactPath{}, fmt.Errorf("SunSpec fact path segment has no name")
+		}
+		if segment.Indexed && segment.Index == 0 {
+			return SunSpecFactPath{}, fmt.Errorf("SunSpec indexed fact path segment has zero index")
+		}
+		if !segment.Indexed && segment.Index != 0 {
+			return SunSpecFactPath{}, fmt.Errorf("SunSpec unindexed fact path segment has an index")
+		}
+	}
+	return SunSpecFactPath{segments: append([]SunSpecFactPathSegment(nil), segments...)}, nil
+}
+
+func (p SunSpecFactPath) Segments() []SunSpecFactPathSegment {
+	return append([]SunSpecFactPathSegment(nil), p.segments...)
+}
+
+// SunSpecOccurrenceSourceRange maps an occurrence-relative range to its exact,
+// potentially fragmented physical source spans.
+type SunSpecOccurrenceSourceRange struct {
+	offset, wordCount uint32
+	spans             []SunSpecSourceSpan
+}
+
+func NewSunSpecOccurrenceSourceRange(offset, wordCount uint32, spans []SunSpecSourceSpan) (SunSpecOccurrenceSourceRange, error) {
+	if wordCount == 0 || offset >= maxSunSpecOccurrenceWords || wordCount > maxSunSpecOccurrenceWords-offset {
+		return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source range is outside bounds")
+	}
+	if len(spans) == 0 {
+		return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source range has no spans")
+	}
+	var total uint32
+	for _, span := range spans {
+		if span.LogicalViewID == 0 || span.WordCount == 0 || uint32(span.PDUOffset)+uint32(span.WordCount) > maxSunSpecOccurrenceWords {
+			return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source span is outside bounds")
+		}
+		if total > wordCount-uint32(span.WordCount) {
+			return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source spans exceed range")
+		}
+		total += uint32(span.WordCount)
+	}
+	if total != wordCount {
+		return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source spans do not cover range")
+	}
+	return SunSpecOccurrenceSourceRange{offset: offset, wordCount: wordCount, spans: append([]SunSpecSourceSpan(nil), spans...)}, nil
+}
+
+func (r SunSpecOccurrenceSourceRange) OccurrenceOffset() uint32 { return r.offset }
+func (r SunSpecOccurrenceSourceRange) WordCount() uint32        { return r.wordCount }
+func (r SunSpecOccurrenceSourceRange) SourceSpans() []SunSpecSourceSpan {
+	return append([]SunSpecSourceSpan(nil), r.spans...)
+}

--- a/sunspec_nested_layout_test.go
+++ b/sunspec_nested_layout_test.go
@@ -1,0 +1,83 @@
+package modbusreg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSunSpecFactPathRetainsOrderedHierarchyWithoutAliasing(t *testing.T) {
+	input := []SunSpecFactPathSegment{
+		{Name: "Crv", Indexed: true, Index: 2},
+		{Name: "MustTrip"},
+		{Name: "Pt", Indexed: true, Index: 5},
+	}
+	path, err := NewSunSpecFactPath(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input[0].Name = "mutated"
+	got := path.Segments()
+	if !reflect.DeepEqual(got, []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 2}, {Name: "MustTrip"}, {Name: "Pt", Indexed: true, Index: 5}}) {
+		t.Fatalf("segments=%#v", got)
+	}
+	got[2].Index = 99
+	if path.Segments()[2].Index != 5 {
+		t.Fatal("returned path segments alias the immutable path")
+	}
+	for _, segments := range [][]SunSpecFactPathSegment{
+		nil,
+		{{Name: ""}},
+		{{Name: "Crv", Index: 1}},
+	} {
+		if _, err := NewSunSpecFactPath(segments); err == nil {
+			t.Fatalf("invalid segments accepted: %#v", segments)
+		}
+	}
+}
+
+func TestSunSpecOccurrenceSourceRangeRetainsFragmentsWithoutAliasing(t *testing.T) {
+	input := []SunSpecSourceSpan{
+		{LogicalViewID: 11, PDUOffset: 120, WordCount: 3},
+		{LogicalViewID: 12, PDUOffset: 0, WordCount: 1},
+	}
+	rangeValue, err := NewSunSpecOccurrenceSourceRange(40, 4, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input[0].PDUOffset = 0
+	if rangeValue.OccurrenceOffset() != 40 || rangeValue.WordCount() != 4 {
+		t.Fatalf("range=(%d,%d)", rangeValue.OccurrenceOffset(), rangeValue.WordCount())
+	}
+	got := rangeValue.SourceSpans()
+	want := []SunSpecSourceSpan{{LogicalViewID: 11, PDUOffset: 120, WordCount: 3}, {LogicalViewID: 12, PDUOffset: 0, WordCount: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("spans=%#v", got)
+	}
+	got[0].LogicalViewID = 99
+	if rangeValue.SourceSpans()[0].LogicalViewID != 11 {
+		t.Fatal("returned source spans alias the immutable range")
+	}
+	for _, invalid := range []struct {
+		offset, words uint32
+		spans         []SunSpecSourceSpan
+	}{
+		{0, 0, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 1}}},
+		{65536, 1, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 1}}},
+		{65535, 2, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 2}}},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 0, PDUOffset: 0, WordCount: 1}}},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 0}}},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 65535, WordCount: 2}}},
+		{0, 2, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 1}}},
+	} {
+		if _, err := NewSunSpecOccurrenceSourceRange(invalid.offset, invalid.words, invalid.spans); err == nil {
+			t.Fatalf("invalid source range accepted: %#v", invalid)
+		}
+	}
+}
+
+func TestSunSpecFactRemainsFlatWithoutNestedPrimitives(t *testing.T) {
+	fact := SunSpecFact{GroupID: "module", RepeatIndex: 2, Repeated: true}
+	if fact.GroupID != "module" || fact.RepeatIndex != 2 || !fact.Repeated {
+		t.Fatalf("flat fact metadata changed: %#v", fact)
+	}
+}

--- a/sunspec_nested_layout_test.go
+++ b/sunspec_nested_layout_test.go
@@ -24,6 +24,9 @@ func TestSunSpecFactPathRetainsOrderedHierarchyWithoutAliasing(t *testing.T) {
 	if path.Segments()[2].Index != 5 {
 		t.Fatal("returned path segments alias the immutable path")
 	}
+	if _, err := NewSunSpecFactPath([]SunSpecFactPathSegment{{Name: "Layer", Indexed: true, Index: 0}}); err != nil {
+		t.Fatalf("zero-based indexed segment rejected: %v", err)
+	}
 	for _, segments := range [][]SunSpecFactPathSegment{
 		nil,
 		{{Name: ""}},


### PR DESCRIPTION
## Summary
- add only tests for immutable nested fact-path and occurrence-relative source-range primitives

## TDD
- RED: `GOWORK=off go test ./...` fails because the primitive API is absent

## Scope
- no model definition, decoder emission, cache/key, chain, runtime, vendor, transport, gateway, or live changes