### PR TITLE
Add bounded Growatt Protocol II identity decoder

### DIFF
--- a/growatt_protocol_ii_identity.go
+++ b/growatt_protocol_ii_identity.go
@@ -35,10 +35,13 @@ type GrowattProtocolIIIdentityInput struct {
 // snapshot. It does not create a detector, standard registry match, catalog
 // entry, runtime activation, telemetry publication, or write authority.
 type GrowattProtocolIIIdentityObservation struct {
-	unitID       byte
-	profile      GrowattProtocolIIIdentityProfile
-	slices       []GrowattProtocolIIIdentitySlice
-	firmwareText string
+	unitID          byte
+	profile         GrowattProtocolIIIdentityProfile
+	slices          []GrowattProtocolIIIdentitySlice
+	firmwareText    string
+	deviceType      uint16
+	modelBuild      [2]uint16
+	protocolVersion uint16
 }
 
 func (o GrowattProtocolIIIdentityObservation) UnitID() byte { return o.unitID }
@@ -48,16 +51,10 @@ func (o GrowattProtocolIIIdentityObservation) Profile() GrowattProtocolIIIdentit
 func (o GrowattProtocolIIIdentityObservation) Slices() []GrowattProtocolIIIdentitySlice {
 	return cloneGrowattProtocolIIIdentitySlices(o.slices)
 }
-func (o GrowattProtocolIIIdentityObservation) FirmwareText() string { return o.firmwareText }
-func (o GrowattProtocolIIIdentityObservation) DeviceType() uint16 {
-	return o.slices[1].Words[0]
-}
-func (o GrowattProtocolIIIdentityObservation) ModelBuild() [2]uint16 {
-	return [2]uint16{o.slices[2].Words[0], o.slices[2].Words[1]}
-}
-func (o GrowattProtocolIIIdentityObservation) ProtocolVersion() uint16 {
-	return o.slices[3].Words[0]
-}
+func (o GrowattProtocolIIIdentityObservation) FirmwareText() string    { return o.firmwareText }
+func (o GrowattProtocolIIIdentityObservation) DeviceType() uint16      { return o.deviceType }
+func (o GrowattProtocolIIIdentityObservation) ModelBuild() [2]uint16   { return o.modelBuild }
+func (o GrowattProtocolIIIdentityObservation) ProtocolVersion() uint16 { return o.protocolVersion }
 
 // OutboundAllowed is permanently false: identity evidence cannot authorize a
 // control operation or another Modbus request.
@@ -92,10 +89,13 @@ func DecodeGrowattProtocolIIIdentity(input GrowattProtocolIIIdentityInput) (Grow
 	}
 
 	return GrowattProtocolIIIdentityObservation{
-		unitID:       input.UnitID,
-		profile:      input.Profile,
-		slices:       cloneGrowattProtocolIIIdentitySlices(input.Slices),
-		firmwareText: firmware,
+		unitID:          input.UnitID,
+		profile:         input.Profile,
+		slices:          cloneGrowattProtocolIIIdentitySlices(input.Slices),
+		firmwareText:    firmware,
+		deviceType:      input.Slices[1].Words[0],
+		modelBuild:      [2]uint16{input.Slices[2].Words[0], input.Slices[2].Words[1]},
+		protocolVersion: input.Slices[3].Words[0],
 	}, nil
 }
 

