### PR TITLE
Classify valid SunSpec V2 Model 707 occurrences structurally

### DIFF
--- a/sunspec_chain.go
+++ b/sunspec_chain.go
@@ -265,15 +265,16 @@ func (c *SunSpecChain) payload(r SunSpecReadRequest, x LogicalViewRecord) (SunSp
 		d = SunSpecChainDispositionUnsupportedLength
 	}
 	c.occ = append(c.occ, SunSpecOccurrence{
-		Ordinal:        uint32(len(c.occ) + 1),
-		WireKey:        wk,
-		SchemaRevision: c.plan.revision,
-		HeaderOffset:   c.current.header,
-		PayloadOffset:  c.current.header + 2,
-		Disposition:    d,
-		decoderKey:     key,
-		words:          append([]uint16(nil), c.current.words...),
-		spans:          append([]SunSpecSourceSpan(nil), c.current.spans...),
+		Ordinal:             uint32(len(c.occ) + 1),
+		WireKey:             wk,
+		SchemaRevision:      c.plan.revision,
+		HeaderOffset:        c.current.header,
+		PayloadOffset:       c.current.header + 2,
+		Disposition:         d,
+		decoderKey:          key,
+		structuralCandidate: c.plan.structuralCandidate(wk, c.current.words, c.current.spans),
+		words:               append([]uint16(nil), c.current.words...),
+		spans:               append([]SunSpecSourceSpan(nil), c.current.spans...),
 	})
 	c.current = nil
 	return SunSpecChainSnapshot{}, c.queue(nextAddress, nextWords, nextPurpose)

