### PR TITLE
Record Growatt Protocol II offline identity disposition

### DIFF
--- a/growatt_disposition_test.go
+++ b/growatt_disposition_test.go
@@ -15,11 +15,13 @@ func TestGrowattDispositionFailsClosedWithoutQualifiedEvidence(t *testing.T) {
 		t.Fatal(err)
 	}
 	var record struct {
-		Schema         string `json:"schema"`
-		Profile        string `json:"profile"`
-		ProfileVersion string `json:"profile_version"`
-		Outcome        string `json:"outcome"`
-		Evidence       struct {
+		Schema                        string `json:"schema"`
+		Profile                       string `json:"profile"`
+		ProfileVersion                string `json:"profile_version"`
+		Outcome                       string `json:"outcome"`
+		OfflineIdentityGateRegistered bool   `json:"offline_identity_gate_registered"`
+		AutomaticRuntimeAdmission     bool   `json:"automatic_runtime_admission"`
+		Evidence                      struct {
 			PacketID          string `json:"packet_id"`
 			DocsMergeSHA      string `json:"docs_merge_sha"`
 			SourceIdentity    string `json:"source_identity"`
@@ -47,15 +49,16 @@ func TestGrowattDispositionFailsClosedWithoutQualifiedEvidence(t *testing.T) {
 	if record.Schema != "helianthus-modbusreg-profile-disposition/v1" ||
 		record.Profile != "growatt" ||
 		record.ProfileVersion != "1.0.0" ||
-		record.Outcome != "NO_ADMISSIBLE_PROFILE" {
+		record.Outcome != "OFFLINE_IDENTITY_ADMITTED" ||
+		!record.OfflineIdentityGateRegistered || record.AutomaticRuntimeAdmission {
 		t.Fatalf("unexpected disposition identity: %#v", record)
 	}
 	if record.Evidence.PacketID != "GROWATT-CANDIDATE-V1" ||
 		record.Evidence.DocsMergeSHA != "6654837a4ec29a3f226a29f701574ee84495ff2f" ||
 		record.Evidence.SourceIdentity != "sha256:fac88d609d74ff6b3c9c31ed65370d166d1fb17461e91b4b4855018fe232a320" ||
 		record.Evidence.SourceLicense != "vendor-copyright-inspection-only" ||
-		record.Evidence.PacketDisposition != "HYPOTHESIS" ||
-		record.Evidence.Eligible {
+		record.Evidence.PacketDisposition != "DOCUMENTED_OFFLINE_IDENTITY" ||
+		!record.Evidence.Eligible {
 		t.Fatalf("unexpected evidence lock: %#v", record.Evidence)
 	}
 	wantOperations := []struct {
@@ -75,8 +78,8 @@ func TestGrowattDispositionFailsClosedWithoutQualifiedEvidence(t *testing.T) {
 	if len(record.DecoderKeys) != 0 || record.CatalogRegistered || record.SupportClaim {
 		t.Fatalf("non-admission leaked support: keys=%v catalog=%v claim=%v", record.DecoderKeys, record.CatalogRegistered, record.SupportClaim)
 	}
-	wantUnresolved := []string{"exact_product_family", "firmware_branch", "address_normalization", "word_and_byte_order", "detector_uniqueness"}
-	wantReopen := []string{"public_clean_room_fixture", "exact_family_and_firmware_applicability", "verified_zero_based_address_normalization", "declared_word_and_byte_order", "mutually_exclusive_identity_tuple"}
+	wantUnresolved := []string{"automatic_detector_uniqueness", "exact_fc04_telemetry_schema", "runtime_admission_contract"}
+	wantReopen := []string{"mutually_exclusive_identity_tuple", "exact_fc04_telemetry_schema", "explicit_runtime_admission_contract"}
 	if !reflect.DeepEqual(record.Unresolved, wantUnresolved) || !reflect.DeepEqual(record.ReopenRequires, wantReopen) {
 		t.Fatalf("closure conditions unresolved=%v reopen=%v", record.Unresolved, record.ReopenRequires)
 	}

--- a/growatt_disposition_test.go
+++ b/growatt_disposition_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestGrowattDispositionFailsClosedWithoutQualifiedEvidence(t *testing.T) {
+func TestGrowattProtocolIIDispositionAdmitsOnlyOfflineIdentity(t *testing.T) {
 	data, err := os.ReadFile("profiles/vendor/growatt/disposition.json")
 	if err != nil {
 		t.Fatal(err)

--- a/mixed_catalog_closure_test.go
+++ b/mixed_catalog_closure_test.go
@@ -110,7 +110,7 @@ func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
 	}{
 		{"sunspec.direct-inverter", "PRIMARY", "CONDITIONAL_CAPABILITY", reg.SunSpecThreePhaseMonitoringCapabilityID, ""},
 		{"fronius.gen24", "POST_PRIMARY_FLAVOR", "QUALIFIED_FLAVOR_CLASSIFICATION", reg.SunSpecFroniusObservedFlavorID + "," + reg.SunSpecFroniusObservedFlavorV11ID, ""},
-		{"growatt.direct-inverter", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/growatt/disposition.json"},
+		{"growatt.direct-inverter", "PRIMARY_CANDIDATE", "OFFLINE_IDENTITY_ADMITTED", "", "profiles/vendor/growatt/disposition.json"},
 		{"huawei.smartlogger", "PRIMARY_CANDIDATE", "NO_ADMISSIBLE_PROFILE", "", "profiles/vendor/huawei/smartlogger-disposition.json"},
 		{"huawei.sdongle", "PRIMARY_CANDIDATE", "PRE_LIVE_INSUFFICIENT_EVIDENCE", "", "profiles/vendor/huawei/sdongle-disposition.json"},
 		{"huawei.emma", "PRIMARY_CANDIDATE", "OFFLINE_IDENTITY_ADMITTED", "", "profiles/vendor/huawei/emma-disposition.json"},
@@ -145,7 +145,7 @@ func TestMixedCatalogClosurePinsParticipantsAndFailClosedPolicy(t *testing.T) {
 			disposition.AutomaticRuntimeAdmission || disposition.SupportClaim {
 			t.Fatalf("participant %s became actionable: %#v", got.ID, disposition)
 		}
-		if got.ID == "huawei.emma" && !disposition.OfflineIdentityGate {
+		if (got.ID == "huawei.emma" || got.ID == "growatt.direct-inverter") && !disposition.OfflineIdentityGate {
 			t.Fatalf("participant %s lacks its offline identity gate: %#v", got.ID, disposition)
 		}
 	}

--- a/profiles/mixed-catalog-closure-v1.json
+++ b/profiles/mixed-catalog-closure-v1.json
@@ -57,7 +57,7 @@
     {
       "id": "growatt.direct-inverter",
       "role": "PRIMARY_CANDIDATE",
-      "disposition": "NO_ADMISSIBLE_PROFILE",
+      "disposition": "OFFLINE_IDENTITY_ADMITTED",
       "runtime_identity": "",
       "disposition_file": "profiles/vendor/growatt/disposition.json"
     },

--- a/profiles/vendor/growatt/disposition.json
+++ b/profiles/vendor/growatt/disposition.json
@@ -2,15 +2,17 @@
   "schema": "helianthus-modbusreg-profile-disposition/v1",
   "profile": "growatt",
   "profile_version": "1.0.0",
-  "outcome": "NO_ADMISSIBLE_PROFILE",
+  "outcome": "OFFLINE_IDENTITY_ADMITTED",
   "evidence": {
     "packet_id": "GROWATT-CANDIDATE-V1",
     "docs_merge_sha": "6654837a4ec29a3f226a29f701574ee84495ff2f",
     "source_identity": "sha256:fac88d609d74ff6b3c9c31ed65370d166d1fb17461e91b4b4855018fe232a320",
     "source_license": "vendor-copyright-inspection-only",
-    "packet_disposition": "HYPOTHESIS",
-    "eligible": false
+    "packet_disposition": "DOCUMENTED_OFFLINE_IDENTITY",
+    "eligible": true
   },
+  "offline_identity_gate_registered": true,
+  "automatic_runtime_admission": false,
   "candidate_operations": [
     {"function": 3, "offset": 9, "quantity": 6, "purpose": "firmware_tuple", "executable": false},
     {"function": 3, "offset": 43, "quantity": 1, "purpose": "device_type_code", "executable": false},
@@ -18,20 +20,16 @@
     {"function": 3, "offset": 88, "quantity": 1, "purpose": "protocol_version", "executable": false}
   ],
   "unresolved": [
-    "exact_product_family",
-    "firmware_branch",
-    "address_normalization",
-    "word_and_byte_order",
-    "detector_uniqueness"
+    "automatic_detector_uniqueness",
+    "exact_fc04_telemetry_schema",
+    "runtime_admission_contract"
   ],
   "decoder_keys": [],
   "catalog_registered": false,
   "support_claim": false,
   "reopen_requires": [
-    "public_clean_room_fixture",
-    "exact_family_and_firmware_applicability",
-    "verified_zero_based_address_normalization",
-    "declared_word_and_byte_order",
-    "mutually_exclusive_identity_tuple"
+    "mutually_exclusive_identity_tuple",
+    "exact_fc04_telemetry_schema",
+    "explicit_runtime_admission_contract"
   ]
 }


### PR DESCRIPTION
## Scope

Reconciles the Growatt registry disposition with the merged caller-supplied Protocol II identity decoder.

## Boundaries

The result remains offline identity only: no standard/global selection, catalog registration, automatic runtime admission, telemetry activation, transport, control, or live I/O.

## TDD

The first commit is RED: disposition and mixed-catalog tests require the offline-only state before the JSON records provide it.