### PR TITLE
Carry private typed metadata through SunSpec nested layouts

### DIFF
--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -29,21 +29,21 @@ func derTripLVV2NestedTemplate() (sunSpecNestedLayoutTemplate, error) {
 						name: "MustTrip", fields: []sunSpecNestedLayoutField{{name: "ActPt", wordCount: 1}},
 						children: []sunSpecNestedLayoutGroup{{
 							name: "Pt", repeatCount: "points", indexBase: 1,
-							fields: []sunSpecNestedLayoutField{{name: "V", wordCount: 1, emit: true}, {name: "Tms", wordCount: 2, emit: true}},
+							fields: []sunSpecNestedLayoutField{{name: "V", wordCount: 1, emit: true, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint16, scaleFactor: "V_SF"}}, {name: "Tms", wordCount: 2, emit: true, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint32, scaleFactor: "Tms_SF"}}},
 						}},
 					},
 					{
 						name: "MayTrip", fields: []sunSpecNestedLayoutField{{name: "ActPt", wordCount: 1}},
 						children: []sunSpecNestedLayoutGroup{{
 							name: "Pt", repeatCount: "points", indexBase: 1,
-							fields: []sunSpecNestedLayoutField{{name: "V", wordCount: 1, emit: true}, {name: "Tms", wordCount: 2, emit: true}},
+							fields: []sunSpecNestedLayoutField{{name: "V", wordCount: 1, emit: true, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint16, scaleFactor: "V_SF"}}, {name: "Tms", wordCount: 2, emit: true, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint32, scaleFactor: "Tms_SF"}}},
 						}},
 					},
 					{
 						name: "MomCess", fields: []sunSpecNestedLayoutField{{name: "ActPt", wordCount: 1}},
 						children: []sunSpecNestedLayoutGroup{{
 							name: "Pt", repeatCount: "points", indexBase: 1,
-							fields: []sunSpecNestedLayoutField{{name: "V", wordCount: 1, emit: true}, {name: "Tms", wordCount: 2, emit: true}},
+							fields: []sunSpecNestedLayoutField{{name: "V", wordCount: 1, emit: true, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint16, scaleFactor: "V_SF"}}, {name: "Tms", wordCount: 2, emit: true, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint32, scaleFactor: "Tms_SF"}}},
 						}},
 					},
 				},

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -184,13 +184,15 @@ func TestSunSpecV2DERTripLVNestedLayoutValidationDoesNotAdmitModel(t *testing.T)
 		kind               string
 		field              string
 		offset, width, pdu uint32
+		pointType          SunSpecPointType
+		scaleFactor        string
 	}{
-		{1, "MustTrip", "V", 11, 1, 200}, {1, "MustTrip", "Tms", 12, 2, 201},
-		{1, "MayTrip", "V", 15, 1, 204}, {1, "MayTrip", "Tms", 16, 2, 205},
-		{1, "MomCess", "V", 19, 1, 208}, {1, "MomCess", "Tms", 20, 2, 209},
-		{2, "MustTrip", "V", 24, 1, 301}, {2, "MustTrip", "Tms", 25, 2, 302},
-		{2, "MayTrip", "V", 28, 1, 305}, {2, "MayTrip", "Tms", 29, 2, 306},
-		{2, "MomCess", "V", 32, 1, 309}, {2, "MomCess", "Tms", 33, 2, 310},
+		{1, "MustTrip", "V", 11, 1, 200, SunSpecTypeUint16, "V_SF"}, {1, "MustTrip", "Tms", 12, 2, 201, SunSpecTypeUint32, "Tms_SF"},
+		{1, "MayTrip", "V", 15, 1, 204, SunSpecTypeUint16, "V_SF"}, {1, "MayTrip", "Tms", 16, 2, 205, SunSpecTypeUint32, "Tms_SF"},
+		{1, "MomCess", "V", 19, 1, 208, SunSpecTypeUint16, "V_SF"}, {1, "MomCess", "Tms", 20, 2, 209, SunSpecTypeUint32, "Tms_SF"},
+		{2, "MustTrip", "V", 24, 1, 301, SunSpecTypeUint16, "V_SF"}, {2, "MustTrip", "Tms", 25, 2, 302, SunSpecTypeUint32, "Tms_SF"},
+		{2, "MayTrip", "V", 28, 1, 305, SunSpecTypeUint16, "V_SF"}, {2, "MayTrip", "Tms", 29, 2, 306, SunSpecTypeUint32, "Tms_SF"},
+		{2, "MomCess", "V", 32, 1, 309, SunSpecTypeUint16, "V_SF"}, {2, "MomCess", "Tms", 33, 2, 310, SunSpecTypeUint32, "Tms_SF"},
 	} {
 		gotPath := entries[index].Path().Segments()
 		wantPath := []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: want.curve}, {Name: want.kind}, {Name: "Pt", Indexed: true, Index: 1}, {Name: want.field}}
