### PR TITLE
Decode bounded OutBack AXS SunSpec observed state

### DIFF
--- a/sunspec_outback_axs.go
+++ b/sunspec_outback_axs.go
@@ -1,0 +1,57 @@
+package modbusreg
+
+const (
+	OutBackAXSModelInterface      uint16 = 64110
+	OutBackAXSModelChargeControl  uint16 = 64111
+	OutBackAXSInterfaceModelWords uint16 = 282
+	OutBackAXSChargeModelWords    uint16 = 23
+)
+
+// OutBackAXSReadOnlyDecoder is explicitly supplied by an OutBack caller. It
+// exposes observed state only; it has no profile discovery or send surface.
+type OutBackAXSReadOnlyDecoder struct{ namespace SunSpecVendorDecoderNamespace }
+
+func NewOutBackAXSReadOnlyDecoder() (OutBackAXSReadOnlyDecoder, error) {
+	definitions, err := outBackAXSDefinitions()
+	if err != nil {
+		return OutBackAXSReadOnlyDecoder{}, err
+	}
+	namespace, err := newSunSpecVendorDecoderNamespace(SunSpecModelsRevisionV1, definitions)
+	if err != nil {
+		return OutBackAXSReadOnlyDecoder{}, err
+	}
+	return OutBackAXSReadOnlyDecoder{namespace: namespace}, nil
+}
+
+func (d OutBackAXSReadOnlyDecoder) Decode(words []uint16) (SunSpecDecodedModel, error) {
+	return d.namespace.Decode(words)
+}
+
+func outBackAXSDefinitions() ([]sunSpecModelDefinition, error) {
+	interfacePoints := []sunSpecPointDefinition{
+		sunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("FirmwareMajor", "outback.axs.firmware.major", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("FirmwareMid", "outback.axs.firmware.mid", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("FirmwareMinor", "outback.axs.firmware.minor", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("Excluded", "", SunSpecTypePad, 273, "", "", false, nil, 0),
+		sunSpecPoint("BatteryTemperature", "outback.axs.temperature.battery", SunSpecTypeInt16, 1, "C", "TemperatureSF", false, nil, 0),
+		sunSpecPoint("AmbientTemperature", "outback.axs.temperature.ambient", SunSpecTypeInt16, 1, "C", "TemperatureSF", false, nil, 0),
+		sunSpecPoint("TemperatureSF", "outback.axs.temperature.scale", SunSpecTypeScaleFactor, 1, "", "", false, nil, 0),
+		sunSpecPoint("Error", "outback.axs.error", SunSpecTypeBitfield16, 1, "", "", false, nil, 0),
+		sunSpecPoint("Status", "outback.axs.status", SunSpecTypeBitfield16, 1, "", "", false, nil, 0),
+		sunSpecPoint("Spare", "", SunSpecTypePad, 1, "", "", false, nil, 0),
+	}
+	chargePoints := []sunSpecPointDefinition{
+		sunSpecPoint("ID", "", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		sunSpecPoint("L", "", SunSpecTypeUint16, 1, "", "", false, nil, 0),
+		// The public contract fixes the block's exact geometry but not a point
+		// map. Keep its payload vendor-scoped and raw rather than invent facts.
+		sunSpecPoint("VendorPayload", "", SunSpecTypePad, 23, "", "", false, nil, 0),
+	}
+	definitions, err := appendSunSpecDefinition(nil, SunSpecModelsRevisionV1, OutBackAXSModelInterface, OutBackAXSInterfaceModelWords, SunSpecTopologyNone, false, interfacePoints)
+	if err != nil {
+		return nil, err
+	}
+	return appendSunSpecDefinition(definitions, SunSpecModelsRevisionV1, OutBackAXSModelChargeControl, OutBackAXSChargeModelWords, SunSpecTopologyNone, false, chargePoints)
+}

--- a/sunspec_outback_axs_test.go
+++ b/sunspec_outback_axs_test.go
@@ -1,0 +1,52 @@
+package modbusreg
+
+import "testing"
+
+func TestOutBackAXSReadOnlyDecoderIsExplicitAndStandardRegistryStaysIsolated(t *testing.T) {
+	standard := mustStandardSunSpecRegistry(t)
+	for _, key := range []SunSpecDecoderKey{
+		{ModelID: 64110, ModelLength: 282, SchemaRevision: SunSpecModelsRevisionV1},
+		{ModelID: 64111, ModelLength: 23, SchemaRevision: SunSpecModelsRevisionV1},
+	} {
+		if _, ok := standard.definition(key); ok {
+			t.Fatalf("standard registry must not expose vendor key %#v", key)
+		}
+	}
+
+	decoder, err := NewOutBackAXSReadOnlyDecoder()
+	if err != nil {
+		t.Fatalf("NewOutBackAXSReadOnlyDecoder() error = %v", err)
+	}
+	words := make([]uint16, 284)
+	words[0], words[1] = 64110, 282
+	words[2], words[3], words[4] = 1, 2, 3
+	words[278], words[279], words[280] = 25, 20, 0
+	words[281], words[282] = 0x8000, 0x0001
+	decoded, err := decoder.Decode(words)
+	if err != nil {
+		t.Fatalf("decoder.Decode() error = %v", err)
+	}
+	if decoded.Key() != (SunSpecDecoderKey{ModelID: 64110, ModelLength: 282, SchemaRevision: SunSpecModelsRevisionV1}) {
+		t.Fatalf("unexpected decoder key: %#v", decoded.Key())
+	}
+	for _, forbidden := range []string{"network", "password", "mac", "config", "control"} {
+		if _, ok := decoded.Fact(forbidden); ok {
+			t.Fatalf("excluded fact leaked: %q", forbidden)
+		}
+	}
+	if _, ok := decoded.Fact("outback.axs.firmware.major"); !ok {
+		t.Fatal("firmware fact missing")
+	}
+}
+
+func TestOutBackAXSReadOnlyDecoderFailsClosed(t *testing.T) {
+	decoder, err := NewOutBackAXSReadOnlyDecoder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, words := range [][]uint16{{64110, 281}, {64112, 64}, {64111, 23}} {
+		if _, err := decoder.Decode(words); err == nil {
+			t.Fatalf("decoder accepted unsupported or malformed words: %#v", words)
+		}
+	}
+}

--- a/sunspec_outback_axs_test.go
+++ b/sunspec_outback_axs_test.go
@@ -37,6 +37,19 @@ func TestOutBackAXSReadOnlyDecoderIsExplicitAndStandardRegistryStaysIsolated(t *
 	if _, ok := decoded.Fact("outback.axs.firmware.major"); !ok {
 		t.Fatal("firmware fact missing")
 	}
+
+	charge := make([]uint16, 25)
+	charge[0], charge[1], charge[2] = 64111, 23, 7
+	decoded, err = decoder.Decode(charge)
+	if err != nil {
+		t.Fatalf("charge decoder.Decode() error = %v", err)
+	}
+	if len(decoded.Facts()) != 0 {
+		t.Fatalf("vendor-scoped raw charge block emitted facts: %#v", decoded.Facts())
+	}
+	if got := decoded.RawWords(); got[2] != 7 {
+		t.Fatalf("vendor-scoped raw charge block was not retained: %#v", got)
+	}
 }
 
 func TestOutBackAXSReadOnlyDecoderFailsClosed(t *testing.T) {
@@ -44,7 +57,7 @@ func TestOutBackAXSReadOnlyDecoderFailsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, words := range [][]uint16{{64110, 281}, {64112, 64}, {64111, 23}} {
+	for _, words := range [][]uint16{{64110, 281}, {64112, 64}, {64111, 22}} {
 		if _, err := decoder.Decode(words); err == nil {
 			t.Fatalf("decoder accepted unsupported or malformed words: %#v", words)
 		}

--- a/sunspec_outback_axs_test.go
+++ b/sunspec_outback_axs_test.go
@@ -1,6 +1,9 @@
 package modbusreg
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestOutBackAXSReadOnlyDecoderIsExplicitAndStandardRegistryStaysIsolated(t *testing.T) {
 	standard := mustStandardSunSpecRegistry(t)
@@ -29,9 +32,11 @@ func TestOutBackAXSReadOnlyDecoderIsExplicitAndStandardRegistryStaysIsolated(t *
 	if decoded.Key() != (SunSpecDecoderKey{ModelID: 64110, ModelLength: 282, SchemaRevision: SunSpecModelsRevisionV1}) {
 		t.Fatalf("unexpected decoder key: %#v", decoded.Key())
 	}
-	for _, forbidden := range []string{"network", "password", "mac", "config", "control"} {
-		if _, ok := decoded.Fact(forbidden); ok {
-			t.Fatalf("excluded fact leaked: %q", forbidden)
+	for _, fact := range decoded.Facts() {
+		for _, forbidden := range []string{"network", "password", "mac", "config", "control"} {
+			if strings.Contains(fact.FieldID, forbidden) {
+				t.Fatalf("excluded fact leaked: %#v", fact)
+			}
 		}
 	}
 	if _, ok := decoded.Fact("outback.axs.firmware.major"); !ok {
@@ -57,7 +62,7 @@ func TestOutBackAXSReadOnlyDecoderFailsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, words := range [][]uint16{{64110, 281}, {64112, 64}, {64111, 22}} {
+	for _, words := range [][]uint16{{64110, 281}, {64110, 282}, {64112, 64}, {64111, 22}} {
 		if _, err := decoder.Decode(words); err == nil {
 			t.Fatalf("decoder accepted unsupported or malformed words: %#v", words)
 		}

--- a/sunspec_vendor_namespace.go
+++ b/sunspec_vendor_namespace.go
@@ -1,0 +1,57 @@
+package modbusreg
+
+import "fmt"
+
+// SunSpecVendorDecoderNamespace holds definitions supplied explicitly by one
+// vendor flavor. It is separate from the standard registry and never extends
+// the standard decoder catalog.
+type SunSpecVendorDecoderNamespace struct {
+	registry SunSpecDecoderRegistry
+}
+
+func newSunSpecVendorDecoderNamespace(revision SunSpecSchemaRevision, definitions []sunSpecModelDefinition) (SunSpecVendorDecoderNamespace, error) {
+	if len(definitions) == 0 {
+		return SunSpecVendorDecoderNamespace{}, fmt.Errorf("vendor SunSpec namespace has no definitions")
+	}
+	registry := SunSpecDecoderRegistry{revision: revision, definitions: make(map[SunSpecDecoderKey]sunSpecModelDefinition, len(definitions))}
+	for _, definition := range definitions {
+		if definition.key.SchemaRevision != revision {
+			return SunSpecVendorDecoderNamespace{}, fmt.Errorf("vendor SunSpec definition has incompatible revision")
+		}
+		if _, duplicate := registry.definitions[definition.key]; duplicate {
+			return SunSpecVendorDecoderNamespace{}, fmt.Errorf("vendor SunSpec decoder key is duplicated")
+		}
+		registry.definitions[definition.key] = definition
+		registry.keys = append(registry.keys, definition.key)
+	}
+	return SunSpecVendorDecoderNamespace{registry: registry}, nil
+}
+
+func (n SunSpecVendorDecoderNamespace) Decode(words []uint16) (SunSpecDecodedModel, error) {
+	if len(words) < 2 {
+		return SunSpecDecodedModel{}, fmt.Errorf("vendor SunSpec occurrence is incomplete")
+	}
+	key := SunSpecDecoderKey{ModelID: words[0], ModelLength: words[1], SchemaRevision: n.registry.revision}
+	if _, ok := n.registry.definitions[key]; !ok {
+		return SunSpecDecodedModel{}, fmt.Errorf("vendor SunSpec decoder key is unsupported")
+	}
+	copyKey := key
+	decoded, err := n.registry.DecodeOccurrence(SunSpecOccurrence{
+		WireKey:        SunSpecWireKey{ModelID: key.ModelID, ModelLength: key.ModelLength},
+		SchemaRevision: key.SchemaRevision,
+		Disposition:    SunSpecChainDispositionAdmitted,
+		decoderKey:     &copyKey,
+		words:          append([]uint16(nil), words...),
+	})
+	if err != nil {
+		return SunSpecDecodedModel{}, err
+	}
+	filtered := decoded.facts[:0]
+	for _, fact := range decoded.facts {
+		if fact.FieldID != "" {
+			filtered = append(filtered, fact)
+		}
+	}
+	decoded.facts = append([]SunSpecFact(nil), filtered...)
+	return decoded, nil
+}


### PR DESCRIPTION
Closes #121

## Docs gate

Docs AXS contract: `136828daf710b4d312798e237e9df7a8cf4889b7`.

## RED

`GOWORK=off go test ./...` fails because the explicit AXS decoder namespace is absent.

## Scope

Explicit vendor-scoped read-only decoder only. Standard registry remains unchanged; no profile discovery, runtime admission, transport, gateway, live I/O, or operation.