### PR TITLE
Attach optional nested layout carriers to SunSpec facts

### DIFF
--- a/sunspec_decoder.go
+++ b/sunspec_decoder.go
@@ -15,6 +15,48 @@ type SunSpecFact struct {
 	RepeatIndex uint16
 	Repeated    bool
 	Value       SunSpecValue
+	path        SunSpecFactPath
+	sourceRange SunSpecOccurrenceSourceRange
+	hasLayout   bool
+}
+
+// WithNestedLayout returns a fact carrying optional future nested-layout
+// identity. Existing flat facts remain unchanged until this method is used.
+func (f SunSpecFact) WithNestedLayout(path SunSpecFactPath, sourceRange SunSpecOccurrenceSourceRange) (SunSpecFact, error) {
+	validatedPath, err := NewSunSpecFactPath(path.Segments())
+	if err != nil {
+		return SunSpecFact{}, err
+	}
+	validatedRange, err := NewSunSpecOccurrenceSourceRange(sourceRange.offset, sourceRange.wordCount, sourceRange.spans)
+	if err != nil {
+		return SunSpecFact{}, err
+	}
+	f.path = validatedPath
+	f.sourceRange = validatedRange
+	f.hasLayout = true
+	return f, nil
+}
+
+func (f SunSpecFact) NestedPath() (SunSpecFactPath, bool) {
+	if !f.hasLayout {
+		return SunSpecFactPath{}, false
+	}
+	path, err := NewSunSpecFactPath(f.path.Segments())
+	if err != nil {
+		return SunSpecFactPath{}, false
+	}
+	return path, true
+}
+
+func (f SunSpecFact) OccurrenceSourceRange() (SunSpecOccurrenceSourceRange, bool) {
+	if !f.hasLayout {
+		return SunSpecOccurrenceSourceRange{}, false
+	}
+	rangeValue, err := NewSunSpecOccurrenceSourceRange(f.sourceRange.offset, f.sourceRange.wordCount, f.sourceRange.spans)
+	if err != nil {
+		return SunSpecOccurrenceSourceRange{}, false
+	}
+	return rangeValue, true
 }
 
 type SunSpecDecodedModel struct {
@@ -55,6 +97,10 @@ func (m SunSpecDecodedModel) Fact(fieldID string) (SunSpecFact, bool) {
 func cloneSunSpecFact(fact SunSpecFact) SunSpecFact {
 	fact.Value.raw = append([]uint16(nil), fact.Value.raw...)
 	fact.Value.bitSymbols = append([]string(nil), fact.Value.bitSymbols...)
+	if fact.hasLayout {
+		fact.path.segments = append([]SunSpecFactPathSegment(nil), fact.path.segments...)
+		fact.sourceRange.spans = append([]SunSpecSourceSpan(nil), fact.sourceRange.spans...)
+	}
 	return fact
 }
 

--- a/sunspec_nested_layout_test.go
+++ b/sunspec_nested_layout_test.go
@@ -1,6 +1,7 @@
 package modbusreg
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -82,6 +83,74 @@ func TestSunSpecFactRemainsFlatWithoutNestedPrimitives(t *testing.T) {
 	fact := SunSpecFact{GroupID: "module", RepeatIndex: 2, Repeated: true}
 	if fact.GroupID != "module" || fact.RepeatIndex != 2 || !fact.Repeated {
 		t.Fatalf("flat fact metadata changed: %#v", fact)
+	}
+}
+
+func TestSunSpecFactNestedCarriersCloneAndPreserveLegacyJSON(t *testing.T) {
+	base := SunSpecFact{FieldID: "v", PointName: "V", Unit: "V", GroupID: "module", RepeatIndex: 2, Repeated: true}
+	legacyJSON, err := json.Marshal(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := base.NestedPath(); ok {
+		t.Fatal("flat fact unexpectedly has a nested path")
+	}
+	if _, ok := base.OccurrenceSourceRange(); ok {
+		t.Fatal("flat fact unexpectedly has a source range")
+	}
+
+	path, err := NewSunSpecFactPath([]SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 2}, {Name: "MustTrip"}, {Name: "Pt", Indexed: true, Index: 5}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceRange, err := NewSunSpecOccurrenceSourceRange(7, 2, []SunSpecSourceSpan{{LogicalViewID: 41, PDUOffset: 50, WordCount: 1}, {LogicalViewID: 42, PDUOffset: 90, WordCount: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	withCarriers, err := base.WithNestedLayout(path, sourceRange)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := withCarriers.NestedPath(); !ok || !reflect.DeepEqual(got.Segments(), path.Segments()) {
+		t.Fatalf("path=%#v present=%t", got.Segments(), ok)
+	}
+	if got, ok := withCarriers.OccurrenceSourceRange(); !ok || !reflect.DeepEqual(got.SourceSpans(), sourceRange.SourceSpans()) || got.OccurrenceOffset() != 7 {
+		t.Fatalf("source range=%#v present=%t", got, ok)
+	}
+
+	returnedPath, _ := withCarriers.NestedPath()
+	returnedSegments := returnedPath.Segments()
+	returnedSegments[0].Name = "changed"
+	returnedRange, _ := withCarriers.OccurrenceSourceRange()
+	returnedSpans := returnedRange.SourceSpans()
+	returnedSpans[0].PDUOffset = 0
+	if got, _ := withCarriers.NestedPath(); got.Segments()[0].Name != "Crv" {
+		t.Fatal("fact path accessor aliases internal state")
+	}
+	if got, _ := withCarriers.OccurrenceSourceRange(); got.SourceSpans()[0].PDUOffset != 50 {
+		t.Fatal("fact source range accessor aliases internal state")
+	}
+
+	clone := cloneSunSpecFact(withCarriers)
+	clonePath, _ := clone.NestedPath()
+	cloneSegments := clonePath.Segments()
+	cloneSegments[0].Name = "clone"
+	cloneRange, _ := clone.OccurrenceSourceRange()
+	cloneSpans := cloneRange.SourceSpans()
+	cloneSpans[0].PDUOffset = 1
+	if got, _ := withCarriers.NestedPath(); got.Segments()[0].Name != "Crv" {
+		t.Fatal("fact clone aliases path state")
+	}
+	if got, _ := withCarriers.OccurrenceSourceRange(); got.SourceSpans()[0].PDUOffset != 50 {
+		t.Fatal("fact clone aliases source range state")
+	}
+
+	gotJSON, err := json.Marshal(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotJSON, legacyJSON) || base.GroupID != "module" || base.RepeatIndex != 2 || !base.Repeated {
+		t.Fatalf("legacy fact changed: json=%s base=%#v", gotJSON, base)
 	}
 }
 


### PR DESCRIPTION
## Summary
- specify optional hierarchical path and occurrence source-range carriers on `SunSpecFact`
- preserve flat fact JSON and legacy repeat metadata

## TDD
- RED: `GOWORK=off go test ./...` fails because carrier accessors and constructor are absent

## Scope
- only `sunspec_decoder.go`, `sunspec_nested_layout.go`, and `sunspec_nested_layout_test.go`
- no decoder emission, model/catalog/cache/chain/runtime/vendor/transport/gateway/live changes