### PR TITLE
Attach OutBack AXS decoder through an explicit read-only flavor seam

### DIFF
--- a/sunspec_outback_axs_flavor.go
+++ b/sunspec_outback_axs_flavor.go
@@ -1,0 +1,109 @@
+package modbusreg
+
+const OutBackAXSReadOnlyFlavorID = "sunspec.flavor.outback.axs.readonly@1.0.0"
+
+type OutBackAXSReadOnlyFlavorReason string
+
+const (
+	OutBackAXSReadOnlyFlavorReasonInvalidChain         OutBackAXSReadOnlyFlavorReason = "INVALID_CHAIN"
+	OutBackAXSReadOnlyFlavorReasonCommonNotAdmitted    OutBackAXSReadOnlyFlavorReason = "COMMON_NOT_ADMITTED"
+	OutBackAXSReadOnlyFlavorReasonInterfaceAbsent      OutBackAXSReadOnlyFlavorReason = "INTERFACE_ABSENT"
+	OutBackAXSReadOnlyFlavorReasonInterfaceWrongLength OutBackAXSReadOnlyFlavorReason = "INTERFACE_WRONG_LENGTH"
+	OutBackAXSReadOnlyFlavorReasonInterfaceAmbiguous   OutBackAXSReadOnlyFlavorReason = "INTERFACE_AMBIGUOUS"
+	OutBackAXSReadOnlyFlavorReasonMatched              OutBackAXSReadOnlyFlavorReason = "MATCHED"
+)
+
+// OutBackAXSReadOnlyFlavorDecision is an immutable result of an explicitly
+// requested OutBack selection. It neither alters the standard registry nor
+// authorizes acquisition, runtime activation, or control.
+type OutBackAXSReadOnlyFlavorDecision struct {
+	matched    bool
+	reason     OutBackAXSReadOnlyFlavorReason
+	chain      []SunSpecWireKey
+	occurrence *SunSpecOccurrence
+	model      *SunSpecDecodedModel
+}
+
+func (d OutBackAXSReadOnlyFlavorDecision) Matched() bool { return d.matched }
+func (d OutBackAXSReadOnlyFlavorDecision) Reason() OutBackAXSReadOnlyFlavorReason {
+	return d.reason
+}
+func (d OutBackAXSReadOnlyFlavorDecision) FlavorID() string { return OutBackAXSReadOnlyFlavorID }
+func (d OutBackAXSReadOnlyFlavorDecision) Chain() []SunSpecWireKey {
+	return append([]SunSpecWireKey(nil), d.chain...)
+}
+func (d OutBackAXSReadOnlyFlavorDecision) InterfaceOccurrence() (SunSpecOccurrence, bool) {
+	if d.occurrence == nil {
+		return SunSpecOccurrence{}, false
+	}
+	return cloneOccurrence(*d.occurrence), true
+}
+func (d OutBackAXSReadOnlyFlavorDecision) InterfaceModel() (SunSpecDecodedModel, bool) {
+	if d.model == nil {
+		return SunSpecDecodedModel{}, false
+	}
+	return cloneOutBackAXSDecodedModel(*d.model), true
+}
+
+// EvaluateSnapshot validates a terminal, source-backed V1 snapshot supplied
+// by the caller. The caller chooses when to invoke it; it has no acquisition
+// or profile-discovery side effect.
+func (d OutBackAXSReadOnlyDecoder) EvaluateSnapshot(snapshot SunSpecChainSnapshot) OutBackAXSReadOnlyFlavorDecision {
+	rejected := func(reason OutBackAXSReadOnlyFlavorReason) OutBackAXSReadOnlyFlavorDecision {
+		return OutBackAXSReadOnlyFlavorDecision{reason: reason}
+	}
+	chain, valid := sunSpecSnapshotWireChain(snapshot)
+	if !valid {
+		return rejected(OutBackAXSReadOnlyFlavorReasonInvalidChain)
+	}
+	occurrences := snapshot.Occurrences()
+	if len(occurrences) == 0 {
+		return rejected(OutBackAXSReadOnlyFlavorReasonInvalidChain)
+	}
+	standard, err := NewStandardSunSpecDecoderRegistry(SunSpecModelsRevisionV1)
+	if err != nil {
+		return rejected(OutBackAXSReadOnlyFlavorReasonCommonNotAdmitted)
+	}
+	common, err := standard.DecodeOccurrence(occurrences[0])
+	if err != nil || !common.GeometryValid() || !common.Qualifies() {
+		return rejected(OutBackAXSReadOnlyFlavorReasonCommonNotAdmitted)
+	}
+
+	var selected *SunSpecOccurrence
+	for index := range occurrences {
+		occurrence := occurrences[index]
+		if occurrence.ModelID() != OutBackAXSModelInterface {
+			continue
+		}
+		if occurrence.ModelLength() != OutBackAXSInterfaceModelWords {
+			return rejected(OutBackAXSReadOnlyFlavorReasonInterfaceWrongLength)
+		}
+		if selected != nil {
+			return rejected(OutBackAXSReadOnlyFlavorReasonInterfaceAmbiguous)
+		}
+		copy := cloneOccurrence(occurrence)
+		selected = &copy
+	}
+	if selected == nil {
+		return rejected(OutBackAXSReadOnlyFlavorReasonInterfaceAbsent)
+	}
+	model, err := d.Decode(selected.Words())
+	if err != nil {
+		return rejected(OutBackAXSReadOnlyFlavorReasonInterfaceWrongLength)
+	}
+	modelCopy := cloneOutBackAXSDecodedModel(model)
+	return OutBackAXSReadOnlyFlavorDecision{
+		matched:    true,
+		reason:     OutBackAXSReadOnlyFlavorReasonMatched,
+		chain:      append([]SunSpecWireKey(nil), chain...),
+		occurrence: selected,
+		model:      &modelCopy,
+	}
+}
+
+func cloneOutBackAXSDecodedModel(model SunSpecDecodedModel) SunSpecDecodedModel {
+	model.raw = append([]uint16(nil), model.raw...)
+	model.spans = append([]SunSpecSourceSpan(nil), model.spans...)
+	model.facts = model.Facts()
+	return model
+}

