### PR TITLE
Parse bounded Huawei EMMA offline inventory

### DIFF
--- a/huawei_emma_inventory.go
+++ b/huawei_emma_inventory.go
@@ -6,11 +6,11 @@ package modbusreg
 type HuaweiEMMAOfflineInventoryInput struct {
 	InventoryGuardBefore uint16
 	InventoryGuardAfter  uint16
-	Pages                []HuaweiSmartLoggerInventoryPage
+	Pages                []HuaweiGatewayInventoryPage
 }
 
 // HuaweiEMMAOfflineInventory is a validated, default-denied inventory view.
-type HuaweiEMMAOfflineInventory = HuaweiSmartLoggerInventory
+type HuaweiEMMAOfflineInventory = HuaweiGatewayInventory
 
 // ParseHuaweiEMMAOfflineInventory validates a supplied EMMA inventory. Only
 // the finite EMMA aliases can be a self entry; a canonical family label or an

--- a/huawei_emma_inventory.go
+++ b/huawei_emma_inventory.go
@@ -1,0 +1,26 @@
+package modbusreg
+
+// HuaweiEMMAOfflineInventoryInput is a detached, already-read EMMA extended
+// MEI inventory. The guard values are supplied by the caller; this package
+// performs no request or inventory acquisition.
+type HuaweiEMMAOfflineInventoryInput struct {
+	InventoryGuardBefore uint16
+	InventoryGuardAfter  uint16
+	Pages                []HuaweiSmartLoggerInventoryPage
+}
+
+// HuaweiEMMAOfflineInventory is a validated, default-denied inventory view.
+type HuaweiEMMAOfflineInventory = HuaweiSmartLoggerInventory
+
+// ParseHuaweiEMMAOfflineInventory validates a supplied EMMA inventory. Only
+// the finite EMMA aliases can be a self entry; a canonical family label or an
+// unrecognized variant is fail-closed.
+func ParseHuaweiEMMAOfflineInventory(input HuaweiEMMAOfflineInventoryInput) (HuaweiEMMAOfflineInventory, error) {
+	return parseHuaweiExtendedMEIOfflineInventory(HuaweiSmartLoggerOfflineInventoryInput{
+		ChangeCounterBefore: input.InventoryGuardBefore,
+		ChangeCounterAfter:  input.InventoryGuardAfter,
+		Pages:               input.Pages,
+	}, func(model string) bool {
+		return model == "EMMA-A01" || model == "EMMA-A02"
+	})
+}

