### PR TITLE
Retain opaque Tesla FC101/FC102 terminal provenance

### DIFF
--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -285,6 +285,53 @@ type TeslaHSCProvenance struct {
 	payloadDigest        string
 }
 
+// TeslaHSCOpaqueTerminalProvenance is redacted metadata for one already-
+// correlated FC101 or FC102 normal terminal response. It never retains or
+// exposes raw response bytes.
+type TeslaHSCOpaqueTerminalProvenance struct {
+	function      modbus.PrivateFunctionCode
+	payloadLength int
+	payloadDigest string
+}
+
+// DecodeTeslaHSCOpaqueTerminalProvenance validates one selected opaque terminal
+// exchange and retains only deterministic redacted response metadata. It does
+// not construct a request or grant any outbound admission.
+func DecodeTeslaHSCOpaqueTerminalProvenance(
+	function modbus.PrivateFunctionCode,
+	payloads [][]byte,
+) (TeslaHSCOpaqueTerminalProvenance, error) {
+	if function != teslaHSCFunction101 && function != teslaHSCFunction102 {
+		return TeslaHSCOpaqueTerminalProvenance{}, fmt.Errorf("tesla HSC opaque terminal function is unsupported")
+	}
+	responses, err := DecodeTeslaHSCExchange(function, payloads)
+	if err != nil {
+		return TeslaHSCOpaqueTerminalProvenance{}, err
+	}
+	payload := responses[0].Payload()
+	digest := sha256.Sum256(payload)
+	return TeslaHSCOpaqueTerminalProvenance{
+		function:      function,
+		payloadLength: len(payload),
+		payloadDigest: hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+// Function returns the selected opaque terminal-response function.
+func (provenance TeslaHSCOpaqueTerminalProvenance) Function() modbus.PrivateFunctionCode {
+	return provenance.function
+}
+
+// PayloadLength returns the bounded terminal-response byte count.
+func (provenance TeslaHSCOpaqueTerminalProvenance) PayloadLength() int {
+	return provenance.payloadLength
+}
+
+// PayloadDigest returns the deterministic redacted terminal-response digest.
+func (provenance TeslaHSCOpaqueTerminalProvenance) PayloadDigest() string {
+	return provenance.payloadDigest
+}
+
 // NewTeslaHSCProvenance creates provenance that contains no raw payload bytes.
 func NewTeslaHSCProvenance(
 	compatibilityVersion string,

--- a/tesla_hsc_opaque_terminal_provenance_test.go
+++ b/tesla_hsc_opaque_terminal_provenance_test.go
@@ -1,0 +1,41 @@
+package modbusreg
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaHSCOpaqueTerminalProvenanceRetainsOnlySelectedFC101AndFC102ResponseMetadata(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		function modbus.PrivateFunctionCode
+		payload  []byte
+	}{
+		{name: "fc101", function: teslaHSCFunction101, payload: []byte{0x01}},
+		{name: "fc102", function: teslaHSCFunction102, payload: []byte{0x02, 0x00}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := DecodeTeslaHSCOpaqueTerminalProvenance(test.function, [][]byte{test.payload})
+			if err != nil {
+				t.Fatal(err)
+			}
+			digest := sha256.Sum256(test.payload)
+			if got.Function() != test.function || got.PayloadLength() != len(test.payload) ||
+				got.PayloadDigest() != hex.EncodeToString(digest[:]) {
+				t.Fatalf("redacted opaque terminal provenance = %#v", got)
+			}
+		})
+	}
+}
+
+func TestTeslaHSCOpaqueTerminalProvenanceRejectsNonterminalOrUnselectedExchange(t *testing.T) {
+	if _, err := DecodeTeslaHSCOpaqueTerminalProvenance(teslaHSCFunction100, [][]byte{{0}}); err == nil {
+		t.Fatal("FC100 intermediate-capable exchange accepted as opaque terminal provenance")
+	}
+	if _, err := DecodeTeslaHSCOpaqueTerminalProvenance(teslaHSCFunction101, [][]byte{{0x01}, {0x02}}); err == nil {
+		t.Fatal("multiple FC101 responses accepted as one terminal response")
+	}
+}

--- a/tesla_hsc_opaque_terminal_provenance_test.go
+++ b/tesla_hsc_opaque_terminal_provenance_test.go
@@ -14,6 +14,7 @@ func TestTeslaHSCOpaqueTerminalProvenanceRetainsOnlySelectedFC101AndFC102Respons
 		function modbus.PrivateFunctionCode
 		payload  []byte
 	}{
+		{name: "fc101_empty", function: teslaHSCFunction101, payload: nil},
 		{name: "fc101", function: teslaHSCFunction101, payload: []byte{0x01}},
 		{name: "fc102", function: teslaHSCFunction102, payload: []byte{0x02, 0x00}},
 	} {


### PR DESCRIPTION
Closes #134

## RED

The committed test-only head fails because `DecodeTeslaHSCOpaqueTerminalProvenance` does not yet exist.

## Scope

Redacted, offline provenance only for already-correlated FC101/FC102 terminal normal responses. No request construction, send/admission, serial I/O, field decoding, or generic transport changes.

## Acceptance

- only FC101/FC102 terminal normal exchanges are accepted
- length and deterministic digest are retained without raw bytes
- multi-response and FC100 are rejected
- outbound remains denied
