### PR TITLE
Add occurrence source-span slicer

### DIFF
--- a/sunspec_nested_layout.go
+++ b/sunspec_nested_layout.go
@@ -64,6 +64,55 @@ func NewSunSpecOccurrenceSourceRange(offset, wordCount uint32, spans []SunSpecSo
 	return SunSpecOccurrenceSourceRange{offset: offset, wordCount: wordCount, spans: append([]SunSpecSourceSpan(nil), spans...)}, nil
 }
 
+// NewSunSpecOccurrenceSourceRangeFromSpans selects an occurrence-relative
+// range from a complete ordered occurrence without coalescing physical spans.
+func NewSunSpecOccurrenceSourceRangeFromSpans(offset, wordCount uint32, spans []SunSpecSourceSpan) (SunSpecOccurrenceSourceRange, error) {
+	if len(spans) == 0 {
+		return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence has no source spans")
+	}
+	var total uint32
+	for _, span := range spans {
+		if span.LogicalViewID == 0 || span.WordCount == 0 || uint32(span.PDUOffset)+uint32(span.WordCount) > maxSunSpecOccurrenceWords {
+			return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source span is outside bounds")
+		}
+		if total > maxSunSpecOccurrenceWords-uint32(span.WordCount) {
+			return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence extent exceeds bounds")
+		}
+		total += uint32(span.WordCount)
+	}
+	if wordCount == 0 || offset >= total || wordCount > total-offset {
+		return SunSpecOccurrenceSourceRange{}, fmt.Errorf("SunSpec occurrence source range is outside aggregate")
+	}
+
+	end := offset + wordCount
+	cursor := uint32(0)
+	selected := make([]SunSpecSourceSpan, 0, len(spans))
+	for _, span := range spans {
+		spanStart := cursor
+		spanEnd := cursor + uint32(span.WordCount)
+		cursor = spanEnd
+		if spanEnd <= offset {
+			continue
+		}
+		if spanStart >= end {
+			break
+		}
+		start := uint32(0)
+		if offset > spanStart {
+			start = offset - spanStart
+		}
+		finish := uint32(span.WordCount)
+		if end < spanEnd {
+			finish = end - spanStart
+		}
+		part := span
+		part.PDUOffset = uint16(uint32(span.PDUOffset) + start)
+		part.WordCount = uint16(finish - start)
+		selected = append(selected, part)
+	}
+	return NewSunSpecOccurrenceSourceRange(offset, wordCount, selected)
+}
+
 func (r SunSpecOccurrenceSourceRange) OccurrenceOffset() uint32 { return r.offset }
 func (r SunSpecOccurrenceSourceRange) WordCount() uint32        { return r.wordCount }
 func (r SunSpecOccurrenceSourceRange) SourceSpans() []SunSpecSourceSpan {

--- a/sunspec_nested_layout_test.go
+++ b/sunspec_nested_layout_test.go
@@ -84,3 +84,45 @@ func TestSunSpecFactRemainsFlatWithoutNestedPrimitives(t *testing.T) {
 		t.Fatalf("flat fact metadata changed: %#v", fact)
 	}
 }
+
+func TestSunSpecOccurrenceSourceRangeFromSpansSlicesWithoutCoalescing(t *testing.T) {
+	spans := []SunSpecSourceSpan{
+		{LogicalViewID: 11, PDUOffset: 100, WordCount: 2},
+		{LogicalViewID: 11, PDUOffset: 200, WordCount: 2},
+		{LogicalViewID: 12, PDUOffset: 0, WordCount: 2},
+	}
+	rangeValue, err := NewSunSpecOccurrenceSourceRangeFromSpans(1, 5, spans)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []SunSpecSourceSpan{
+		{LogicalViewID: 11, PDUOffset: 101, WordCount: 1},
+		{LogicalViewID: 11, PDUOffset: 200, WordCount: 2},
+		{LogicalViewID: 12, PDUOffset: 0, WordCount: 2},
+	}
+	if !reflect.DeepEqual(rangeValue.SourceSpans(), want) {
+		t.Fatalf("sliced spans=%#v", rangeValue.SourceSpans())
+	}
+	got := rangeValue.SourceSpans()
+	got[0].PDUOffset = 999
+	if rangeValue.SourceSpans()[0].PDUOffset != 101 {
+		t.Fatal("sliced spans alias returned range")
+	}
+
+	for _, invalid := range []struct {
+		offset, words uint32
+		spans         []SunSpecSourceSpan
+	}{
+		{0, 1, nil},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 0, PDUOffset: 0, WordCount: 1}}},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 0}}},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 65535, WordCount: 2}}},
+		{6, 1, spans},
+		{0, 7, spans},
+		{0, 1, []SunSpecSourceSpan{{LogicalViewID: 1, PDUOffset: 0, WordCount: 65535}, {LogicalViewID: 2, PDUOffset: 0, WordCount: 2}}},
+	} {
+		if _, err := NewSunSpecOccurrenceSourceRangeFromSpans(invalid.offset, invalid.words, invalid.spans); err == nil {
+			t.Fatalf("invalid aggregate accepted: %#v", invalid)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- specify a pure occurrence-relative source-span slicing helper

## TDD
- RED: `GOWORK=off go test ./...` fails because the helper is absent

## Scope
- only `sunspec_nested_layout.go` and `sunspec_nested_layout_test.go`
- no decoder, model, cache, chain, runtime, transport, gateway, or live I/O