### PR TITLE
Summarize bounded FC100 protobuf wire entries

### DIFF
--- a/tesla_fc100_tedapi.go
+++ b/tesla_fc100_tedapi.go
@@ -6,18 +6,29 @@ import (
 	"fmt"
 )
 
+const maxTeslaFC100TEDAPIWireEntries = 64
+
+// TeslaFC100WireEntry is one redacted numeric protobuf wire key. It carries no
+// encoded value, field name, or operation meaning.
+type TeslaFC100WireEntry struct {
+	fieldNumber uint64
+	wireType    uint8
+}
+
 // TeslaFC100TEDAPI is a bounded, redacted FC100 TEDAPI replay projection. It
-// identifies only the first protobuf key shape and never assigns field names,
+// identifies ordered protobuf wire-key shapes and never assigns field names,
 // operation meaning, admission, or send authority.
 type TeslaFC100TEDAPI struct {
-	messageLength int
-	firstField    uint64
-	firstWireType uint8
-	payloadDigest string
+	envelopeLength int
+	messageLength  int
+	firstField     uint64
+	firstWireType  uint8
+	wireEntries    []TeslaFC100WireEntry
+	payloadDigest  string
 }
 
 // DecodeTeslaFC100TEDAPI validates the exact FC100 length envelope and parses
