### PR TITLE
Document standalone Modbus profile-registry agent contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@ projection loss. It does not own sockets, serial ports, Modbus TCP/RTU framing,
 retries, canonical or universal semantics, gateway composition, or private
 consumer bindings.
 
+The universal cross-protocol semantic owner is planned `helianthus-semreg`.
+That repository is not an active dependency or authority until it exists with a
+merged scope. Until then, this registry must keep Modbus-native evidence and
+profiles explicit and must not absorb universal semantic ownership.
+
 Do not create vendor-specific repositories. Keep standard families
 vendor-neutral and limit overlays to proven vendor differences. A detection
 result with multiple eligible matches is `ambiguous/multiple_matches`; score,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,13 +31,28 @@ than wholesale-replacing state.
    conformance check before pushing. Include exact commands and results in the
    pull request.
 5. Open a linked pull request stating scope, native evidence, tests,
-   documentation-gate impact, and residual risk.
+   documentation-gate impact, any required companion documentation PR, and
+   residual risk.
 6. Resolve valid P0-P2 findings, then obtain a fresh exact-HEAD
    `NO_BLOCKING_FINDINGS` review verdict. P3/P4 findings are triaged as fix,
    backlog, or by design.
 7. Squash merge only after all applicable checks and gates are green and the
    exact-HEAD blocker review is clear. Verify remote `main`, issue, PR, and
    branch state, then stop at the requested boundary.
+
+## Documentation and evidence gate
+
+Profile, codec, detector, qualification, native-decoding, capability,
+projection-loss, or exported-behavior changes require a public documentation
+and evidence update in
+https://github.com/Project-Helianthus/helianthus-docs-modbus. Open the companion
+documentation PR in the same delivery cycle and merge it first or together with
+the code PR. A missing, red, or blocking companion gate prevents this repository
+from merging.
+
+Documentation-only instruction changes that establish no protocol or profile
+claim may record the gate as not applicable. Publish only redacted,
+redistributable evidence and keep hypotheses distinct from qualified behavior.
 
 ## Safety and public boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,50 @@
-# AGENTS
+# AGENTS.md
 
-This repository is part of the Helianthus multi-protocol gateway platform.
-Workspace orchestration is governed by the workspace-root `AGENTS.md` and the
-cruise-control skills referenced there.
+## Purpose and ownership
 
-## Repository Rules
+`helianthus-modbusreg` is the single public multi-vendor Modbus profile
+registry. It owns isolated vendor profiles, shared profile primitives,
+detectors, qualification, native decoding, capability provenance, and explicit
+projection loss. It does not own sockets, serial ports, Modbus TCP/RTU framing,
+retries, canonical or universal semantics, gateway composition, or private
+consumer bindings.
 
-1. Work one issue at a time and keep at most one open pull request.
-2. Use `issue/<id>-<slug>` branches and squash merge only.
-3. Run `./scripts/ci_local.sh` before pushing.
-4. Add focused RED tests before behavioral repairs where TDD adds value, and
-   preserve the observed failure in normal Git or pull-request evidence.
-5. Profile, codec, detector, qualification, or exported behavior changes
-   require their merged or companion public documentation and evidence gate.
-6. Resolve valid blockers against the current head under the workspace review
-   policy.
+Do not create vendor-specific repositories. Keep standard families
+vendor-neutral and limit overlays to proven vendor differences. A detection
+result with multiple eligible matches is `ambiguous/multiple_matches`; score,
+priority, registration order, detector order, or vendor name must not choose a
+winner. Preserve raw native evidence and distinguish observed, inferred,
+qualified, promoted, unsupported, and unknown states. Partial read failures
+must retain last-known-good fields where the profile contract permits it rather
+than wholesale-replacing state.
 
-## Ownership Invariants
+## Workflow
 
-- This is one multi-vendor registry; do not create repositories per vendor.
-- Standard families remain vendor-neutral. Overlays contain only proven,
-  minimal vendor differences.
-- This repository does not own sockets, serial ports, Modbus framing, canonical
-  publication policy, gateway composition, or private bindings.
-- Profile detection is bounded, read-only, version-aware, and fail-closed.
-- Public builds, tests, fixtures, and docs must never require private
-  repositories or artifacts.
-- Stop after the requested repository or milestone boundary. Gateway work
-  waits for a separate operator request.
+1. Reconcile `origin/main`, the working tree, related issues, branches, pull
+   requests, reviews, and checks before editing.
+2. Use one scoped issue and an `issue/<number>-<slug>` branch created from
+   current `origin/main`. Keep unrelated work out of the branch.
+3. Add focused RED tests first for profile, codec, detector, qualification, or
+   exported-behavior changes where TDD adds evidence; record the observed
+   failure before implementation.
+4. Run `./scripts/ci_local.sh` and every applicable unit, race, lint, and
+   conformance check before pushing. Include exact commands and results in the
+   pull request.
+5. Open a linked pull request stating scope, native evidence, tests,
+   documentation-gate impact, and residual risk.
+6. Resolve valid P0-P2 findings, then obtain a fresh exact-HEAD
+   `NO_BLOCKING_FINDINGS` review verdict. P3/P4 findings are triaged as fix,
+   backlog, or by design.
+7. Squash merge only after all applicable checks and gates are green and the
+   exact-HEAD blocker review is clear. Verify remote `main`, issue, PR, and
+   branch state, then stop at the requested boundary.
+
+## Safety and public boundaries
+
+Discovery and qualification are explicit read-only allowlists with bounded
+retries, version-aware evidence, and fail-closed outcomes. Public builds,
+tests, fixtures, and documentation must be self-contained and must not require
+private repositories, artifacts, credentials, local network access, or personal
+laboratory equipment. Any real installation, credential use, destructive or
+irreversible action, safety-relevant control, or live-device write requires
+explicit operator confirmation at action time.


### PR DESCRIPTION
## Summary\n- replace the workspace-dependent AGENTS.md with a standalone repository contract\n- preserve the single multi-vendor registry boundary and exclude transport/universal semantics\n- record read-only fail-closed qualification, public/private, review, squash-merge, and live-mutation boundaries\n\n## Validation\n- ./scripts/ci_local.sh\n- git diff --check\n- static scan confirms no workspace, local instruction, sibling checkout, or personal-lab dependency\n\n## Gates and risk\n- Documentation-only change; no profile/runtime behavior or conformance delta.\n- Exact-HEAD blocker review remains required before merge.\n- Residual risk: wording governs future work; it changes no runtime behavior.\n\nCloses #123