--- a/sunspec_outback_axs_flavor_test.go
+++ b/sunspec_outback_axs_flavor_test.go
@@ -1,0 +1,89 @@
+package modbusreg
+
+import "testing"
+
+func TestOutBackAXSReadOnlyDecoderSelectsOneExplicitExactInterface(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	decoder, err := NewOutBackAXSReadOnlyDecoder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := outBackAXSSnapshot(t, registry, outBackAXSOccurrence(OutBackAXSModelInterface, OutBackAXSInterfaceModelWords, 2))
+
+	decision := decoder.EvaluateSnapshot(snapshot)
+	if !decision.Matched() || decision.Reason() != OutBackAXSReadOnlyFlavorReasonMatched {
+		t.Fatalf("matched=%t reason=%q", decision.Matched(), decision.Reason())
+	}
+	occurrence, ok := decision.InterfaceOccurrence()
+	if !ok || occurrence.WireKey != (SunSpecWireKey{ModelID: OutBackAXSModelInterface, ModelLength: OutBackAXSInterfaceModelWords}) {
+		t.Fatalf("interface occurrence=%#v found=%t", occurrence, ok)
+	}
+	if _, standard := registry.definition(SunSpecDecoderKey{ModelID: OutBackAXSModelInterface, ModelLength: OutBackAXSInterfaceModelWords, SchemaRevision: SunSpecModelsRevisionV1}); standard {
+		t.Fatal("explicit vendor selection extended the standard registry")
+	}
+}
+
+func TestOutBackAXSReadOnlyDecoderFailsClosedOnInvalidOrAmbiguousSnapshot(t *testing.T) {
+	registry := mustStandardSunSpecRegistry(t)
+	decoder, err := NewOutBackAXSReadOnlyDecoder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	validCommon := commonOccurrence(t, registry, "Maker", "Model", "1.0", 1)
+	invalidCommon := cloneOccurrence(validCommon)
+	invalidCommon.words[2] = 0
+
+	for name, tc := range map[string]struct {
+		snapshot SunSpecChainSnapshot
+		reason   OutBackAXSReadOnlyFlavorReason
+	}{
+		"missing interface": {
+			snapshot: outBackAXSSnapshot(t, registry),
+			reason:   OutBackAXSReadOnlyFlavorReasonInterfaceAbsent,
+		},
+		"wrong interface length": {
+			snapshot: outBackAXSSnapshot(t, registry, outBackAXSOccurrence(OutBackAXSModelInterface, OutBackAXSInterfaceModelWords-1, 2)),
+			reason:   OutBackAXSReadOnlyFlavorReasonInterfaceWrongLength,
+		},
+		"duplicate interfaces": {
+			snapshot: outBackAXSSnapshot(t, registry,
+				outBackAXSOccurrence(OutBackAXSModelInterface, OutBackAXSInterfaceModelWords, 2),
+				outBackAXSOccurrence(OutBackAXSModelInterface, OutBackAXSInterfaceModelWords, 3),
+			),
+			reason: OutBackAXSReadOnlyFlavorReasonInterfaceAmbiguous,
+		},
+		"invalid common": {
+			snapshot: snapshotFromOccurrences(invalidCommon, outBackAXSOccurrence(OutBackAXSModelInterface, OutBackAXSInterfaceModelWords, 2)),
+			reason:   OutBackAXSReadOnlyFlavorReasonCommonNotAdmitted,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			decision := decoder.EvaluateSnapshot(tc.snapshot)
+			if decision.Matched() || decision.Reason() != tc.reason {
+				t.Fatalf("matched=%t reason=%q want=%q", decision.Matched(), decision.Reason(), tc.reason)
+			}
+			if _, ok := decision.InterfaceOccurrence(); ok {
+				t.Fatal("rejected decision exposed vendor occurrence")
+			}
+		})
+	}
+}
+
+func outBackAXSSnapshot(t *testing.T, registry SunSpecDecoderRegistry, vendor ...SunSpecOccurrence) SunSpecChainSnapshot {
+	t.Helper()
+	occurrences := []SunSpecOccurrence{commonOccurrence(t, registry, "Maker", "Model", "1.0", 1)}
+	occurrences = append(occurrences, vendor...)
+	return snapshotFromOccurrences(occurrences...)
+}
+
+func outBackAXSOccurrence(modelID, length uint16, ordinal uint32) SunSpecOccurrence {
+	words := make([]uint16, int(length)+2)
+	words[0], words[1] = modelID, length
+	return SunSpecOccurrence{
+		Ordinal:        ordinal,
+		WireKey:        SunSpecWireKey{ModelID: modelID, ModelLength: length},
+		SchemaRevision: testSunSpecModelsRevision,
+		Disposition:    SunSpecChainDispositionUnknownModel,
+		words:          words,
+	}
+}