@@ -202,6 +204,17 @@ func TestSunSpecV2DERTripLVNestedLayoutValidationDoesNotAdmitModel(t *testing.T)
 		if gotRange.OccurrenceOffset() != want.offset || gotRange.WordCount() != want.width || !reflect.DeepEqual(gotRange.SourceSpans(), wantSpans) {
 			t.Fatalf("entry %d range=%#v want offset=%d width=%d spans=%#v", index, gotRange, want.offset, want.width, wantSpans)
 		}
+		if gotType, ok := entries[index].PointType(); !ok || gotType != want.pointType {
+			t.Fatalf("entry %d point type=%q ok=%v want=%q", index, gotType, ok, want.pointType)
+		}
+		if gotScale, ok := entries[index].ScaleFactor(); !ok || gotScale != want.scaleFactor {
+			t.Fatalf("entry %d scale factor=%q ok=%v want=%q", index, gotScale, ok, want.scaleFactor)
+		}
+	}
+	entries[0].valueMetadata.pointType = SunSpecTypeInt16
+	again := layout.Entries()
+	if got, ok := again[0].PointType(); !ok || got != SunSpecTypeUint16 {
+		t.Fatalf("entry metadata aliases layout state: %q ok=%v", got, ok)
 	}
 
 	zeroWords := []uint16{707, 7, 0, 0, 0, 0, 0, 0, 0}

--- a/sunspec_nested_layout_builder.go
+++ b/sunspec_nested_layout_builder.go
@@ -16,10 +16,17 @@ type sunSpecNestedCountSpec struct {
 	min, max             uint32
 }
 