--- a/growatt_protocol_ii_identity.go
+++ b/growatt_protocol_ii_identity.go
@@ -1,0 +1,140 @@
+package modbusreg
+
+import "fmt"
+
+const growattProtocolIIIdentitySchema = "Protocol II v1.24 TL3-X"
+
+// GrowattProtocolIIIdentityProfile is supplied by the caller's bounded
+// fixture. The decoder never discovers a family or interprets another
+// Growatt profile from these words.
+type GrowattProtocolIIIdentityProfile struct {
+	Schema          string
+	Family          string
+	DeviceType      uint16
+	ModelBuild      [2]uint16
+	ProtocolVersion uint16
+}
+
+// GrowattProtocolIIIdentitySlice is one exact FC03 PDU slice. It has no
+// endpoint, session, request, or write authority.
+type GrowattProtocolIIIdentitySlice struct {
+	Offset uint16
+	Words  []uint16
+}
+
+// GrowattProtocolIIIdentityInput is a caller-supplied, offline identity
+// snapshot for the native Growatt Protocol II v1.24 TL3-X contract.
+type GrowattProtocolIIIdentityInput struct {
+	UnitID   byte
+	Function FunctionCode
+	Profile  GrowattProtocolIIIdentityProfile
+	Slices   []GrowattProtocolIIIdentitySlice
+}
+
+// GrowattProtocolIIIdentityObservation retains a validated raw identity
+// snapshot. It does not create a detector, standard registry match, catalog
+// entry, runtime activation, telemetry publication, or write authority.
+type GrowattProtocolIIIdentityObservation struct {
+	unitID       byte
+	profile      GrowattProtocolIIIdentityProfile
+	slices       []GrowattProtocolIIIdentitySlice
+	firmwareText string
+}
+
+func (o GrowattProtocolIIIdentityObservation) UnitID() byte { return o.unitID }
+func (o GrowattProtocolIIIdentityObservation) Profile() GrowattProtocolIIIdentityProfile {
+	return o.profile
+}
+func (o GrowattProtocolIIIdentityObservation) Slices() []GrowattProtocolIIIdentitySlice {
+	return cloneGrowattProtocolIIIdentitySlices(o.slices)
+}
+func (o GrowattProtocolIIIdentityObservation) FirmwareText() string { return o.firmwareText }
+func (o GrowattProtocolIIIdentityObservation) DeviceType() uint16 {
+	return o.slices[1].Words[0]
+}
+func (o GrowattProtocolIIIdentityObservation) ModelBuild() [2]uint16 {
+	return [2]uint16{o.slices[2].Words[0], o.slices[2].Words[1]}
+}
+func (o GrowattProtocolIIIdentityObservation) ProtocolVersion() uint16 {
+	return o.slices[3].Words[0]
+}
+
+// OutboundAllowed is permanently false: identity evidence cannot authorize a
+// control operation or another Modbus request.
+func (GrowattProtocolIIIdentityObservation) OutboundAllowed() bool { return false }
+
+// DecodeGrowattProtocolIIIdentity validates the four individually bounded
+// FC03 identity slices allowed by the Protocol II v1.24 TL3-X contract.
+func DecodeGrowattProtocolIIIdentity(input GrowattProtocolIIIdentityInput) (GrowattProtocolIIIdentityObservation, error) {
+	if input.UnitID == 0 || input.UnitID == 255 || input.Function != FunctionReadHoldingRegisters ||
+		!validGrowattProtocolIIIdentityProfile(input.Profile) {
+		return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity is invalid")
+	}
+
+	want := [...]struct{ offset, words uint16 }{{9, 6}, {43, 1}, {82, 2}, {88, 1}}
+	if len(input.Slices) != len(want) {
+		return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity slice count is invalid")
+	}
+	for index, expected := range want {
+		slice := input.Slices[index]
+		if slice.Offset != expected.offset || len(slice.Words) != int(expected.words) {
+			return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity slice %d is invalid", index)
+		}
+	}
+	if input.Slices[1].Words[0] != input.Profile.DeviceType ||
+		[2]uint16{input.Slices[2].Words[0], input.Slices[2].Words[1]} != input.Profile.ModelBuild ||
+		input.Slices[3].Words[0] != input.Profile.ProtocolVersion {
+		return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity tuple disagrees with caller profile")
+	}
+	firmware, err := growattProtocolIIASCII(input.Slices[0].Words)
+	if err != nil {
+		return GrowattProtocolIIIdentityObservation{}, err
+	}
+
+	return GrowattProtocolIIIdentityObservation{
+		unitID:       input.UnitID,
+		profile:      input.Profile,
+		slices:       cloneGrowattProtocolIIIdentitySlices(input.Slices),
+		firmwareText: firmware,
+	}, nil
+}
+
+func validGrowattProtocolIIIdentityProfile(profile GrowattProtocolIIIdentityProfile) bool {
+	if profile.Schema != growattProtocolIIIdentitySchema {
+		return false
+	}
+	switch profile.Family {
+	case "MAX", "MID", "MAC":
+		return true
+	default:
+		return false
+	}
+}
+
+func growattProtocolIIASCII(words []uint16) (string, error) {
+	bytes := make([]byte, 0, len(words)*2)
+	for _, word := range words {
+		bytes = append(bytes, byte(word>>8), byte(word))
+	}
+	end := len(bytes)
+	for end > 0 && (bytes[end-1] == 0 || bytes[end-1] == ' ') {
+		end--
+	}
+	if end == 0 {
+		return "", fmt.Errorf("growatt Protocol II firmware text is empty")
+	}
+	for _, value := range bytes[:end] {
+		if value < 0x20 || value > 0x7e {
+			return "", fmt.Errorf("growatt Protocol II firmware text is malformed")
+		}
+	}
+	return string(bytes[:end]), nil
+}
+
+func cloneGrowattProtocolIIIdentitySlices(slices []GrowattProtocolIIIdentitySlice) []GrowattProtocolIIIdentitySlice {
+	cloned := make([]GrowattProtocolIIIdentitySlice, len(slices))
+	for index, slice := range slices {
+		cloned[index] = GrowattProtocolIIIdentitySlice{Offset: slice.Offset, Words: append([]uint16(nil), slice.Words...)}
+	}
+	return cloned
+}