--- a/sunspec_outback_axs_flavor_test.go
+++ b/sunspec_outback_axs_flavor_test.go
@@ -18,6 +18,18 @@ func TestOutBackAXSReadOnlyDecoderSelectsOneExplicitExactInterface(t *testing.T)
 	if !ok || occurrence.WireKey != (SunSpecWireKey{ModelID: OutBackAXSModelInterface, ModelLength: OutBackAXSInterfaceModelWords}) {
 		t.Fatalf("interface occurrence=%#v found=%t", occurrence, ok)
 	}
+	if chain := decision.Chain(); len(chain) != 3 || chain[1] != occurrence.WireKey {
+		t.Fatalf("selected chain=%#v", chain)
+	}
+	model, ok := decision.InterfaceModel()
+	if !ok || model.Key() != (SunSpecDecoderKey{ModelID: OutBackAXSModelInterface, ModelLength: OutBackAXSInterfaceModelWords, SchemaRevision: SunSpecModelsRevisionV1}) {
+		t.Fatalf("interface model=%#v found=%t", model, ok)
+	}
+	model.raw[2] = 99
+	again, ok := decision.InterfaceModel()
+	if !ok || again.RawWords()[2] != 0 {
+		t.Fatal("interface model aliases decision state")
+	}
 	if _, standard := registry.definition(SunSpecDecoderKey{ModelID: OutBackAXSModelInterface, ModelLength: OutBackAXSInterfaceModelWords, SchemaRevision: SunSpecModelsRevisionV1}); standard {
 		t.Fatal("explicit vendor selection extended the standard registry")
 	}


### PR DESCRIPTION
## RED

`GOWORK=off go test ./...` fails because the explicit AXS snapshot evaluator and closed reason set do not yet exist.

## Scope

- explicit caller-invoked selection over an existing terminal snapshot
- V1 Common Model plus exactly one `64110/282`
- OutBack decoder remains injected; the standard registry, acquisition plan, catalog, runtime and transport stay unchanged
- no write, send, control, discovery or automatic attachment

## Validation

Local full CI, exact-HEAD GitHub CI and fresh review before merge.

Closes #124