+type sunSpecNestedValueMetadata struct {
+	pointType   SunSpecPointType
+	scaleFactor string
+}
+
 type sunSpecNestedLayoutField struct {
-	name      string
-	wordCount uint32
-	emit      bool
+	name             string
+	wordCount        uint32
+	emit             bool
+	hasValueMetadata bool
+	valueMetadata    sunSpecNestedValueMetadata
 }
 
 type sunSpecNestedLayoutGroup struct {
@@ -37,8 +44,10 @@ type sunSpecNestedLayoutTemplate struct {
 }
 
 type sunSpecNestedLayoutEntry struct {
-	path        SunSpecFactPath
-	sourceRange SunSpecOccurrenceSourceRange
+	path             SunSpecFactPath
+	sourceRange      SunSpecOccurrenceSourceRange
+	hasValueMetadata bool
+	valueMetadata    sunSpecNestedValueMetadata
 }
 
 func (e sunSpecNestedLayoutEntry) Path() SunSpecFactPath {
@@ -57,6 +66,20 @@ func (e sunSpecNestedLayoutEntry) SourceRange() SunSpecOccurrenceSourceRange {
 	return rangeValue
 }
 
+func (e sunSpecNestedLayoutEntry) PointType() (SunSpecPointType, bool) {
+	if !e.hasValueMetadata {
+		return "", false
+	}
+	return e.valueMetadata.pointType, true
+}
+
+func (e sunSpecNestedLayoutEntry) ScaleFactor() (string, bool) {
+	if !e.hasValueMetadata || e.valueMetadata.scaleFactor == "" {
+		return "", false
+	}
+	return e.valueMetadata.scaleFactor, true
+}
+
 type sunSpecNestedOccurrenceLayout struct {
 	key     sunSpecNestedTemplateKey
 	entries []sunSpecNestedLayoutEntry
@@ -65,7 +88,7 @@ type sunSpecNestedOccurrenceLayout struct {
 func (l sunSpecNestedOccurrenceLayout) Entries() []sunSpecNestedLayoutEntry {
 	out := make([]sunSpecNestedLayoutEntry, len(l.entries))
 	for index, entry := range l.entries {
-		out[index] = sunSpecNestedLayoutEntry{path: entry.Path(), sourceRange: entry.SourceRange()}
+		out[index] = sunSpecNestedLayoutEntry{path: entry.Path(), sourceRange: entry.SourceRange(), hasValueMetadata: entry.hasValueMetadata, valueMetadata: entry.valueMetadata}
 	}
 	return out
 }
@@ -115,6 +138,9 @@ func validateSunSpecNestedLayoutGroup(group sunSpecNestedLayoutGroup, countNames
 	for _, field := range group.fields {
 		if field.name == "" || field.wordCount == 0 {
 			return fmt.Errorf("SunSpec nested layout field is invalid")
+		}
+		if field.hasValueMetadata && (!field.emit || field.valueMetadata.pointType == "") {
+			return fmt.Errorf("SunSpec nested layout metadata is invalid")
 		}
 		if root && field.emit {
 			return fmt.Errorf("SunSpec nested layout root cannot emit a path")
@@ -257,7 +283,7 @@ func (w *sunSpecNestedLayoutWalk) walk(group sunSpecNestedLayoutGroup, parent []
 			if err != nil {
 				return err
 			}
-			*w.entries = append(*w.entries, sunSpecNestedLayoutEntry{path: factPath, sourceRange: sourceRange})
+			*w.entries = append(*w.entries, sunSpecNestedLayoutEntry{path: factPath, sourceRange: sourceRange, hasValueMetadata: field.hasValueMetadata, valueMetadata: field.valueMetadata})
 		}
 		for _, child := range group.children {
 			if err := w.walk(child, path); err != nil {

--- a/sunspec_nested_layout_builder_test.go
+++ b/sunspec_nested_layout_builder_test.go
@@ -84,6 +84,12 @@ func TestSunSpecNestedLayoutBuildsImmutableSyntheticEntries(t *testing.T) {
 	if len(entries) != 8 {
 		t.Fatalf("entries=%d", len(entries))
 	}
+	if _, ok := entries[0].PointType(); ok {
+		t.Fatal("legacy synthetic entry unexpectedly has typed metadata")
+	}
+	if _, ok := entries[0].ScaleFactor(); ok {
+		t.Fatal("legacy synthetic entry unexpectedly has a scale factor")
+	}
 	path := entries[0].Path()
 	if !reflect.DeepEqual(path.Segments(), []SunSpecFactPathSegment{
 		{Name: "Crv", Indexed: true, Index: 1},

--- a/sunspec_nested_layout_builder_test.go
+++ b/sunspec_nested_layout_builder_test.go
@@ -149,3 +149,16 @@ func TestSunSpecNestedLayoutRejectsInvalidOccurrenceWithoutEntries(t *testing.T)
 		})
 	}
 }
+
+func TestSunSpecNestedLayoutRejectsMetadataOnNonEmittingField(t *testing.T) {
+	_, err := newSunSpecNestedLayoutTemplate(
+		sunSpecNestedTemplateKey{revision: syntheticNestedLayoutRevision, modelID: syntheticNestedLayoutModelID},
+		nil,
+		sunSpecNestedLayoutGroup{fields: []sunSpecNestedLayoutField{{
+			name: "ID", wordCount: 1, hasValueMetadata: true, valueMetadata: sunSpecNestedValueMetadata{pointType: SunSpecTypeUint16},
+		}}},
+	)
+	if err == nil {
+		t.Fatal("non-emitting field accepted typed metadata")
+	}
+}


### PR DESCRIPTION
Closes #107

## RED
`9434c6adfc52d2c2b139bbfd287ae0d898063263` requires private nested entry point-type and scale-factor accessors before they exist. `GOWORK=off go test ./...` fails at compile time.

## Scope
Private immutable metadata propagation only.

## Excluded
No value decoding, SunSpecFact, field IDs, units, JSON, registry/catalog/chain/decoder behavior, runtime, transport, gateway, or live I/O.