--- a/growatt_protocol_ii_identity_test.go
+++ b/growatt_protocol_ii_identity_test.go
@@ -1,0 +1,86 @@
+package modbusreg
+
+import "testing"
+
+func TestGrowattProtocolIIIdentityAcceptsOnlyAnExplicitFC03FixtureProfile(t *testing.T) {
+	input := validGrowattProtocolIIIdentityInput()
+	observation, err := DecodeGrowattProtocolIIIdentity(input)
+	if err != nil {
+		t.Fatalf("DecodeGrowattProtocolIIIdentity() error = %v", err)
+	}
+	if observation.UnitID() != 1 || observation.Profile() != input.Profile || observation.OutboundAllowed() {
+		t.Fatalf("observation did not preserve the read-only caller profile: %#v", observation)
+	}
+	if got := observation.FirmwareText(); got != "FW-1" {
+		t.Fatalf("FirmwareText() = %q, want %q", got, "FW-1")
+	}
+	if got := observation.DeviceType(); got != 0x1234 {
+		t.Fatalf("DeviceType() = %#x, want %#x", got, uint16(0x1234))
+	}
+	if got := observation.ModelBuild(); got != [2]uint16{0x4d41, 0x5831} {
+		t.Fatalf("ModelBuild() = %#v", got)
+	}
+	if got := observation.ProtocolVersion(); got != 0x0124 {
+		t.Fatalf("ProtocolVersion() = %#x, want %#x", got, uint16(0x0124))
+	}
+
+	slices := observation.Slices()
+	slices[0].Words[0] = 0
+	if got := observation.Slices()[0].Words[0]; got != 0x4657 {
+		t.Fatalf("Slices() aliases observation: %#x", got)
+	}
+}
+
+func TestGrowattProtocolIIIdentityRejectsOutOfContractInputs(t *testing.T) {
+	for name, mutate := range map[string]func(*GrowattProtocolIIIdentityInput){
+		"broadcast unit": func(input *GrowattProtocolIIIdentityInput) { input.UnitID = 0 },
+		"reserved unit":  func(input *GrowattProtocolIIIdentityInput) { input.UnitID = 255 },
+		"other function": func(input *GrowattProtocolIIIdentityInput) {
+			input.Function = FunctionReadInputRegisters
+		},
+		"other schema":   func(input *GrowattProtocolIIIdentityInput) { input.Profile.Schema = "Protocol II v1.23 TL3-X" },
+		"unknown family": func(input *GrowattProtocolIIIdentityInput) { input.Profile.Family = "MIX" },
+		"missing slice":  func(input *GrowattProtocolIIIdentityInput) { input.Slices = input.Slices[:3] },
+		"coalesced slice": func(input *GrowattProtocolIIIdentityInput) {
+			input.Slices = []GrowattProtocolIIIdentitySlice{{Offset: 9, Words: make([]uint16, 80)}}
+		},
+		"serial range": func(input *GrowattProtocolIIIdentityInput) {
+			input.Slices[0] = GrowattProtocolIIIdentitySlice{Offset: 23, Words: make([]uint16, 6)}
+		},
+		"wrong device type": func(input *GrowattProtocolIIIdentityInput) { input.Slices[1].Words[0] = 0xbeef },
+		"wrong model build": func(input *GrowattProtocolIIIdentityInput) { input.Slices[2].Words[1] = 0xbeef },
+		"wrong protocol":    func(input *GrowattProtocolIIIdentityInput) { input.Slices[3].Words[0] = 0x0123 },
+		"interior nul": func(input *GrowattProtocolIIIdentityInput) {
+			input.Slices[0].Words[0] = 0x4600
+			input.Slices[0].Words[1] = 0x5731
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := validGrowattProtocolIIIdentityInput()
+			mutate(&input)
+			if _, err := DecodeGrowattProtocolIIIdentity(input); err == nil {
+				t.Fatal("accepted an out-of-contract Growatt Protocol II identity")
+			}
+		})
+	}
+}
+
+func validGrowattProtocolIIIdentityInput() GrowattProtocolIIIdentityInput {
+	return GrowattProtocolIIIdentityInput{
+		UnitID:   1,
+		Function: FunctionReadHoldingRegisters,
+		Profile: GrowattProtocolIIIdentityProfile{
+			Schema:          "Protocol II v1.24 TL3-X",
+			Family:          "MAX",
+			DeviceType:      0x1234,
+			ModelBuild:      [2]uint16{0x4d41, 0x5831},
+			ProtocolVersion: 0x0124,
+		},
+		Slices: []GrowattProtocolIIIdentitySlice{
+			{Offset: 9, Words: []uint16{0x4657, 0x2d31, 0, 0, 0, 0}},
+			{Offset: 43, Words: []uint16{0x1234}},
+			{Offset: 82, Words: []uint16{0x4d41, 0x5831}},
+			{Offset: 88, Words: []uint16{0x0124}},
+		},
+	}
+}

