### PR TITLE
Project offline SunSpec V2 Model 707 structural candidates

### DIFF
--- a/sunspec_chain_test.go
+++ b/sunspec_chain_test.go
@@ -152,6 +152,11 @@ func TestSunSpecV2StructuralCandidateDoesNotChangeChainBehaviorOrActivateModels(
 	if copy[0].structuralCandidate == selectedOccurrences[0].structuralCandidate {
 		t.Fatal("candidate sidecar aliases snapshot storage")
 	}
+	copy[0].structuralCandidate.layout.entries[0].path.segments[0].Name = "mutated"
+	again := selected.Occurrences()
+	if again[0].structuralCandidate.layout.entries[0].path.segments[0].Name == "mutated" {
+		t.Fatal("candidate layout aliases snapshot storage")
+	}
 }
 
 func TestSunSpecChainRetainsOrderedDuplicatesUnknownAndWrongLength(t *testing.T) {

--- a/sunspec_core_types.go
+++ b/sunspec_core_types.go
@@ -34,8 +34,11 @@ type SunSpecSourceSpan struct {
 
 // sunSpecStructuralCandidate is private metadata for a complete occurrence
 // whose opted-in structure has been validated. It intentionally carries no
-// decoder, fact, catalog, or public selection surface.
-type sunSpecStructuralCandidate struct{ modelID uint16 }
+// decoder, catalog, or public selection surface.
+type sunSpecStructuralCandidate struct {
+	modelID uint16
+	layout  sunSpecNestedOccurrenceLayout
+}
 
 type SunSpecOccurrence struct {
 	Ordinal                     uint32
@@ -78,6 +81,7 @@ func cloneOccurrence(o SunSpecOccurrence) SunSpecOccurrence {
 	}
 	if o.structuralCandidate != nil {
 		candidate := *o.structuralCandidate
+		candidate.layout = cloneSunSpecNestedOccurrenceLayout(candidate.layout)
 		o.structuralCandidate = &candidate
 	}
 	return o

--- a/sunspec_models_der_v2.go
+++ b/sunspec_models_der_v2.go
@@ -15,24 +15,14 @@ func sunSpecV2DERTripLVStructuralCandidate(revision SunSpecSchemaRevision, wireK
 		return nil
 	}
 	length := uint64(7) + uint64(curves)*(uint64(4)+9*uint64(points))
-	if length > 65534 || length != uint64(wireKey.ModelLength) || !sunSpecStructuralCandidateSpansCover(spans, uint32(len(words))) {
+	if length > 65534 || length != uint64(wireKey.ModelLength) {
 		return nil
 	}
-	return &sunSpecStructuralCandidate{modelID: wireKey.ModelID}
-}
-
-func sunSpecStructuralCandidateSpansCover(spans []SunSpecSourceSpan, expected uint32) bool {
-	if len(spans) == 0 {
-		return false
+	layout, err := buildDERTripLVV2StructuralProjectionLayout(words, spans)
+	if err != nil {
+		return nil
 	}
-	var total uint32
-	for _, span := range spans {
-		if span.LogicalViewID == 0 || span.WordCount == 0 || uint32(span.PDUOffset)+uint32(span.WordCount) > maxSunSpecOccurrenceWords || uint32(span.WordCount) > expected-total {
-			return false
-		}
-		total += uint32(span.WordCount)
-	}
-	return total == expected
+	return &sunSpecStructuralCandidate{modelID: wireKey.ModelID, layout: layout}
 }
 
 func derTripLVV2NestedTemplate() (sunSpecNestedLayoutTemplate, error) {
@@ -87,6 +77,55 @@ func buildDERTripLVV2NestedLayout(words []uint16, spans []SunSpecSourceSpan) (su
 		return sunSpecNestedOccurrenceLayout{}, err
 	}
 	return buildSunSpecNestedOccurrenceLayout(template, words, spans)
+}
+
+func buildDERTripLVV2StructuralProjectionLayout(words []uint16, spans []SunSpecSourceSpan) (sunSpecNestedOccurrenceLayout, error) {
+	template, err := derTripLVV2StructuralProjectionTemplate()
+	if err != nil {
+		return sunSpecNestedOccurrenceLayout{}, err
+	}
+	return buildSunSpecNestedOccurrenceLayout(template, words, spans)
+}
+
+func derTripLVV2StructuralProjectionTemplate() (sunSpecNestedLayoutTemplate, error) {
+	field := func(fieldID, name string, pointType SunSpecPointType, wordCount uint32, unit, scaleFactor string, symbols map[uint64]string) sunSpecNestedLayoutField {
+		return sunSpecNestedLayoutField{
+			name: name, wordCount: wordCount, emit: true, hasValueMetadata: true,
+			valueMetadata: sunSpecNestedValueMetadata{fieldID: fieldID, pointName: name, unit: unit, pointType: pointType, scaleFactor: scaleFactor, symbols: cloneSunSpecSymbols(symbols)},
+		}
+	}
+	enaSymbols := map[uint64]string{0: "DISABLED", 1: "ENABLED"}
+	resultSymbols := map[uint64]string{0: "IN_PROGRESS", 1: "COMPLETED", 2: "FAILED"}
+	readOnlySymbols := map[uint64]string{0: "RW", 1: "R"}
+	return newSunSpecNestedLayoutTemplate(
+		sunSpecNestedTemplateKey{revision: SunSpecModelsRevisionV2, modelID: 707},
+		[]sunSpecNestedCountSpec{
+			{name: "points", occurrenceWordOffset: 5, unavailable: 0xffff, min: 0, max: 65534},
+			{name: "curves", occurrenceWordOffset: 6, unavailable: 0xffff, min: 0, max: 65534},
+		},
+		sunSpecNestedLayoutGroup{
+			fields: []sunSpecNestedLayoutField{
+				field("sunspec.der.v2.707.ID", "ID", SunSpecTypeUint16, 1, "", "", nil),
+				field("sunspec.der.v2.707.L", "L", SunSpecTypeUint16, 1, "", "", nil),
+				field("sunspec.der.v2.707.Ena", "Ena", SunSpecTypeEnum16, 1, "", "", enaSymbols),
+				field("sunspec.der.v2.707.AdptCrvReq", "AdptCrvReq", SunSpecTypeUint16, 1, "", "", nil),
+				field("sunspec.der.v2.707.AdptCrvRslt", "AdptCrvRslt", SunSpecTypeEnum16, 1, "", "", resultSymbols),
+				field("sunspec.der.v2.707.NPt", "NPt", SunSpecTypeUint16, 1, "", "", nil),
+				field("sunspec.der.v2.707.NCrvSet", "NCrvSet", SunSpecTypeUint16, 1, "", "", nil),
+				field("sunspec.der.v2.707.V_SF", "V_SF", SunSpecTypeScaleFactor, 1, "", "", nil),
+				field("sunspec.der.v2.707.Tms_SF", "Tms_SF", SunSpecTypeScaleFactor, 1, "", "", nil),
+			},
+			children: []sunSpecNestedLayoutGroup{{
+				name: "Crv", repeatCount: "curves", indexBase: 1,
+				fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.ReadOnly", "ReadOnly", SunSpecTypeEnum16, 1, "", "", readOnlySymbols)},
+				children: []sunSpecNestedLayoutGroup{
+					{name: "MustTrip", fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.MustTrip.ActPt", "ActPt", SunSpecTypeUint16, 1, "", "", nil)}, children: []sunSpecNestedLayoutGroup{{name: "Pt", repeatCount: "points", indexBase: 1, fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.MustTrip.Pt.V", "V", SunSpecTypeUint16, 1, "VNomPct", "V_SF", nil), field("sunspec.der.v2.707.Crv.MustTrip.Pt.Tms", "Tms", SunSpecTypeUint32, 2, "Secs", "Tms_SF", nil)}}}},
+					{name: "MayTrip", fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.MayTrip.ActPt", "ActPt", SunSpecTypeUint16, 1, "", "", nil)}, children: []sunSpecNestedLayoutGroup{{name: "Pt", repeatCount: "points", indexBase: 1, fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.MayTrip.Pt.V", "V", SunSpecTypeUint16, 1, "VNomPct", "V_SF", nil), field("sunspec.der.v2.707.Crv.MayTrip.Pt.Tms", "Tms", SunSpecTypeUint32, 2, "Secs", "Tms_SF", nil)}}}},
+					{name: "MomCess", fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.MomCess.ActPt", "ActPt", SunSpecTypeUint16, 1, "", "", nil)}, children: []sunSpecNestedLayoutGroup{{name: "Pt", repeatCount: "points", indexBase: 1, fields: []sunSpecNestedLayoutField{field("sunspec.der.v2.707.Crv.MomCess.Pt.V", "V", SunSpecTypeUint16, 1, "VNomPct", "V_SF", nil), field("sunspec.der.v2.707.Crv.MomCess.Pt.Tms", "Tms", SunSpecTypeUint32, 2, "Secs", "Tms_SF", nil)}}}},
+				},
+			}},
+		},
+	)
 }
 
 func derDCMeasureV2SunSpecDefinition(length uint16) (sunSpecModelDefinition, error) {

--- a/sunspec_nested_layout_builder.go
+++ b/sunspec_nested_layout_builder.go
@@ -17,8 +17,10 @@ type sunSpecNestedCountSpec struct {
 }
 
 type sunSpecNestedValueMetadata struct {
-	pointType   SunSpecPointType
-	scaleFactor string
+	fieldID, pointName, unit string
+	pointType                SunSpecPointType
+	scaleFactor              string
+	symbols                  map[uint64]string
 }
 
 type sunSpecNestedLayoutField struct {
@@ -88,9 +90,24 @@ type sunSpecNestedOccurrenceLayout struct {
 func (l sunSpecNestedOccurrenceLayout) Entries() []sunSpecNestedLayoutEntry {
 	out := make([]sunSpecNestedLayoutEntry, len(l.entries))
 	for index, entry := range l.entries {
-		out[index] = sunSpecNestedLayoutEntry{path: entry.Path(), sourceRange: entry.SourceRange(), hasValueMetadata: entry.hasValueMetadata, valueMetadata: entry.valueMetadata}
+		out[index] = cloneSunSpecNestedLayoutEntry(entry)
 	}
 	return out
+}
+
+func cloneSunSpecNestedOccurrenceLayout(layout sunSpecNestedOccurrenceLayout) sunSpecNestedOccurrenceLayout {
+	return sunSpecNestedOccurrenceLayout{key: layout.key, entries: layout.Entries()}
+}
+
+func cloneSunSpecNestedLayoutEntry(entry sunSpecNestedLayoutEntry) sunSpecNestedLayoutEntry {
+	metadata := entry.valueMetadata
+	metadata.symbols = cloneSunSpecSymbols(metadata.symbols)
+	return sunSpecNestedLayoutEntry{
+		path:             entry.Path(),
+		sourceRange:      entry.SourceRange(),
+		hasValueMetadata: entry.hasValueMetadata,
+		valueMetadata:    metadata,
+	}
 }
 
 func newSunSpecNestedLayoutTemplate(key sunSpecNestedTemplateKey, counts []sunSpecNestedCountSpec, root sunSpecNestedLayoutGroup) (sunSpecNestedLayoutTemplate, error) {
@@ -142,9 +159,6 @@ func validateSunSpecNestedLayoutGroup(group sunSpecNestedLayoutGroup, countNames
 		if field.hasValueMetadata && (!field.emit || field.valueMetadata.pointType == "") {
 			return fmt.Errorf("SunSpec nested layout metadata is invalid")
 		}
-		if root && field.emit {
-			return fmt.Errorf("SunSpec nested layout root cannot emit a path")
-		}
 	}
 	for _, child := range group.children {
 		if err := validateSunSpecNestedLayoutGroup(child, countNames, false, depth+1); err != nil {
@@ -156,6 +170,9 @@ func validateSunSpecNestedLayoutGroup(group sunSpecNestedLayoutGroup, countNames
 
 func cloneSunSpecNestedLayoutGroup(group sunSpecNestedLayoutGroup) sunSpecNestedLayoutGroup {
 	group.fields = append([]sunSpecNestedLayoutField(nil), group.fields...)
+	for index := range group.fields {
+		group.fields[index].valueMetadata.symbols = cloneSunSpecSymbols(group.fields[index].valueMetadata.symbols)
+	}
 	group.children = append([]sunSpecNestedLayoutGroup(nil), group.children...)
 	for index := range group.children {
 		group.children[index] = cloneSunSpecNestedLayoutGroup(group.children[index])

--- a/sunspec_qualification_observation_test.go
+++ b/sunspec_qualification_observation_test.go
@@ -140,6 +140,32 @@ func TestSunSpecQualificationObservationJSONGoldenAndBoundedReplay(t *testing.T)
 	}
 }
 
+func TestSunSpecQualificationObservationJSONIgnoresPrivateStructuralCandidate(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	baseline, err := NewSunSpecQualificationObservation(registry, qualificationSnapshot(t, registry))
+	if err != nil {
+		t.Fatal(err)
+	}
+	baselineJSON, err := json.Marshal(baseline)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	candidateSnapshot := qualificationSnapshot(t, registry)
+	candidateSnapshot.occurrences[0].structuralCandidate = &sunSpecStructuralCandidate{modelID: 707}
+	candidate, err := NewSunSpecQualificationObservation(registry, candidateSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateJSON, err := json.Marshal(candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(candidateJSON, baselineJSON) {
+		t.Fatal("qualification JSON changed when private structural candidate metadata was present")
+	}
+}
+
 func TestSunSpecQualificationObservationRetainsCoalescedTCPProvenance(t *testing.T) {
 	registry := mustStandardSunSpecRegistry(t)
 	baseline, err := NewSunSpecQualificationObservation(registry, qualificationSnapshot(t, registry))

--- a/sunspec_structural_projection.go
+++ b/sunspec_structural_projection.go
@@ -1,0 +1,124 @@
+package modbusreg
+
+// SunSpecStructuralProjection is a detached offline projection of one
+// privately validated structural candidate. It is neither a decoder selection
+// nor a profile, qualification, or runtime admission result.
+type SunSpecStructuralProjection struct {
+	wireKey  SunSpecWireKey
+	revision SunSpecSchemaRevision
+	ordinal  uint32
+	raw      []uint16
+	spans    []SunSpecSourceSpan
+	facts    []SunSpecFact
+}
+
+func (p SunSpecStructuralProjection) WireKey() SunSpecWireKey { return p.wireKey }
+func (p SunSpecStructuralProjection) SchemaRevision() SunSpecSchemaRevision {
+	return p.revision
+}
+func (p SunSpecStructuralProjection) Ordinal() uint32 { return p.ordinal }
+func (p SunSpecStructuralProjection) RawWords() []uint16 {
+	return append([]uint16(nil), p.raw...)
+}
+func (p SunSpecStructuralProjection) SourceSpans() []SunSpecSourceSpan {
+	return append([]SunSpecSourceSpan(nil), p.spans...)
+}
+func (p SunSpecStructuralProjection) Facts() []SunSpecFact {
+	out := make([]SunSpecFact, len(p.facts))
+	for index, fact := range p.facts {
+		out[index] = cloneSunSpecFact(fact)
+	}
+	return out
+}
+
+// ProjectSunSpecStructuralFacts projects only layout sidecars retained during
+// post-payload structural selection. It never selects, admits, or decodes an
+// occurrence, and does not recompute occurrence geometry.
+func ProjectSunSpecStructuralFacts(snapshot SunSpecChainSnapshot) []SunSpecStructuralProjection {
+	projections := make([]SunSpecStructuralProjection, 0)
+	for _, occurrence := range snapshot.Occurrences() {
+		projection, ok := projectSunSpecStructuralCandidate(occurrence)
+		if ok {
+			projections = append(projections, projection)
+		}
+	}
+	return projections
+}
+
+func projectSunSpecStructuralCandidate(occurrence SunSpecOccurrence) (SunSpecStructuralProjection, bool) {
+	candidate := occurrence.structuralCandidate
+	if candidate == nil || candidate.modelID != 707 || occurrence.SchemaRevision != SunSpecModelsRevisionV2 || occurrence.WireKey.ModelID != candidate.modelID || occurrence.Disposition != SunSpecChainDispositionUnknownModel || occurrence.decoderKey != nil || candidate.layout.key != (sunSpecNestedTemplateKey{revision: SunSpecModelsRevisionV2, modelID: 707}) {
+		return SunSpecStructuralProjection{}, false
+	}
+	facts, ok := projectSunSpecStructuralLayout(occurrence.words, candidate.layout)
+	if !ok {
+		return SunSpecStructuralProjection{}, false
+	}
+	return SunSpecStructuralProjection{
+		wireKey:  occurrence.WireKey,
+		revision: occurrence.SchemaRevision,
+		ordinal:  occurrence.Ordinal,
+		raw:      append([]uint16(nil), occurrence.words...),
+		spans:    append([]SunSpecSourceSpan(nil), occurrence.spans...),
+		facts:    facts,
+	}, true
+}
+
+func projectSunSpecStructuralLayout(words []uint16, layout sunSpecNestedOccurrenceLayout) ([]SunSpecFact, bool) {
+	entries := layout.Entries()
+	if len(entries) == 0 {
+		return []SunSpecFact{}, true
+	}
+	scales := make(map[string]SunSpecValue)
+	for _, entry := range entries {
+		definition, raw, ok := sunSpecStructuralEntryDefinition(words, entry)
+		if !ok {
+			return nil, false
+		}
+		if definition.pointType == SunSpecTypeScaleFactor {
+			scales[definition.name] = decodeSunSpecValue(definition, raw, nil)
+		}
+	}
+	facts := make([]SunSpecFact, 0, len(entries))
+	for _, entry := range entries {
+		definition, raw, ok := sunSpecStructuralEntryDefinition(words, entry)
+		if !ok {
+			return nil, false
+		}
+		var scale *SunSpecValue
+		if definition.scaleFactor != "" {
+			value, exists := scales[definition.scaleFactor]
+			if !exists {
+				return nil, false
+			}
+			scale = &value
+		}
+		fact, err := (SunSpecFact{
+			FieldID: definition.fieldID, PointName: definition.name, Unit: definition.unit,
+			Value: decodeSunSpecValue(definition, raw, scale),
+		}).WithNestedLayout(entry.Path(), entry.SourceRange())
+		if err != nil {
+			return nil, false
+		}
+		facts = append(facts, fact)
+	}
+	return facts, true
+}
+
+func sunSpecStructuralEntryDefinition(words []uint16, entry sunSpecNestedLayoutEntry) (sunSpecPointDefinition, []uint16, bool) {
+	if !entry.hasValueMetadata {
+		return sunSpecPointDefinition{}, nil, false
+	}
+	metadata := entry.valueMetadata
+	rangeValue := entry.SourceRange()
+	start, count := rangeValue.OccurrenceOffset(), rangeValue.WordCount()
+	if count == 0 || start > uint32(len(words)) || count > uint32(len(words))-start || count > 0xffff || metadata.fieldID == "" || metadata.pointName == "" {
+		return sunSpecPointDefinition{}, nil, false
+	}
+	definition := sunSpecPointDefinition{
+		name: metadata.pointName, fieldID: metadata.fieldID, unit: metadata.unit,
+		scaleFactor: metadata.scaleFactor, pointType: metadata.pointType, size: uint16(count),
+		symbols: cloneSunSpecSymbols(metadata.symbols),
+	}
+	return definition, append([]uint16(nil), words[start:start+count]...), true
+}

--- a/sunspec_structural_projection_test.go
+++ b/sunspec_structural_projection_test.go
@@ -55,7 +55,7 @@ func TestProjectSunSpecStructuralFactsProjectsOnlyRetained707Candidates(t *testi
 	if voltage.FieldID != "sunspec.der.v2.707.Crv.MustTrip.Pt.V" || voltage.Unit != "VNomPct" || voltage.Required {
 		t.Fatalf("voltage fact=%#v", voltage)
 	}
-	if decimal, ok := voltage.Value.Decimal(); !ok || decimal.Coefficient != 1 || decimal.Exponent != 0 {
+	if decimal, ok := voltage.Value.Decimal(); !ok || decimal.Coefficient != 0 || decimal.Exponent != 0 {
 		t.Fatalf("voltage value=%#v", voltage.Value)
 	}
 	if elapsed.FieldID != "sunspec.der.v2.707.Crv.MustTrip.Pt.Tms" || elapsed.Unit != "Secs" {
@@ -101,7 +101,7 @@ func TestProjectSunSpecStructuralFactsKeepsInvalidScaleRaw(t *testing.T) {
 		if !ok || !reflect.DeepEqual(path.Segments(), []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 1}, {Name: "MustTrip"}, {Name: "Pt", Indexed: true, Index: 1}, {Name: "V"}}) {
 			continue
 		}
-		if fact.Value.State() != SunSpecValueNotImplemented || len(fact.Value.RawWords()) != 1 || fact.Value.RawWords()[0] != 1 {
+		if fact.Value.State() != SunSpecValueNotImplemented || len(fact.Value.RawWords()) != 1 || fact.Value.RawWords()[0] != 0 {
 			t.Fatalf("scaled voltage did not retain raw unavailable state: %#v", fact.Value)
 		}
 		if _, ok := fact.Value.Decimal(); ok {

--- a/sunspec_structural_projection_test.go
+++ b/sunspec_structural_projection_test.go
@@ -1,0 +1,113 @@
+package modbusreg
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestProjectSunSpecStructuralFactsProjectsOnlyRetained707Candidates(t *testing.T) {
+	plain, _ := runV2StructuralCandidateChain(t, nil)
+	if got := ProjectSunSpecStructuralFacts(plain); len(got) != 0 {
+		t.Fatalf("plain projections=%#v", got)
+	}
+
+	snapshot, _ := runV2StructuralCandidateChain(t, []uint16{707})
+	projections := ProjectSunSpecStructuralFacts(snapshot)
+	if len(projections) != 2 {
+		t.Fatalf("projections=%d want=2", len(projections))
+	}
+	for index, projection := range projections {
+		if got := projection.WireKey(); got != (SunSpecWireKey{ModelID: 707, ModelLength: 33}) {
+			t.Fatalf("projection %d wire key=%#v", index, got)
+		}
+		if projection.SchemaRevision() != SunSpecModelsRevisionV2 || projection.Ordinal() != uint32(index+1) {
+			t.Fatalf("projection %d identity revision=%q ordinal=%d", index, projection.SchemaRevision(), projection.Ordinal())
+		}
+		if facts := projection.Facts(); len(facts) != 29 {
+			t.Fatalf("projection %d facts=%d want=29", index, len(facts))
+		}
+	}
+
+	first := projections[0]
+	if got := first.RawWords(); len(got) != 35 || got[0] != 707 || got[1] != 33 {
+		t.Fatalf("projection raw=%#v", got)
+	}
+	if got := first.SourceSpans(); len(got) == 0 {
+		t.Fatal("projection omitted source spans")
+	}
+
+	facts := first.Facts()
+	var voltage, elapsed, readOnly SunSpecFact
+	for _, fact := range facts {
+		path, ok := fact.NestedPath()
+		if !ok {
+			t.Fatalf("fact %q omitted nested path", fact.FieldID)
+		}
+		switch {
+		case reflect.DeepEqual(path.Segments(), []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 1}, {Name: "MustTrip"}, {Name: "Pt", Indexed: true, Index: 1}, {Name: "V"}}):
+			voltage = fact
+		case reflect.DeepEqual(path.Segments(), []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 1}, {Name: "MustTrip"}, {Name: "Pt", Indexed: true, Index: 1}, {Name: "Tms"}}):
+			elapsed = fact
+		case reflect.DeepEqual(path.Segments(), []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 1}, {Name: "ReadOnly"}}):
+			readOnly = fact
+		}
+	}
+	if voltage.FieldID != "sunspec.der.v2.707.Crv.MustTrip.Pt.V" || voltage.Unit != "VNomPct" || voltage.Required {
+		t.Fatalf("voltage fact=%#v", voltage)
+	}
+	if decimal, ok := voltage.Value.Decimal(); !ok || decimal.Coefficient != 1 || decimal.Exponent != 0 {
+		t.Fatalf("voltage value=%#v", voltage.Value)
+	}
+	if elapsed.FieldID != "sunspec.der.v2.707.Crv.MustTrip.Pt.Tms" || elapsed.Unit != "Secs" {
+		t.Fatalf("elapsed fact=%#v", elapsed)
+	}
+	if decimal, ok := elapsed.Value.Decimal(); !ok || decimal.Coefficient != 1 || decimal.Exponent != 0 {
+		t.Fatalf("elapsed value=%#v", elapsed.Value)
+	}
+	if number, symbol, ok := readOnly.Value.Enum(); !ok || number != 0 || symbol != "RW" {
+		t.Fatalf("read-only enum=%#v", readOnly.Value)
+	}
+	if source, ok := voltage.OccurrenceSourceRange(); !ok || source.OccurrenceOffset() != 11 || source.WordCount() != 1 || len(source.SourceSpans()) == 0 {
+		t.Fatalf("voltage provenance=%#v ok=%v", source, ok)
+	}
+
+	facts[0].path.segments[0].Name = "mutated"
+	if got, _ := first.Facts()[0].NestedPath(); got.Segments()[0].Name == "mutated" {
+		t.Fatal("projection facts alias retained layout")
+	}
+	raw := first.RawWords()
+	raw[0] = 1
+	if first.RawWords()[0] != 707 {
+		t.Fatal("projection raw words alias retained occurrence")
+	}
+
+	api := reflect.TypeFor[SunSpecStructuralProjection]()
+	for _, forbidden := range []string{"DecoderKey", "Qualifies", "Topology", "Decode"} {
+		if _, exists := api.MethodByName(forbidden); exists {
+			t.Fatalf("projection exposes admission/decoder surface %s", forbidden)
+		}
+	}
+}
+
+func TestProjectSunSpecStructuralFactsKeepsInvalidScaleRaw(t *testing.T) {
+	snapshot, _ := runV2StructuralCandidateChain(t, []uint16{707})
+	snapshot.occurrences[0].words[7] = 0x8000 // V_SF remains structurally present but unavailable.
+	projections := ProjectSunSpecStructuralFacts(snapshot)
+	if len(projections) != 2 {
+		t.Fatalf("projections=%d want=2", len(projections))
+	}
+	for _, fact := range projections[0].Facts() {
+		path, ok := fact.NestedPath()
+		if !ok || !reflect.DeepEqual(path.Segments(), []SunSpecFactPathSegment{{Name: "Crv", Indexed: true, Index: 1}, {Name: "MustTrip"}, {Name: "Pt", Indexed: true, Index: 1}, {Name: "V"}}) {
+			continue
+		}
+		if fact.Value.State() != SunSpecValueNotImplemented || len(fact.Value.RawWords()) != 1 || fact.Value.RawWords()[0] != 1 {
+			t.Fatalf("scaled voltage did not retain raw unavailable state: %#v", fact.Value)
+		}
+		if _, ok := fact.Value.Decimal(); ok {
+			t.Fatal("scaled voltage retained a decimal under unavailable scale")
+		}
+		return
+	}
+	t.Fatal("projected voltage fact absent")
+}


### PR DESCRIPTION
Closes #111

RED-first for the docs-gated offline projection API. This branch will retain a clone-safe immutable layout only after the existing complete Model 707 structural candidate succeeds, then project detached facts without decoder admission or DecodeOccurrence/DecodeChain integration.

Docs gate: `helianthus-docs-modbus@c66ffa75b8a3a40bd66f1a7ef434ec48715a950c`.

Excluded: decoder keys/catalog/cache, qualification JSON, acquisition, runtime, transport, vendor/profile admission, and live I/O.