### PR TITLE
Decode bounded Growatt BMS RS485 read-only raw observation

### DIFF
--- a/growatt_bms_rs485.go
+++ b/growatt_bms_rs485.go
@@ -55,7 +55,7 @@ func (GrowattBMSReadOnlyObservation) OutboundAllowed() bool { return false }
 // DecodeGrowattBMSReadOnlyObservation validates the four individually bounded
 // FC03 slices permitted by the Growatt BMS read-only contract.
 func DecodeGrowattBMSReadOnlyObservation(input GrowattBMSReadOnlyInput) (GrowattBMSReadOnlyObservation, error) {
-	if input.UnitID == 0 || input.Function != FunctionReadHoldingRegisters ||
+	if input.UnitID == 0 || input.UnitID > 247 || input.Function != FunctionReadHoldingRegisters ||
 		input.Revision != (GrowattBMSRevisionTuple{
 			Family: growattBMSFamily, FileRevision: growattBMSFileRevision,
 			HeaderVersion: growattBMSHeaderVersion, CumulativeRevision: growattBMSCumulativeRevision,

--- a/growatt_bms_rs485.go
+++ b/growatt_bms_rs485.go
@@ -1,0 +1,90 @@
+package modbusreg
+
+import "fmt"
+
+const (
+	growattBMSFamily             = "1xSxxP ESS"
+	growattBMSFileRevision       = "Rev2.01"
+	growattBMSHeaderVersion      = "V2.0"
+	growattBMSCumulativeRevision = "2.02"
+)
+
+// GrowattBMSRevisionTuple is supplied independently of wire values because
+// the bounded read set does not identify a protocol revision by itself.
+type GrowattBMSRevisionTuple struct {
+	Family, FileRevision, HeaderVersion, CumulativeRevision string
+}
+
+// GrowattBMSReadOnlySlice is one exact FC03 PDU slice. Its words are opaque
+// until a separate field-definition contract makes a particular field typed.
+type GrowattBMSReadOnlySlice struct {
+	Offset uint16
+	Words  []uint16
+}
+
+// GrowattBMSReadOnlyInput is an already-read, caller-supplied offline
+// observation. It carries no endpoint, session, request, or write authority.
+type GrowattBMSReadOnlyInput struct {
+	UnitID   byte
+	Function FunctionCode
+	Revision GrowattBMSRevisionTuple
+	Slices   []GrowattBMSReadOnlySlice
+}
+
+// GrowattBMSReadOnlyObservation retains exactly one validated, raw-only
+// candidate observation. It creates no detector, catalog, runtime activation,
+// or telemetry publication surface.
+type GrowattBMSReadOnlyObservation struct {
+	unitID   byte
+	revision GrowattBMSRevisionTuple
+	slices   []GrowattBMSReadOnlySlice
+}
+
+func (o GrowattBMSReadOnlyObservation) UnitID() byte { return o.unitID }
+func (o GrowattBMSReadOnlyObservation) Revision() GrowattBMSRevisionTuple {
+	return o.revision
+}
+func (o GrowattBMSReadOnlyObservation) Slices() []GrowattBMSReadOnlySlice {
+	return cloneGrowattBMSReadOnlySlices(o.slices)
+}
+
+// OutboundAllowed is permanently false: this observation can never authorize
+// a control operation or a further Modbus request.
+func (GrowattBMSReadOnlyObservation) OutboundAllowed() bool { return false }
+
+// DecodeGrowattBMSReadOnlyObservation validates the four individually bounded
+// FC03 slices permitted by the Growatt BMS read-only contract.
+func DecodeGrowattBMSReadOnlyObservation(input GrowattBMSReadOnlyInput) (GrowattBMSReadOnlyObservation, error) {
+	if input.UnitID == 0 || input.Function != FunctionReadHoldingRegisters ||
+		input.Revision != (GrowattBMSRevisionTuple{
+			Family: growattBMSFamily, FileRevision: growattBMSFileRevision,
+			HeaderVersion: growattBMSHeaderVersion, CumulativeRevision: growattBMSCumulativeRevision,
+		}) {
+		return GrowattBMSReadOnlyObservation{}, fmt.Errorf("growatt BMS read-only observation identity is invalid")
+	}
+	want := [...]struct{ offset, words uint16 }{
+		{0x0001, 7}, {0x000d, 29}, {0x0100, 12}, {0x010d, 2},
+	}
+	if len(input.Slices) != len(want) {
+		return GrowattBMSReadOnlyObservation{}, fmt.Errorf("growatt BMS read-only slice count is invalid")
+	}
+	for index, expected := range want {
+		slice := input.Slices[index]
+		if slice.Offset != expected.offset || len(slice.Words) != int(expected.words) {
+			return GrowattBMSReadOnlyObservation{}, fmt.Errorf("growatt BMS read-only slice %d is invalid", index)
+		}
+	}
+	return GrowattBMSReadOnlyObservation{
+		unitID:   input.UnitID,
+		revision: input.Revision,
+		slices:   cloneGrowattBMSReadOnlySlices(input.Slices),
+	}, nil
+}
+
+func cloneGrowattBMSReadOnlySlices(slices []GrowattBMSReadOnlySlice) []GrowattBMSReadOnlySlice {
+	cloned := make([]GrowattBMSReadOnlySlice, len(slices))
+	for index, slice := range slices {
+		cloned[index] = GrowattBMSReadOnlySlice{Offset: slice.Offset, Words: append([]uint16(nil), slice.Words...)}
+	}
+	return cloned
+}

--- a/growatt_bms_rs485_test.go
+++ b/growatt_bms_rs485_test.go
@@ -28,7 +28,10 @@ func TestGrowattBMSReadOnlyObservationRetainsOnlyExactDeclaredSlices(t *testing.
 
 func TestGrowattBMSReadOnlyObservationRejectsAnythingOutsideTheFourSlices(t *testing.T) {
 	for name, mutate := range map[string]func(*GrowattBMSReadOnlyInput){
-		"broadcast":      func(input *GrowattBMSReadOnlyInput) { input.UnitID = 0 },
+		"broadcast": func(input *GrowattBMSReadOnlyInput) { input.UnitID = 0 },
+		"other function": func(input *GrowattBMSReadOnlyInput) {
+			input.Function = FunctionReadInputRegisters
+		},
 		"other revision": func(input *GrowattBMSReadOnlyInput) { input.Revision.HeaderVersion = "V2.1" },
 		"missing slice":  func(input *GrowattBMSReadOnlyInput) { input.Slices = input.Slices[:3] },
 		"coalesced range": func(input *GrowattBMSReadOnlyInput) {
@@ -53,7 +56,8 @@ func TestGrowattBMSReadOnlyObservationRejectsAnythingOutsideTheFourSlices(t *tes
 
 func validGrowattBMSReadOnlyInput() GrowattBMSReadOnlyInput {
 	return GrowattBMSReadOnlyInput{
-		UnitID: 1,
+		UnitID:   1,
+		Function: FunctionReadHoldingRegisters,
 		Revision: GrowattBMSRevisionTuple{
 			Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02",
 		},

--- a/growatt_bms_rs485_test.go
+++ b/growatt_bms_rs485_test.go
@@ -28,7 +28,8 @@ func TestGrowattBMSReadOnlyObservationRetainsOnlyExactDeclaredSlices(t *testing.
 
 func TestGrowattBMSReadOnlyObservationRejectsAnythingOutsideTheFourSlices(t *testing.T) {
 	for name, mutate := range map[string]func(*GrowattBMSReadOnlyInput){
-		"broadcast": func(input *GrowattBMSReadOnlyInput) { input.UnitID = 0 },
+		"broadcast":     func(input *GrowattBMSReadOnlyInput) { input.UnitID = 0 },
+		"reserved unit": func(input *GrowattBMSReadOnlyInput) { input.UnitID = 248 },
 		"other function": func(input *GrowattBMSReadOnlyInput) {
 			input.Function = FunctionReadInputRegisters
 		},

--- a/growatt_bms_rs485_test.go
+++ b/growatt_bms_rs485_test.go
@@ -1,0 +1,67 @@
+package modbusreg
+
+import "testing"
+
+func TestGrowattBMSReadOnlyObservationRetainsOnlyExactDeclaredSlices(t *testing.T) {
+	input := validGrowattBMSReadOnlyInput()
+	observation, err := DecodeGrowattBMSReadOnlyObservation(input)
+	if err != nil {
+		t.Fatalf("DecodeGrowattBMSReadOnlyObservation() error = %v", err)
+	}
+	if observation.UnitID() != 1 || observation.Revision() != (GrowattBMSRevisionTuple{
+		Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02",
+	}) || observation.OutboundAllowed() {
+		t.Fatalf("observation did not preserve a read-only tuple: %#v", observation)
+	}
+	slices := observation.Slices()
+	if len(slices) != 4 || slices[0].Offset != 0x0001 || len(slices[0].Words) != 7 ||
+		slices[1].Offset != 0x000d || len(slices[1].Words) != 29 ||
+		slices[2].Offset != 0x0100 || len(slices[2].Words) != 12 ||
+		slices[3].Offset != 0x010d || len(slices[3].Words) != 2 {
+		t.Fatalf("slices=%#v", slices)
+	}
+	slices[0].Words[0] = 99
+	if got := observation.Slices()[0].Words[0]; got != 1 {
+		t.Fatalf("slice words alias observation: %d", got)
+	}
+}
+
+func TestGrowattBMSReadOnlyObservationRejectsAnythingOutsideTheFourSlices(t *testing.T) {
+	for name, mutate := range map[string]func(*GrowattBMSReadOnlyInput){
+		"broadcast":      func(input *GrowattBMSReadOnlyInput) { input.UnitID = 0 },
+		"other revision": func(input *GrowattBMSReadOnlyInput) { input.Revision.HeaderVersion = "V2.1" },
+		"missing slice":  func(input *GrowattBMSReadOnlyInput) { input.Slices = input.Slices[:3] },
+		"coalesced range": func(input *GrowattBMSReadOnlyInput) {
+			input.Slices = []GrowattBMSReadOnlySlice{{Offset: 0x0001, Words: make([]uint16, 41)}}
+		},
+		"barcode range": func(input *GrowattBMSReadOnlyInput) {
+			input.Slices[0] = GrowattBMSReadOnlySlice{Offset: 0x0009, Words: make([]uint16, 7)}
+		},
+		"extra range": func(input *GrowattBMSReadOnlyInput) {
+			input.Slices = append(input.Slices, GrowattBMSReadOnlySlice{Offset: 0x0200, Words: []uint16{1}})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := validGrowattBMSReadOnlyInput()
+			mutate(&input)
+			if _, err := DecodeGrowattBMSReadOnlyObservation(input); err == nil {
+				t.Fatal("accepted an out-of-bound Growatt BMS observation")
+			}
+		})
+	}
+}
+
+func validGrowattBMSReadOnlyInput() GrowattBMSReadOnlyInput {
+	return GrowattBMSReadOnlyInput{
+		UnitID: 1,
+		Revision: GrowattBMSRevisionTuple{
+			Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02",
+		},
+		Slices: []GrowattBMSReadOnlySlice{
+			{Offset: 0x0001, Words: []uint16{1, 0, 0, 0, 0, 0, 0}},
+			{Offset: 0x000d, Words: make([]uint16, 29)},
+			{Offset: 0x0100, Words: make([]uint16, 12)},
+			{Offset: 0x010d, Words: []uint16{0, 0}},
+		},
+	}
+}


### PR DESCRIPTION
## RED

`GOWORK=off go test ./...` fails because the bounded raw-only observation API is absent.

## Scope

Validate only one caller-supplied `1xSxxP ESS` / `Rev2.01` / `V2.0` / `2.02` tuple, unit 1-247, and four exact documented FC03 slices.

## Boundaries

No typed field semantics, inferred topology, catalog, detector, runtime, transport or live I/O. Controls and all outbound requests remain denied.

Docs gate: helianthus-docs-modbus #76 merge `a0e6adc75fcd8cbec50a53c067a1153fc31198c5`.

Closes #128