--- a/growatt_protocol_ii_identity_test.go
+++ b/growatt_protocol_ii_identity_test.go
@@ -43,6 +43,13 @@ func TestGrowattProtocolIIIdentityAcceptsOnlyTheThreeDeclaredFamilies(t *testing
 	}
 }
 
+func TestGrowattProtocolIIIdentityZeroValueAccessorsAreSafe(t *testing.T) {
+	var observation GrowattProtocolIIIdentityObservation
+	if observation.DeviceType() != 0 || observation.ModelBuild() != [2]uint16{} || observation.ProtocolVersion() != 0 {
+		t.Fatalf("zero-value accessors returned non-zero observation: %#v", observation)
+	}
+}
+
 func TestGrowattProtocolIIIdentityRejectsOutOfContractInputs(t *testing.T) {
 	for name, mutate := range map[string]func(*GrowattProtocolIIIdentityInput){
 		"broadcast unit": func(input *GrowattProtocolIIIdentityInput) { input.UnitID = 0 },

--- a/growatt_protocol_ii_identity_test.go
+++ b/growatt_protocol_ii_identity_test.go
@@ -31,6 +31,18 @@ func TestGrowattProtocolIIIdentityAcceptsOnlyAnExplicitFC03FixtureProfile(t *tes
 	}
 }
 
+func TestGrowattProtocolIIIdentityAcceptsOnlyTheThreeDeclaredFamilies(t *testing.T) {
+	for _, family := range []string{"MAX", "MID", "MAC"} {
+		t.Run(family, func(t *testing.T) {
+			input := validGrowattProtocolIIIdentityInput()
+			input.Profile.Family = family
+			if _, err := DecodeGrowattProtocolIIIdentity(input); err != nil {
+				t.Fatalf("DecodeGrowattProtocolIIIdentity() family %q error = %v", family, err)
+			}
+		})
+	}
+}
+
 func TestGrowattProtocolIIIdentityRejectsOutOfContractInputs(t *testing.T) {
 	for name, mutate := range map[string]func(*GrowattProtocolIIIdentityInput){
 		"broadcast unit": func(input *GrowattProtocolIIIdentityInput) { input.UnitID = 0 },


### PR DESCRIPTION
## Scope

Adds a caller-supplied, read-only Growatt Protocol II v1.24 TL3-X identity decoder for exact FC03 slices `9/6`, `43/1`, `82/2`, and `88/1`. It is native Growatt, not SunSpec.

## Boundaries

- explicit caller profile only; no detector or global selection
- no catalog, runtime, transport, endpoint, or live I/O behavior
- no control/write authority

## TDD

The first commit is RED: tests reference the intentionally absent decoder API and fail to compile.