--- a/sunspec_chain_plan.go
+++ b/sunspec_chain_plan.go
@@ -16,19 +16,21 @@ type SunSpecChainLimits struct {
 	MaxOccurrences uint32
 }
 type SunSpecChainPlanSpec struct {
-	SchemaRevision SunSpecSchemaRevision
-	BaseCandidates []uint16
-	Limits         SunSpecChainLimits
-	DecoderKeys    []SunSpecDecoderKey
+	SchemaRevision         SunSpecSchemaRevision
+	BaseCandidates         []uint16
+	Limits                 SunSpecChainLimits
+	DecoderKeys            []SunSpecDecoderKey
+	StructuralCandidateIDs []uint16
 }
 type SunSpecChainPlan struct {
-	revision SunSpecSchemaRevision
-	bases    []uint16
-	limits   SunSpecChainLimits
-	keys     map[SunSpecWireKey]SunSpecDecoderKey
-	known    map[uint16]struct{}
-	nonce    uint64
-	initial  []SunSpecReadRequest
+	revision               SunSpecSchemaRevision
+	bases                  []uint16
+	limits                 SunSpecChainLimits
+	keys                   map[SunSpecWireKey]SunSpecDecoderKey
+	known                  map[uint16]struct{}
+	structuralCandidateIDs map[uint16]struct{}
+	nonce                  uint64
+	initial                []SunSpecReadRequest
 }
 type SunSpecReadRequest struct {
 	address, words            uint16
@@ -44,7 +46,7 @@ func NewSunSpecChainPlan(s SunSpecChainPlanSpec) (SunSpecChainPlan, error) {
 	if !validSunSpecRevision(s.SchemaRevision) || len(s.BaseCandidates) == 0 || s.Limits.MaxTotalWords < 4 || s.Limits.MaxOccurrences == 0 || s.Limits.MaxTotalWords > 65536 || s.Limits.MaxOccurrences > s.Limits.MaxTotalWords/2 {
 		return SunSpecChainPlan{}, fmt.Errorf("SunSpec chain plan requires explicit finite bounds")
 	}
-	p := SunSpecChainPlan{revision: s.SchemaRevision, bases: append([]uint16(nil), s.BaseCandidates...), limits: s.Limits, keys: map[SunSpecWireKey]SunSpecDecoderKey{}, known: map[uint16]struct{}{}, nonce: sunSpecPlanNonce.Add(1)}
+	p := SunSpecChainPlan{revision: s.SchemaRevision, bases: append([]uint16(nil), s.BaseCandidates...), limits: s.Limits, keys: map[SunSpecWireKey]SunSpecDecoderKey{}, known: map[uint16]struct{}{}, structuralCandidateIDs: map[uint16]struct{}{}, nonce: sunSpecPlanNonce.Add(1)}
 	seenBases := make(map[uint16]struct{}, len(p.bases))
 	for _, b := range p.bases {
 		if _, duplicate := seenBases[b]; duplicate {
@@ -66,6 +68,12 @@ func NewSunSpecChainPlan(s SunSpecChainPlanSpec) (SunSpecChainPlan, error) {
 		p.keys[wk] = k
 		p.known[k.ModelID] = struct{}{}
 	}
+	for _, id := range s.StructuralCandidateIDs {
+		if _, exists := p.structuralCandidateIDs[id]; exists {
+			return SunSpecChainPlan{}, fmt.Errorf("SunSpec structural candidate identifier duplicated")
+		}
+		p.structuralCandidateIDs[id] = struct{}{}
+	}
 	for i, b := range p.bases {
 		p.initial = append(p.initial, SunSpecReadRequest{address: b, words: 2, purpose: SunSpecReadSignature, nonce: p.nonce, sequence: uint64(i + 1)})
 	}
@@ -75,6 +83,12 @@ func (p SunSpecChainPlan) Requests() []SunSpecReadRequest {
 	return append([]SunSpecReadRequest(nil), p.initial...)
 }
 func (p SunSpecChainPlan) SchemaRevision() SunSpecSchemaRevision { return p.revision }
+func (p SunSpecChainPlan) structuralCandidate(wireKey SunSpecWireKey, words []uint16, spans []SunSpecSourceSpan) *sunSpecStructuralCandidate {
+	if _, enabled := p.structuralCandidateIDs[wireKey.ModelID]; !enabled {
+		return nil
+	}
+	return sunSpecV2DERTripLVStructuralCandidate(p.revision, wireKey, words, spans)
+}
 func sortedRequests(m map[uint64]SunSpecReadRequest) []SunSpecReadRequest {
 	ids := make([]uint64, 0, len(m))
 	for id := range m {

--- a/sunspec_chain_plan_test.go
+++ b/sunspec_chain_plan_test.go
@@ -36,6 +36,35 @@ func TestSunSpecChainPlannerRejectsDuplicateBaseCandidates(t *testing.T) {
 	}
 }
 
+func TestSunSpecChainPlanStructuralCandidateOptInIsPrivateAndDoesNotChangeInitialReads(t *testing.T) {
+	base := SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 128, MaxOccurrences: 3},
+	}
+	plain, err := NewSunSpecChainPlan(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selectedSpec := base
+	selectedSpec.StructuralCandidateIDs = []uint16{707}
+	selected, err := NewSunSpecChainPlan(selectedSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := selected.Requests(), plain.Requests(); len(got) != len(want) || got[0].Address() != want[0].Address() || got[0].WordCount() != want[0].WordCount() || got[0].Purpose() != want[0].Purpose() {
+		t.Fatalf("opt-in initial reads=%#v plain=%#v", got, want)
+	}
+	if _, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision:         base.SchemaRevision,
+		BaseCandidates:         base.BaseCandidates,
+		Limits:                 base.Limits,
+		StructuralCandidateIDs: []uint16{707, 707},
+	}); err == nil {
+		t.Fatal("duplicate structural candidate IDs were admitted")
+	}
+}
+
 func TestSunSpecChainPublicRequestsAreReadOnly(t *testing.T) {
 	typ := reflect.TypeFor[SunSpecReadRequest]()
 	for i := 0; i < typ.NumMethod(); i++ {

--- a/sunspec_chain_test.go
+++ b/sunspec_chain_test.go
@@ -58,6 +58,102 @@ func TestSunSpecChainRejectsCrossInstanceReplay(t *testing.T) {
 	}
 }
 
+type sunSpecReadTrace struct {
+	address uint16
+	words   uint16
+	purpose SunSpecReadPurpose
+}
+
+func runV2StructuralCandidateChain(t *testing.T, candidateIDs []uint16) (SunSpecChainSnapshot, []sunSpecReadTrace) {
+	t.Helper()
+	plan, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision:         SunSpecModelsRevisionV2,
+		BaseCandidates:         []uint16{40000},
+		Limits:                 SunSpecChainLimits{MaxTotalWords: 256, MaxOccurrences: 4},
+		StructuralCandidateIDs: candidateIDs,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	chain := NewSunSpecChain(plan)
+	id := uint64(1)
+	trace := make([]sunSpecReadTrace, 0, 8)
+	admit := func(words []uint16) (SunSpecChainSnapshot, error) {
+		r := chain.NextRequests()[0]
+		trace = append(trace, sunSpecReadTrace{r.Address(), r.WordCount(), r.Purpose()})
+		snapshot, err := chain.AdmitReplay(r, chainView(t, r, id, words, "fixture"))
+		id++
+		return snapshot, err
+	}
+	if _, err := admit([]uint16{sunSpecSignatureFirst, sunSpecSignatureSecond}); err != nil {
+		t.Fatal(err)
+	}
+	first707 := []uint16{707, 33, 0, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1}
+	second707 := append([]uint16(nil), first707...)
+	stream := append([]uint16(nil), first707...)
+	stream = append(stream, second707...)
+	stream = append(stream, 708, 33)
+	stream = append(stream, make([]uint16, 33)...)
+	stream = append(stream, 709, 39)
+	stream = append(stream, make([]uint16, 39)...)
+	for len(stream) > 0 {
+		r := chain.NextRequests()[0]
+		if len(stream) < int(r.WordCount()) {
+			t.Fatalf("fixture ended before request %#v", r)
+		}
+		chunk := stream[:r.WordCount()]
+		stream = stream[r.WordCount():]
+		if _, err := admit(chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := admit([]uint16{sunSpecEndModel, 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot, trace
+}
+
+func TestSunSpecV2StructuralCandidateDoesNotChangeChainBehaviorOrActivateModels(t *testing.T) {
+	plain, plainTrace := runV2StructuralCandidateChain(t, nil)
+	selected, selectedTrace := runV2StructuralCandidateChain(t, []uint16{707})
+	if !reflect.DeepEqual(selectedTrace, plainTrace) {
+		t.Fatalf("candidate changed read trace=%#v plain=%#v", selectedTrace, plainTrace)
+	}
+	if !reflect.DeepEqual(selected.RawWords(), plain.RawWords()) || len(selected.SourceViews()) != len(plain.SourceViews()) {
+		t.Fatal("candidate changed retained raw acquisition evidence")
+	}
+	plainOccurrences, selectedOccurrences := plain.Occurrences(), selected.Occurrences()
+	if len(selectedOccurrences) != 4 || len(plainOccurrences) != len(selectedOccurrences) {
+		t.Fatalf("occurrences plain=%#v selected=%#v", plainOccurrences, selectedOccurrences)
+	}
+	for index, occurrence := range selectedOccurrences {
+		if occurrence.Disposition != SunSpecChainDispositionUnknownModel {
+			t.Fatalf("occurrence %d disposition=%q", index, occurrence.Disposition)
+		}
+		if _, ok := occurrence.DecoderKey(); ok {
+			t.Fatalf("occurrence %d unexpectedly has decoder key", index)
+		}
+		if occurrence.WireKey.ModelID == 707 {
+			if occurrence.structuralCandidate == nil {
+				t.Fatalf("Model 707 occurrence %d lacks candidate", index)
+			}
+			if plainOccurrences[index].structuralCandidate != nil {
+				t.Fatalf("non-opt-in Model 707 occurrence %d has candidate", index)
+			}
+		} else if occurrence.structuralCandidate != nil {
+			t.Fatalf("non-707 model %d became candidate", occurrence.WireKey.ModelID)
+		}
+	}
+	if selectedOccurrences[0].structuralCandidate == selectedOccurrences[1].structuralCandidate {
+		t.Fatal("repeated candidates share sidecar storage")
+	}
+	copy := selected.Occurrences()
+	if copy[0].structuralCandidate == selectedOccurrences[0].structuralCandidate {
+		t.Fatal("candidate sidecar aliases snapshot storage")
+	}
+}
+
 func TestSunSpecChainRetainsOrderedDuplicatesUnknownAndWrongLength(t *testing.T) {
 	c := NewSunSpecChain(chainPlan(t, []uint16{40000}))
 	id := uint64(1)

--- a/sunspec_core_types.go
+++ b/sunspec_core_types.go
@@ -31,6 +31,12 @@ type SunSpecSourceSpan struct {
 	// by the referenced logical view.
 	PDUOffset, WordCount uint16
 }
+
+// sunSpecStructuralCandidate is private metadata for a complete occurrence
+// whose opted-in structure has been validated. It intentionally carries no
+// decoder, fact, catalog, or public selection surface.
+type sunSpecStructuralCandidate struct{ modelID uint16 }
+
 type SunSpecOccurrence struct {
 	Ordinal                     uint32
 	WireKey                     SunSpecWireKey
@@ -38,6 +44,7 @@ type SunSpecOccurrence struct {
 	HeaderOffset, PayloadOffset uint16
 	Disposition                 SunSpecChainDisposition
 	decoderKey                  *SunSpecDecoderKey
+	structuralCandidate         *sunSpecStructuralCandidate
 	words                       []uint16
 	spans                       []SunSpecSourceSpan
 }
@@ -68,6 +75,10 @@ func cloneOccurrence(o SunSpecOccurrence) SunSpecOccurrence {
 	if o.decoderKey != nil {
 		k := *o.decoderKey
 		o.decoderKey = &k
+	}
+	if o.structuralCandidate != nil {
+		candidate := *o.structuralCandidate
+		o.structuralCandidate = &candidate
 	}
 	return o
 }

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -6,6 +6,35 @@ const maxSunSpecDERPorts uint32 = (65535 - 18) / 25
 const maxSunSpecBESSStrings uint32 = (65535 - 26) / 32
 const maxSunSpecBESSModules uint32 = (65535 - 46) / 16
 
+func sunSpecV2DERTripLVStructuralCandidate(revision SunSpecSchemaRevision, wireKey SunSpecWireKey, words []uint16, spans []SunSpecSourceSpan) *sunSpecStructuralCandidate {
+	if revision != SunSpecModelsRevisionV2 || wireKey.ModelID != 707 || wireKey.ModelLength > 65534 || len(words) != int(wireKey.ModelLength)+2 || len(words) <= 6 || words[0] != wireKey.ModelID || words[1] != wireKey.ModelLength {
+		return nil
+	}
+	points, curves := words[5], words[6]
+	if points == 0xffff || curves == 0xffff {
+		return nil
+	}
+	length := uint64(7) + uint64(curves)*(uint64(4)+9*uint64(points))
+	if length > 65534 || length != uint64(wireKey.ModelLength) || !sunSpecStructuralCandidateSpansCover(spans, uint32(len(words))) {
+		return nil
+	}
+	return &sunSpecStructuralCandidate{modelID: wireKey.ModelID}
+}
+
+func sunSpecStructuralCandidateSpansCover(spans []SunSpecSourceSpan, expected uint32) bool {
+	if len(spans) == 0 {
+		return false
+	}
+	var total uint32
+	for _, span := range spans {
+		if span.LogicalViewID == 0 || span.WordCount == 0 || uint32(span.PDUOffset)+uint32(span.WordCount) > maxSunSpecOccurrenceWords || uint32(span.WordCount) > expected-total {
+			return false
+		}
+		total += uint32(span.WordCount)
+	}
+	return total == expected
+}
+
 func derTripLVV2NestedTemplate() (sunSpecNestedLayoutTemplate, error) {
 	return newSunSpecNestedLayoutTemplate(
 		sunSpecNestedTemplateKey{revision: SunSpecModelsRevisionV2, modelID: 707},

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -267,6 +267,60 @@ func TestSunSpecV2DERTripLVNestedLayoutValidationDoesNotAdmitModel(t *testing.T)
 	}
 }
 
+func TestSunSpecV2DERTripStructuralCandidateRequiresOptInAndExactGeometry(t *testing.T) {
+	words := []uint16{
+		707, 33,
+		0, 0, 0, 1, 2, 0, 0,
+		0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
+		0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1,
+	}
+	spans := []SunSpecSourceSpan{{LogicalViewID: 7, PDUOffset: 9, WordCount: uint16(len(words))}}
+	plain, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision: SunSpecModelsRevisionV2,
+		BaseCandidates: []uint16{40000},
+		Limits:         SunSpecChainLimits{MaxTotalWords: 64, MaxOccurrences: 2},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate := plain.structuralCandidate(SunSpecWireKey{ModelID: 707, ModelLength: 33}, words, spans); candidate != nil {
+		t.Fatalf("empty opt-in candidate=%#v", candidate)
+	}
+	selected, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
+		SchemaRevision:         SunSpecModelsRevisionV2,
+		BaseCandidates:          []uint16{40000},
+		Limits:                  SunSpecChainLimits{MaxTotalWords: 64, MaxOccurrences: 2},
+		StructuralCandidateIDs: []uint16{707},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate := selected.structuralCandidate(SunSpecWireKey{ModelID: 707, ModelLength: 33}, words, spans); candidate == nil {
+		t.Fatal("complete valid Model 707 is not a structural candidate")
+	}
+	for name, invalid := range map[string][]uint16{
+		"wrong revision":        words,
+		"wrong identifier":      append([]uint16{708}, words[1:]...),
+		"wrong declared length": append([]uint16{707, 32}, words[2:]...),
+		"point unavailable":     append([]uint16{707, 33, 0, 0, 0, 0xffff}, words[6:]...),
+		"curve unavailable":     append([]uint16{707, 33, 0, 0, 0, 1, 0xffff}, words[7:]...),
+		"wrong geometry":        append([]uint16{707, 33, 0, 0, 0, 2, 2}, words[7:]...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidatePlan := selected
+			if name == "wrong revision" {
+				candidatePlan.revision = SunSpecModelsRevisionV1
+			}
+			if candidate := candidatePlan.structuralCandidate(SunSpecWireKey{ModelID: 707, ModelLength: 33}, invalid, spans); candidate != nil {
+				t.Fatalf("invalid Model 707 candidate=%#v", candidate)
+			}
+		})
+	}
+	if candidate := selected.structuralCandidate(SunSpecWireKey{ModelID: 707, ModelLength: 33}, words, []SunSpecSourceSpan{{LogicalViewID: 7, PDUOffset: 9, WordCount: 34}}); candidate != nil {
+		t.Fatalf("partial coverage candidate=%#v", candidate)
+	}
+}
+
 func TestSunSpecV2BESSBaseRetainsPinnedPointOrderTypesAndScales(t *testing.T) {
 	registry, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV2)
 	if err != nil {

--- a/sunspec_models_der_v2_test.go
+++ b/sunspec_models_der_v2_test.go
@@ -288,8 +288,8 @@ func TestSunSpecV2DERTripStructuralCandidateRequiresOptInAndExactGeometry(t *tes
 	}
 	selected, err := NewSunSpecChainPlan(SunSpecChainPlanSpec{
 		SchemaRevision:         SunSpecModelsRevisionV2,
-		BaseCandidates:          []uint16{40000},
-		Limits:                  SunSpecChainLimits{MaxTotalWords: 64, MaxOccurrences: 2},
+		BaseCandidates:         []uint16{40000},
+		Limits:                 SunSpecChainLimits{MaxTotalWords: 64, MaxOccurrences: 2},
 		StructuralCandidateIDs: []uint16{707},
 	})
 	if err != nil {
@@ -318,6 +318,9 @@ func TestSunSpecV2DERTripStructuralCandidateRequiresOptInAndExactGeometry(t *tes
 	}
 	if candidate := selected.structuralCandidate(SunSpecWireKey{ModelID: 707, ModelLength: 33}, words, []SunSpecSourceSpan{{LogicalViewID: 7, PDUOffset: 9, WordCount: 34}}); candidate != nil {
 		t.Fatalf("partial coverage candidate=%#v", candidate)
+	}
+	if candidate := selected.structuralCandidate(SunSpecWireKey{ModelID: 707, ModelLength: 65535}, nil, nil); candidate != nil {
+		t.Fatalf("extent-excess candidate=%#v", candidate)
 	}
 }
 

--- a/sunspec_qualification_observation_test.go
+++ b/sunspec_qualification_observation_test.go
@@ -84,6 +84,9 @@ func TestSunSpecQualificationObservationJSONGoldenAndBoundedReplay(t *testing.T)
 	if err != nil || !bytes.Equal(first, second) {
 		t.Fatalf("qualification JSON is not deterministic: %v", err)
 	}
+	if bytes.Contains(first, []byte("structural_candidate")) {
+		t.Fatal("V1 qualification JSON exposed private structural candidate metadata")
+	}
 	fixture, err := os.ReadFile("testdata/sunspec/qualification/fronius_gen24_float_v1_1.json")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Closes #109

## Boundary

Private, post-payload V2 Model 707 structural-candidate marker only. Public disposition remains `unknown_model`; no decoder key, decoder/catalog/cache change, fact emission, acquisition change, or JSON exposure.

## Evidence

- RED-first commit `f9345299c3d9fd7895a09633a4e169f8732eda99`: `go test ./...` failed because the opt-in plan field/classifier did not exist.
- GREEN commit `61f143204cf0567a9be05af2068dcd25527d43cf`: `go test -race -shuffle=on -count=20 -timeout=4m ./...` passed.
- `./scripts/ci_local.sh` passed: terminology, scope (+14 mutation tests), gofmt, vet, build, race tests, golangci-lint (0 issues).
- Docs gate is merged: docs-modbus `701e84def3cf4470ccc291a57c668fe829a5e51f` (#64).

## Review focus

Confirm the candidate cannot affect header/payload reads, queueing, retry/deadline/limits, terminal behavior, V1, or V2 708/709; and stays private/clone-safe with exact 707 geometry and source-span coverage.