-// one bounded protobuf key varint from its opaque nested message.
+// a bounded complete protobuf wire summary from its opaque nested message.
 func DecodeTeslaFC100TEDAPI(payload []byte) (TeslaFC100TEDAPI, error) {
 	envelope, err := DecodeTeslaHSCEnvelope(teslaHSCFunction100, payload)
 	if err != nil {
@@ -27,37 +38,97 @@ func DecodeTeslaFC100TEDAPI(payload []byte) (TeslaFC100TEDAPI, error) {
 	if len(message) == 0 {
 		return TeslaFC100TEDAPI{}, fmt.Errorf("tesla FC100 TEDAPI message is empty")
 	}
-	key, consumed, err := decodeTeslaTEDAPIKey(message)
+	entries, err := decodeTeslaFC100TEDAPIWireEntries(message)
 	if err != nil {
 		return TeslaFC100TEDAPI{}, err
 	}
-	field := key >> 3
-	wireType := uint8(key & 0x07)
-	if consumed == 0 || field == 0 || field > (1<<29)-1 || wireType > 5 {
-		return TeslaFC100TEDAPI{}, fmt.Errorf("tesla FC100 TEDAPI key is invalid")
-	}
 	digest := sha256.Sum256(message)
 	return TeslaFC100TEDAPI{
-		messageLength: len(message),
-		firstField:    field,
-		firstWireType: wireType,
-		payloadDigest: hex.EncodeToString(digest[:]),
+		envelopeLength: len(payload),
+		messageLength:  len(message),
+		firstField:     entries[0].fieldNumber,
+		firstWireType:  entries[0].wireType,
+		wireEntries:    append([]TeslaFC100WireEntry(nil), entries...),
+		payloadDigest:  hex.EncodeToString(digest[:]),
 	}, nil
 }
 
-func decodeTeslaTEDAPIKey(message []byte) (uint64, int, error) {
+func decodeTeslaFC100TEDAPIWireEntries(message []byte) ([]TeslaFC100WireEntry, error) {
+	entries := make([]TeslaFC100WireEntry, 0, maxTeslaFC100TEDAPIWireEntries)
+	groups := make([]uint64, 0, maxTeslaFC100TEDAPIWireEntries)
+	for offset := 0; offset < len(message); {
+		key, consumed, err := decodeTeslaTEDAPIVarint(message[offset:])
+		if err != nil {
+			return nil, err
+		}
+		offset += consumed
+		field := key >> 3
+		wireType := uint8(key & 0x07)
+		if field == 0 || field > (1<<29)-1 || wireType > 5 {
+			return nil, fmt.Errorf("tesla FC100 TEDAPI key is invalid")
+		}
+		if len(entries) == maxTeslaFC100TEDAPIWireEntries {
+			return nil, fmt.Errorf("tesla FC100 TEDAPI wire entry count exceeds bound")
+		}
+		entries = append(entries, TeslaFC100WireEntry{fieldNumber: field, wireType: wireType})
+		switch wireType {
+		case 0:
+			_, valueLength, err := decodeTeslaTEDAPIVarint(message[offset:])
+			if err != nil {
+				return nil, err
+			}
+			offset += valueLength
+		case 1:
+			if len(message)-offset < 8 {
+				return nil, fmt.Errorf("tesla FC100 TEDAPI fixed64 value is truncated")
+			}
+			offset += 8
+		case 2:
+			valueLength, lengthLength, err := decodeTeslaTEDAPIVarint(message[offset:])
+			if err != nil {
+				return nil, err
+			}
+			offset += lengthLength
+			if valueLength > uint64(len(message)-offset) {
+				return nil, fmt.Errorf("tesla FC100 TEDAPI length-delimited value is truncated")
+			}
+			offset += int(valueLength)
+		case 3:
+			groups = append(groups, field)
+		case 4:
+			if len(groups) == 0 || groups[len(groups)-1] != field {
+				return nil, fmt.Errorf("tesla FC100 TEDAPI group boundary is invalid")
+			}
+			groups = groups[:len(groups)-1]
+		case 5:
+			if len(message)-offset < 4 {
+				return nil, fmt.Errorf("tesla FC100 TEDAPI fixed32 value is truncated")
+			}
+			offset += 4
+		}
+	}
+	if len(groups) != 0 {
+		return nil, fmt.Errorf("tesla FC100 TEDAPI group boundary is truncated")
+	}
+	return entries, nil
+}
+
+func decodeTeslaTEDAPIVarint(message []byte) (uint64, int, error) {
 	var value uint64
 	for index, byteValue := range message {
 		if index == 10 || (index == 9 && byteValue > 1) {
-			return 0, 0, fmt.Errorf("tesla FC100 TEDAPI key overflows")
+			return 0, 0, fmt.Errorf("tesla FC100 TEDAPI varint overflows")
 		}
 		value |= uint64(byteValue&0x7f) << (7 * index)
 		if byteValue&0x80 == 0 {
 			return value, index + 1, nil
 		}
 	}
-	return 0, 0, fmt.Errorf("tesla FC100 TEDAPI key is truncated")
+	return 0, 0, fmt.Errorf("tesla FC100 TEDAPI varint is truncated")
 }
+
+// EnvelopeLength returns the bounded FC100 PDU length including its prefix.
+func (decoded TeslaFC100TEDAPI) EnvelopeLength() int { return decoded.envelopeLength }
 
 // MessageLength returns the bounded nested-message length.
 func (decoded TeslaFC100TEDAPI) MessageLength() int { return decoded.messageLength }
@@ -67,6 +138,20 @@ func (decoded TeslaFC100TEDAPI) FirstFieldNumber() uint64 { return decoded.first
 
 // FirstWireType returns the numeric wire type of the first key.
 func (decoded TeslaFC100TEDAPI) FirstWireType() uint8 { return decoded.firstWireType }
+
+// WireEntries returns independent ordered redacted wire-key metadata.
+func (decoded TeslaFC100TEDAPI) WireEntries() []TeslaFC100WireEntry {
+	return append([]TeslaFC100WireEntry(nil), decoded.wireEntries...)
+}
+
+// WireEntryCount returns the bounded number of retained wire entries.
+func (decoded TeslaFC100TEDAPI) WireEntryCount() int { return len(decoded.wireEntries) }
+
+// FieldNumber returns the numeric protobuf field identifier.
+func (entry TeslaFC100WireEntry) FieldNumber() uint64 { return entry.fieldNumber }
+
+// WireType returns the numeric protobuf wire type.
+func (entry TeslaFC100WireEntry) WireType() uint8 { return entry.wireType }
 
 // PayloadDigest returns deterministic redacted replay provenance.
 func (decoded TeslaFC100TEDAPI) PayloadDigest() string { return decoded.payloadDigest }

--- a/tesla_fc100_tedapi_test.go
+++ b/tesla_fc100_tedapi_test.go
@@ -34,7 +34,7 @@ func TestTeslaFC100TEDAPISummarizesOrderedBoundedWireEntries(t *testing.T) {
 		0x08, 0x96, 0x01, // field 1, varint
 		0x12, 0x02, 0xaa, 0xbb, // field 2, length-delimited
 		0x1d, 0x01, 0x02, 0x03, 0x04, // field 3, fixed32
-		0x23, // field 4, start group
+		0x23,       // field 4, start group
 		0x28, 0x01, // field 5, varint inside group
 		0x24, // field 4, end group
 	}
@@ -67,9 +67,9 @@ func TestTeslaFC100TEDAPIRejectsMalformedOrOverCountedWireSummary(t *testing.T) 
 	}
 	for _, message := range [][]byte{
 		{0x12, 0x02, 0xaa}, // truncated length-delimited value
-		{0x09, 0x01}, // truncated fixed64 value
-		{0x0c}, // unpaired end group
-		{0x0b, 0x14}, // mismatched group boundaries
+		{0x09, 0x01},       // truncated fixed64 value
+		{0x0c},             // unpaired end group
+		{0x0b, 0x14},       // mismatched group boundaries
 		overCountMessage,
 	} {
 		payload := append([]byte{byte(len(message))}, message...)

--- a/tesla_fc100_tedapi_test.go
+++ b/tesla_fc100_tedapi_test.go
@@ -28,3 +28,53 @@ func TestTeslaFC100TEDAPIRejectsMalformedOrOverBoundedFirstVarint(t *testing.T) 
 		}
 	}
 }
+
+func TestTeslaFC100TEDAPISummarizesOrderedBoundedWireEntries(t *testing.T) {
+	message := []byte{
+		0x08, 0x96, 0x01, // field 1, varint
+		0x12, 0x02, 0xaa, 0xbb, // field 2, length-delimited
+		0x1d, 0x01, 0x02, 0x03, 0x04, // field 3, fixed32
+		0x23, // field 4, start group
+		0x28, 0x01, // field 5, varint inside group
+		0x24, // field 4, end group
+	}
+	decoded, err := DecodeTeslaFC100TEDAPI(append([]byte{byte(len(message))}, message...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.EnvelopeLength() != len(message)+1 || decoded.WireEntryCount() != 6 || decoded.Payload() != nil {
+		t.Fatalf("wire summary metadata = %#v", decoded)
+	}
+	entries := decoded.WireEntries()
+	want := []struct {
+		field uint64
+		kind  uint8
+	}{{1, 0}, {2, 2}, {3, 5}, {4, 3}, {5, 0}, {4, 4}}
+	if len(entries) != len(want) {
+		t.Fatalf("wire entries = %#v", entries)
+	}
+	for index, entry := range entries {
+		if entry.FieldNumber() != want[index].field || entry.WireType() != want[index].kind {
+			t.Fatalf("wire entry[%d] = %#v, want field=%d kind=%d", index, entry, want[index].field, want[index].kind)
+		}
+	}
+}
+
+func TestTeslaFC100TEDAPIRejectsMalformedOrOverCountedWireSummary(t *testing.T) {
+	overCountMessage := make([]byte, 0, 130)
+	for range 65 {
+		overCountMessage = append(overCountMessage, 0x08, 0x00)
+	}
+	for _, message := range [][]byte{
+		{0x12, 0x02, 0xaa}, // truncated length-delimited value
+		{0x09, 0x01}, // truncated fixed64 value
+		{0x0c}, // unpaired end group
+		{0x0b, 0x14}, // mismatched group boundaries
+		overCountMessage,
+	} {
+		payload := append([]byte{byte(len(message))}, message...)
+		if _, err := DecodeTeslaFC100TEDAPI(payload); err == nil {
+			t.Fatalf("invalid wire summary accepted: %x", payload)
+		}
+	}
+}


### PR DESCRIPTION
Closes #136

## RED

Test-only HEAD fails because ordered wire-summary accessors are not implemented.

## Scope

FC100 envelope parser validates and summarizes numeric protobuf field/wire entries, envelope length, count, and digest only.

## Exclusions

No values/raw bytes/field names, operation/capability inference, request encoding, admission, send, lifecycle, gateway, or I/O. Companion docs #80 is required before merge.