### PR TITLE
Add Tesla HSC response exchange composition

### DIFF
--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -191,6 +191,33 @@ func DecodeTeslaHSCResponse(
 	return TeslaHSCResponse{function: function, payload: append([]byte(nil), payload...)}, nil
 }
 
+// DecodeTeslaHSCExchange applies the selected Tesla response contract to one
+// completed generic RTU exchange. It consumes only already-correlated normal
+// payloads and never constructs or admits an outbound operation. FC100 may
+// retain its bounded intermediate/result sequence; FC101 and FC102 retain one
+// opaque terminal normal response.
+func DecodeTeslaHSCExchange(
+	function modbus.PrivateFunctionCode,
+	payloads [][]byte,
+) ([]TeslaHSCResponse, error) {
+	if !isTeslaHSCFunction(function) {
+		return nil, fmt.Errorf("tesla HSC function is unsupported")
+	}
+	if len(payloads) == 0 || len(payloads) > 8 ||
+		(function != teslaHSCFunction100 && len(payloads) != 1) {
+		return nil, fmt.Errorf("tesla HSC response count is invalid")
+	}
+	responses := make([]TeslaHSCResponse, 0, len(payloads))
+	for _, payload := range payloads {
+		response, err := DecodeTeslaHSCResponse(function, payload)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, response)
+	}
+	return responses, nil
+}
+
 // Function returns the vendor function identified by this response.
 func (response TeslaHSCResponse) Function() modbus.PrivateFunctionCode {
 	return response.function

--- a/tesla_hsc_exchange_test.go
+++ b/tesla_hsc_exchange_test.go
@@ -1,0 +1,43 @@
+package modbusreg
+
+import (
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaHSCExchangeDecodesSelectedFunctionWithoutAdmission(t *testing.T) {
+	for _, test := range []struct {
+		function modbus.PrivateFunctionCode
+		frames   [][]byte
+		want     [][]byte
+	}{
+		{teslaHSCFunction100, [][]byte{{0}, {1, 0xaa}}, [][]byte{{}, {0xaa}}},
+		{teslaHSCFunction101, [][]byte{{1, 0}}, [][]byte{{1, 0}}},
+		{teslaHSCFunction102, [][]byte{{2, 0, 1}}, [][]byte{{2, 0, 1}}},
+	} {
+		t.Run(string(rune(test.function)), func(t *testing.T) {
+			responses, err := DecodeTeslaHSCExchange(test.function, test.frames)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(responses) != len(test.want) {
+				t.Fatalf("responses = %d, want %d", len(responses), len(test.want))
+			}
+			for index := range test.want {
+				if got := responses[index].Payload(); string(got) != string(test.want[index]) {
+					t.Fatalf("payload[%d] = %x, want %x", index, got, test.want[index])
+				}
+			}
+		})
+	}
+}
+
+func TestTeslaHSCExchangeRejectsWrongResponseMultiplicity(t *testing.T) {
+	if _, err := DecodeTeslaHSCExchange(teslaHSCFunction101, [][]byte{{1}, {2}}); err == nil {
+		t.Fatal("FC101 accepted multiple normal responses")
+	}
+	if _, err := DecodeTeslaHSCExchange(teslaHSCFunction102, nil); err == nil {
+		t.Fatal("FC102 accepted no normal response")
+	}
+}


### PR DESCRIPTION
Closes #119

Adds profile-scoped, inbound response composition over generic already-correlated RTU private-function responses. FC100 retains bounded multi-frame results; FC101/102 retain exactly one opaque normal response. This PR does not construct a Tesla request or grant operation admission.

TDD: RED test is the first commit; implementation follows.