### PR TITLE
Validate Huawei S-Dongle offline gateway observation

### DIFF
--- a/huawei_sdongle_observation.go
+++ b/huawei_sdongle_observation.go
@@ -1,0 +1,110 @@
+package modbusreg
+
+// HuaweiSDongleOfflineReason explains a transport-free gateway-observation
+// result. A matched observation remains default denied.
+type HuaweiSDongleOfflineReason string
+
+const (
+	HuaweiSDongleOfflineMatched          HuaweiSDongleOfflineReason = "matched"
+	HuaweiSDongleOfflineModelMismatch    HuaweiSDongleOfflineReason = "model_mismatch"
+	HuaweiSDongleOfflineFirmwareMismatch HuaweiSDongleOfflineReason = "firmware_mismatch"
+	HuaweiSDongleOfflineProtocolMismatch HuaweiSDongleOfflineReason = "protocol_mismatch"
+	HuaweiSDongleOfflineSearchIncomplete HuaweiSDongleOfflineReason = "search_incomplete"
+	HuaweiSDongleOfflineSequenceMismatch HuaweiSDongleOfflineReason = "sequence_mismatch"
+	HuaweiSDongleOfflineCapacityMismatch HuaweiSDongleOfflineReason = "capacity_mismatch"
+)
+
+const (
+	HuaweiSDongleCanonicalClass    = "S-Dongle"
+	HuaweiSDongleReadOnlyProfileID = "huawei.sdongle.readonly.v1"
+)
+
+// HuaweiSDongleOfflineObservation is an already-decoded unit-100 snapshot.
+// It intentionally carries no endpoint, socket, or request details.
+type HuaweiSDongleOfflineObservation struct {
+	Model                string
+	Firmware             string
+	ProtocolMajor        uint8
+	ProtocolMinor        uint8
+	SearchState          uint16
+	ChangeSequenceBefore uint16
+	ChangeSequenceAfter  uint16
+	Capacity             uint16
+	ChildCount           uint16
+}
+
+// HuaweiSDongleOfflineDecision is a default-denied result. It never enables
+// runtime admission, child inventory, or an operation.
+type HuaweiSDongleOfflineDecision struct {
+	matched bool
+	model   string
+	reason  HuaweiSDongleOfflineReason
+}
+
+func (d HuaweiSDongleOfflineDecision) Matched() bool { return d.matched }
+
+func (d HuaweiSDongleOfflineDecision) CanonicalClass() string {
+	if !d.matched {
+		return ""
+	}
+	return HuaweiSDongleCanonicalClass
+}
+
+func (d HuaweiSDongleOfflineDecision) ModelVariant() string { return d.model }
+
+func (d HuaweiSDongleOfflineDecision) ProfileID() string {
+	if !d.matched {
+		return ""
+	}
+	return HuaweiSDongleReadOnlyProfileID
+}
+
+func (d HuaweiSDongleOfflineDecision) DefaultDenied() bool { return true }
+
+func (d HuaweiSDongleOfflineDecision) Reason() HuaweiSDongleOfflineReason { return d.reason }
+
+// EvaluateHuaweiSDongleOfflineObservation validates a complete, already-read
+// gateway observation. It performs no Modbus I/O and remains non-actionable
+// even when the documented tuple matches.
+func EvaluateHuaweiSDongleOfflineObservation(observation HuaweiSDongleOfflineObservation) HuaweiSDongleOfflineDecision {
+	model := trimHuaweiTerminalPadding(observation.Model)
+	if !isHuaweiSDongleModel(model) {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineModelMismatch}
+	}
+	if !isHuaweiSDongleFirmwareTuple(model, trimHuaweiTerminalPadding(observation.Firmware)) {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineFirmwareMismatch}
+	}
+	if observation.ProtocolMajor != 5 || observation.ProtocolMinor != 0 {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineProtocolMismatch}
+	}
+	if observation.SearchState != 0 {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineSearchIncomplete}
+	}
+	if observation.ChangeSequenceBefore != observation.ChangeSequenceAfter {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineSequenceMismatch}
+	}
+	if observation.ChildCount > observation.Capacity {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineCapacityMismatch}
+	}
+	return HuaweiSDongleOfflineDecision{
+		matched: true,
+		model:   model,
+		reason:  HuaweiSDongleOfflineMatched,
+	}
+}
+
+func isHuaweiSDongleModel(model string) bool {
+	switch model {
+	case "S-DongleA-05", "S-DongleB-03", "S-DongleB-06":
+		return true
+	default:
+		return false
+	}
+}
+
+func isHuaweiSDongleFirmwareTuple(model, firmware string) bool {
+	if firmware == "V200R025C00SPC120" {
+		return true
+	}
+	return model == "S-DongleA-05" && firmware == "V200R022C10SPC312"
+}