--- a/huawei_emma_inventory_test.go
+++ b/huawei_emma_inventory_test.go
@@ -1,0 +1,69 @@
+package modbusreg
+
+import "testing"
+
+func TestParseHuaweiEMMAOfflineInventoryAcceptsFiniteSelfAlias(t *testing.T) {
+	inventory, err := ParseHuaweiEMMAOfflineInventory(HuaweiEMMAOfflineInventoryInput{
+		InventoryGuardBefore: 12,
+		InventoryGuardAfter:  12,
+		Pages: []HuaweiSmartLoggerInventoryPage{{
+			Objects: []HuaweiSmartLoggerInventoryObject{
+				{ObjectID: 0x87, Value: []byte{1}},
+				{ObjectID: 0x88, Value: []byte("1=EMMA-A02;2=SmartHEMS V100R025C00SPC131;5=0")},
+				{ObjectID: 0x89, Value: []byte("1=SUN2000;2=V300R024C10SPC191;5=1")},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ParseHuaweiEMMAOfflineInventory() error = %v", err)
+	}
+	if inventory.DeclaredChildren() != 1 || inventory.ChildCount() != 1 || !inventory.DefaultDenied() ||
+		inventory.Children()[0].Address() != "1" {
+		t.Fatalf("unexpected EMMA inventory: %#v", inventory)
+	}
+}
+
+func TestParseHuaweiEMMAOfflineInventoryFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		input HuaweiEMMAOfflineInventoryInput
+	}{
+		{
+			name: "canonical family token is not an alias",
+			input: HuaweiEMMAOfflineInventoryInput{
+				InventoryGuardBefore: 1, InventoryGuardAfter: 1,
+				Pages: []HuaweiSmartLoggerInventoryPage{{Objects: []HuaweiSmartLoggerInventoryObject{
+					{ObjectID: 0x87, Value: []byte{0}},
+					{ObjectID: 0x88, Value: []byte("1=EMMA;5=0")},
+				}}},
+			},
+		},
+		{
+			name: "case differs",
+			input: HuaweiEMMAOfflineInventoryInput{
+				InventoryGuardBefore: 1, InventoryGuardAfter: 1,
+				Pages: []HuaweiSmartLoggerInventoryPage{{Objects: []HuaweiSmartLoggerInventoryObject{
+					{ObjectID: 0x87, Value: []byte{0}},
+					{ObjectID: 0x88, Value: []byte("1=emma-a01;5=0")},
+				}}},
+			},
+		},
+		{
+			name: "inventory guard changes",
+			input: HuaweiEMMAOfflineInventoryInput{
+				InventoryGuardBefore: 1, InventoryGuardAfter: 2,
+				Pages: []HuaweiSmartLoggerInventoryPage{{Objects: []HuaweiSmartLoggerInventoryObject{
+					{ObjectID: 0x87, Value: []byte{0}},
+					{ObjectID: 0x88, Value: []byte("1=EMMA-A01;5=0")},
+				}}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			inventory, err := ParseHuaweiEMMAOfflineInventory(test.input)
+			if err == nil || inventory.DeclaredChildren() != 0 || inventory.ChildCount() != 0 {
+				t.Fatalf("expected fail-closed inventory, got %#v err=%v", inventory, err)
+			}
+		})
+	}
+}

--- a/huawei_emma_inventory_test.go
+++ b/huawei_emma_inventory_test.go
@@ -6,8 +6,8 @@ func TestParseHuaweiEMMAOfflineInventoryAcceptsFiniteSelfAlias(t *testing.T) {
 	inventory, err := ParseHuaweiEMMAOfflineInventory(HuaweiEMMAOfflineInventoryInput{
 		InventoryGuardBefore: 12,
 		InventoryGuardAfter:  12,
-		Pages: []HuaweiSmartLoggerInventoryPage{{
-			Objects: []HuaweiSmartLoggerInventoryObject{
+		Pages: []HuaweiGatewayInventoryPage{{
+			Objects: []HuaweiGatewayInventoryObject{
 				{ObjectID: 0x87, Value: []byte{1}},
 				{ObjectID: 0x88, Value: []byte("1=EMMA-A02;2=SmartHEMS V100R025C00SPC131;5=0")},
 				{ObjectID: 0x89, Value: []byte("1=SUN2000;2=V300R024C10SPC191;5=1")},
@@ -32,7 +32,7 @@ func TestParseHuaweiEMMAOfflineInventoryFailsClosed(t *testing.T) {
 			name: "canonical family token is not an alias",
 			input: HuaweiEMMAOfflineInventoryInput{
 				InventoryGuardBefore: 1, InventoryGuardAfter: 1,
-				Pages: []HuaweiSmartLoggerInventoryPage{{Objects: []HuaweiSmartLoggerInventoryObject{
+				Pages: []HuaweiGatewayInventoryPage{{Objects: []HuaweiGatewayInventoryObject{
 					{ObjectID: 0x87, Value: []byte{0}},
 					{ObjectID: 0x88, Value: []byte("1=EMMA;5=0")},
 				}}},
@@ -42,7 +42,7 @@ func TestParseHuaweiEMMAOfflineInventoryFailsClosed(t *testing.T) {
 			name: "case differs",
 			input: HuaweiEMMAOfflineInventoryInput{
 				InventoryGuardBefore: 1, InventoryGuardAfter: 1,
-				Pages: []HuaweiSmartLoggerInventoryPage{{Objects: []HuaweiSmartLoggerInventoryObject{
+				Pages: []HuaweiGatewayInventoryPage{{Objects: []HuaweiGatewayInventoryObject{
 					{ObjectID: 0x87, Value: []byte{0}},
 					{ObjectID: 0x88, Value: []byte("1=emma-a01;5=0")},
 				}}},
@@ -52,7 +52,7 @@ func TestParseHuaweiEMMAOfflineInventoryFailsClosed(t *testing.T) {
 			name: "inventory guard changes",
 			input: HuaweiEMMAOfflineInventoryInput{
 				InventoryGuardBefore: 1, InventoryGuardAfter: 2,
-				Pages: []HuaweiSmartLoggerInventoryPage{{Objects: []HuaweiSmartLoggerInventoryObject{
+				Pages: []HuaweiGatewayInventoryPage{{Objects: []HuaweiGatewayInventoryObject{
 					{ObjectID: 0x87, Value: []byte{0}},
 					{ObjectID: 0x88, Value: []byte("1=EMMA-A01;5=0")},
 				}}},

--- a/huawei_smartlogger_inventory.go
+++ b/huawei_smartlogger_inventory.go
@@ -92,6 +92,12 @@ func (c HuaweiSmartLoggerInventoryChild) Attribute(name string) string {
 // child encoding from supplied pages. Any malformed or incomplete input is
 // rejected without returning a partial inventory.
 func ParseHuaweiSmartLoggerOfflineInventory(input HuaweiSmartLoggerOfflineInventoryInput) (HuaweiSmartLoggerInventory, error) {
+	return parseHuaweiExtendedMEIOfflineInventory(input, func(model string) bool {
+		return model == "SmartLogger"
+	})
+}
+
+func parseHuaweiExtendedMEIOfflineInventory(input HuaweiSmartLoggerOfflineInventoryInput, isSelfEntry func(string) bool) (HuaweiSmartLoggerInventory, error) {
 	if input.ChangeCounterBefore != input.ChangeCounterAfter || len(input.Pages) == 0 || len(input.Pages) > huaweiSmartLoggerInventoryMaxPages {
 		return HuaweiSmartLoggerInventory{}, errHuaweiSmartLoggerInventoryInvalid
 	}
@@ -139,7 +145,7 @@ func ParseHuaweiSmartLoggerOfflineInventory(input HuaweiSmartLoggerOfflineInvent
 				if err != nil {
 					return HuaweiSmartLoggerInventory{}, errHuaweiSmartLoggerInventoryInvalid
 				}
-				if child.model == "SmartLogger" {
+				if isSelfEntry(child.model) {
 					if selfSeen || len(children) != 0 {
 						return HuaweiSmartLoggerInventory{}, errHuaweiSmartLoggerInventoryInvalid
 					}

--- a/huawei_smartlogger_inventory.go
+++ b/huawei_smartlogger_inventory.go
@@ -31,6 +31,11 @@ type HuaweiSmartLoggerInventoryPage struct {
 	Objects      []HuaweiSmartLoggerInventoryObject
 }
 
+// HuaweiGatewayInventoryPage is the shared offline extended-MEI page shape for
+// Huawei gateway families. The SmartLogger name remains as a compatibility
+// alias for the first caller.
+type HuaweiGatewayInventoryPage = HuaweiSmartLoggerInventoryPage
+
 // HuaweiSmartLoggerInventoryObject retains a single opaque inventory object
 // until its bounded attribute form has been validated.
 type HuaweiSmartLoggerInventoryObject struct {
@@ -38,11 +43,17 @@ type HuaweiSmartLoggerInventoryObject struct {
 	Value    []byte
 }
 
+// HuaweiGatewayInventoryObject is one shared offline extended-MEI object.
+type HuaweiGatewayInventoryObject = HuaweiSmartLoggerInventoryObject
+
 // HuaweiSmartLoggerInventory is a validated, default-denied child snapshot.
 type HuaweiSmartLoggerInventory struct {
 	declaredChildren int
 	children         []HuaweiSmartLoggerInventoryChild
 }
+
+// HuaweiGatewayInventory is a validated shared offline inventory view.
+type HuaweiGatewayInventory = HuaweiSmartLoggerInventory
 
 func (i HuaweiSmartLoggerInventory) DeclaredChildren() int { return i.declaredChildren }
 
@@ -66,6 +77,9 @@ type HuaweiSmartLoggerInventoryChild struct {
 	featureVersion  string
 	productType     string
 }
+
+// HuaweiGatewayInventoryChild is a non-sensitive shared child view.
+type HuaweiGatewayInventoryChild = HuaweiSmartLoggerInventoryChild
 
 func (c HuaweiSmartLoggerInventoryChild) ObjectID() uint8 { return c.objectID }
 


### PR DESCRIPTION
Closes #117

## Docs gate

Uses the existing Huawei bounded extended-MEI inventory contract shared by SmartLogger and EMMA.

## RED

`GOWORK=off go test ./...` fails because the EMMA offline inventory API does not exist.

## Scope

Offline parser generalization only. No socket, request, catalog/runtime admission, telemetry decode, gateway, or operation.