--- a/huawei_sdongle_observation.go
+++ b/huawei_sdongle_observation.go
@@ -6,6 +6,7 @@ type HuaweiSDongleOfflineReason string
 
 const (
 	HuaweiSDongleOfflineMatched          HuaweiSDongleOfflineReason = "matched"
+	HuaweiSDongleOfflineUnitMismatch     HuaweiSDongleOfflineReason = "unit_mismatch"
 	HuaweiSDongleOfflineModelMismatch    HuaweiSDongleOfflineReason = "model_mismatch"
 	HuaweiSDongleOfflineFirmwareMismatch HuaweiSDongleOfflineReason = "firmware_mismatch"
 	HuaweiSDongleOfflineProtocolMismatch HuaweiSDongleOfflineReason = "protocol_mismatch"
@@ -22,6 +23,7 @@ const (
 // HuaweiSDongleOfflineObservation is an already-decoded unit-100 snapshot.
 // It intentionally carries no endpoint, socket, or request details.
 type HuaweiSDongleOfflineObservation struct {
+	UnitID               uint8
 	Model                string
 	Firmware             string
 	ProtocolMajor        uint8
@@ -67,6 +69,9 @@ func (d HuaweiSDongleOfflineDecision) Reason() HuaweiSDongleOfflineReason { retu
 // gateway observation. It performs no Modbus I/O and remains non-actionable
 // even when the documented tuple matches.
 func EvaluateHuaweiSDongleOfflineObservation(observation HuaweiSDongleOfflineObservation) HuaweiSDongleOfflineDecision {
+	if observation.UnitID != 100 {
+		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineUnitMismatch}
+	}
 	model := trimHuaweiTerminalPadding(observation.Model)
 	if !isHuaweiSDongleModel(model) {
 		return HuaweiSDongleOfflineDecision{reason: HuaweiSDongleOfflineModelMismatch}

--- a/huawei_sdongle_observation_test.go
+++ b/huawei_sdongle_observation_test.go
@@ -1,0 +1,93 @@
+package modbusreg
+
+import "testing"
+
+func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTuples(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   HuaweiSDongleOfflineObservation
+		matched bool
+		variant string
+		reason  HuaweiSDongleOfflineReason
+	}{
+		{
+			name: "A05 current documented tuple",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleA-05", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 4, ChildCount: 2,
+			},
+			matched: true, variant: "S-DongleA-05", reason: HuaweiSDongleOfflineMatched,
+		},
+		{
+			name: "A05 observed legacy tuple remains default denied",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleA-05\x00 ", Firmware: "V200R022C10SPC312 ", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
+			},
+			matched: true, variant: "S-DongleA-05", reason: HuaweiSDongleOfflineMatched,
+		},
+		{
+			name: "model must be exact",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleA-05-Pro", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
+			},
+			reason: HuaweiSDongleOfflineModelMismatch,
+		},
+		{
+			name: "unsupported firmware",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleB-03", Firmware: "V200R025C00SPC121", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
+			},
+			reason: HuaweiSDongleOfflineFirmwareMismatch,
+		},
+		{
+			name: "protocol baseline differs",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 1,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
+			},
+			reason: HuaweiSDongleOfflineProtocolMismatch,
+		},
+		{
+			name: "search incomplete",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 1, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
+			},
+			reason: HuaweiSDongleOfflineSearchIncomplete,
+		},
+		{
+			name: "sequence changes",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 8, Capacity: 1, ChildCount: 1,
+			},
+			reason: HuaweiSDongleOfflineSequenceMismatch,
+		},
+		{
+			name: "child count exceeds capacity",
+			input: HuaweiSDongleOfflineObservation{
+				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 2,
+			},
+			reason: HuaweiSDongleOfflineCapacityMismatch,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := EvaluateHuaweiSDongleOfflineObservation(test.input)
+			if decision.Matched() != test.matched || decision.Reason() != test.reason || decision.DefaultDenied() != true {
+				t.Fatalf("decision=(matched=%t reason=%q defaultDenied=%t), want (matched=%t reason=%q defaultDenied=true)", decision.Matched(), decision.Reason(), decision.DefaultDenied(), test.matched, test.reason)
+			}
+			if test.matched && (decision.CanonicalClass() != "S-Dongle" || decision.ModelVariant() != test.variant || decision.ProfileID() != "huawei.sdongle.readonly.v1") {
+				t.Fatalf("unexpected recognized decision: %#v", decision)
+			}
+			if !test.matched && (decision.CanonicalClass() != "" || decision.ProfileID() != "") {
+				t.Fatalf("unmatched decision must not expose a profile: %#v", decision)
+			}
+		})
+	}
+}

--- a/huawei_sdongle_observation_test.go
+++ b/huawei_sdongle_observation_test.go
@@ -13,7 +13,7 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "A05 current documented tuple",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleA-05", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleA-05", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 4, ChildCount: 2,
 			},
 			matched: true, variant: "S-DongleA-05", reason: HuaweiSDongleOfflineMatched,
@@ -21,15 +21,23 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "A05 observed legacy tuple remains default denied",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleA-05\x00 ", Firmware: "V200R022C10SPC312 ", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleA-05\x00 ", Firmware: "V200R022C10SPC312 ", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
 			},
 			matched: true, variant: "S-DongleA-05", reason: HuaweiSDongleOfflineMatched,
 		},
 		{
+			name: "child unit is not a gateway observation",
+			input: HuaweiSDongleOfflineObservation{
+				UnitID: 1, Model: "S-DongleA-05", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
+			},
+			reason: HuaweiSDongleOfflineUnitMismatch,
+		},
+		{
 			name: "model must be exact",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleA-05-Pro", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleA-05-Pro", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
 			},
 			reason: HuaweiSDongleOfflineModelMismatch,
@@ -37,7 +45,7 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "unsupported firmware",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleB-03", Firmware: "V200R025C00SPC121", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleB-03", Firmware: "V200R025C00SPC121", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
 			},
 			reason: HuaweiSDongleOfflineFirmwareMismatch,
@@ -45,7 +53,7 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "protocol baseline differs",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 1,
+				UnitID: 100, Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 1,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
 			},
 			reason: HuaweiSDongleOfflineProtocolMismatch,
@@ -53,7 +61,7 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "search incomplete",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 1, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 1,
 			},
 			reason: HuaweiSDongleOfflineSearchIncomplete,
@@ -61,7 +69,7 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "sequence changes",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 8, Capacity: 1, ChildCount: 1,
 			},
 			reason: HuaweiSDongleOfflineSequenceMismatch,
@@ -69,7 +77,7 @@ func TestEvaluateHuaweiSDongleOfflineObservationRecognizesExactDefaultDeniedTupl
 		{
 			name: "child count exceeds capacity",
 			input: HuaweiSDongleOfflineObservation{
-				Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+				UnitID: 100, Model: "S-DongleB-06", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
 				SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 1, ChildCount: 2,
 			},
 			reason: HuaweiSDongleOfflineCapacityMismatch,


### PR DESCRIPTION
Closes #115

## Docs gate

Uses the existing Huawei read-only candidate contract in docs-modbus.

## RED

`GOWORK=off go test ./...` fails because the offline observation API does not exist.

## Scope

Default-denied validation of already captured unit-100 fields only. No sockets, Modbus requests, extended MEI, inventory, catalog/runtime admission, or operations.