### PR TITLE
REG-TESLA: add qualified FC100 WC vitals operation profile

### DIFF
--- a/qualified_function_registry.go
+++ b/qualified_function_registry.go
@@ -21,10 +21,19 @@ type QualifiedFunctionSelector struct {
 	Operation     string
 }
 
-// QualifiedFunctionResult retains bytes accepted by the selected codec only.
-// The registry does not infer fields, units, or operation semantics.
+// QualifiedFunctionReplay is a generic redacted result available when a
+// selected codec intentionally withholds response bytes.
+type QualifiedFunctionReplay struct {
+	Kind          string
+	PayloadLength int
+	PayloadDigest string
+}
+
+// QualifiedFunctionResult retains only the representation selected by the
+// codec. The registry does not infer fields, units, or operation semantics.
 type QualifiedFunctionResult struct {
 	Payload []byte
+	Replay  *QualifiedFunctionReplay
 }
 
 // QualifiedFunctionCodec owns construction and normal-response decoding for
@@ -115,6 +124,10 @@ func (registry *QualifiedFunctionRegistry) Dispatch(
 			return nil, err
 		}
 		result.Payload = append([]byte(nil), result.Payload...)
+		if result.Replay != nil {
+			replay := *result.Replay
+			result.Replay = &replay
+		}
 		results = append(results, result)
 	}
 	return results, nil

--- a/qualified_function_registry_test.go
+++ b/qualified_function_registry_test.go
@@ -132,20 +132,33 @@ func (codec *qualifiedFunctionTestCodec) DecodeQualifiedFunction(operation strin
 }
 
 type qualifiedFunctionTestTransport struct {
-	calls    int
-	requests []modbus.PrivateFunctionRequest
+	calls            int
+	requests         []modbus.PrivateFunctionRequest
+	responsePayloads [][]byte
 }
 
 func (transport *qualifiedFunctionTestTransport) Exchange(_ context.Context, unitID byte, request modbus.PrivateFunctionRequest, _ modbus.PrivateFunctionResponsePolicy) ([]modbus.RTUPrivateFunctionResponseADU, error) {
 	transport.calls++
 	transport.requests = append(transport.requests, request)
-	frame, err := modbus.EncodeRTUPrivateFunctionADU(unitID, request)
-	if err != nil {
-		return nil, err
+	payloads := transport.responsePayloads
+	if payloads == nil {
+		payloads = [][]byte{request.Payload()}
 	}
-	response, err := modbus.DecodeRTUPrivateFunctionResponseADU(unitID, request, frame)
-	if err != nil {
-		return nil, err
+	responses := make([]modbus.RTUPrivateFunctionResponseADU, 0, len(payloads))
+	for _, payload := range payloads {
+		responseRequest, err := modbus.NewPrivateFunctionRequest(request.FunctionCode(), payload)
+		if err != nil {
+			return nil, err
+		}
+		frame, err := modbus.EncodeRTUPrivateFunctionADU(unitID, responseRequest)
+		if err != nil {
+			return nil, err
+		}
+		response, err := modbus.DecodeRTUPrivateFunctionResponseADU(unitID, request, frame)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, response)
 	}
-	return []modbus.RTUPrivateFunctionResponseADU{response}, nil
+	return responses, nil
 }

--- a/tesla_fc100_wc_vitals.go
+++ b/tesla_fc100_wc_vitals.go
@@ -1,0 +1,106 @@
+package modbusreg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// TeslaTEDAPIOperationWCVitalsV1 identifies the only explicitly qualified
+// FC100 operation in this compatibility contract.
+const TeslaTEDAPIOperationWCVitalsV1 = "tesla.hsc.fc100.wc_vitals.v1"
+
+var teslaFC100WCVitalsRequestPDU = []byte{0x04, 0x32, 0x02, 0x0a, 0x00}
+
+// TeslaFC100WCVitalsReplayKind distinguishes the echoed FC100 intermediate
+// from the qualified terminal snapshot without exposing field values.
+type TeslaFC100WCVitalsReplayKind string
+
+const (
+	TeslaFC100WCVitalsIntermediate TeslaFC100WCVitalsReplayKind = "intermediate"
+	TeslaFC100WCVitalsTerminal     TeslaFC100WCVitalsReplayKind = "terminal"
+)
+
+// TeslaFC100WCVitalsReplay is a bounded redacted result of the typed response
+// container decoder. Snapshot values and raw bytes are intentionally omitted.
+type TeslaFC100WCVitalsReplay struct {
+	Kind           TeslaFC100WCVitalsReplayKind
+	SnapshotLength int
+	SnapshotDigest string
+}
+
+// OperationAdmissionFor applies the profile gate and the operation-specific
+// exact version gate. Unknown operations remain no-send.
+func (profile TeslaHSCProfile) OperationAdmissionFor(operation string) TeslaTEDAPIOperationAdmission {
+	if profile.Disposition() != TeslaHSCQualifiedReadOnly {
+		return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedProfile}
+	}
+	if operation != TeslaTEDAPIOperationWCVitalsV1 ||
+		profile.config.WCVitalsOperationVersion != TeslaHSCWCVitalsCompatibilityV1 {
+		return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation}
+	}
+	return TeslaTEDAPIOperationAdmission{
+		State:           TeslaTEDAPIAdmissionAllowedWCVitals,
+		OutboundAllowed: true,
+	}
+}
+
+// DecodeTeslaFC100WCVitalsReplay decodes the exact FC100 WC vitals operation
+// shape. It accepts the byte-exact echo or one fully bounded terminal response.
+func DecodeTeslaFC100WCVitalsReplay(payload []byte) (TeslaFC100WCVitalsReplay, error) {
+	response, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
+	if err != nil {
+		return TeslaFC100WCVitalsReplay{}, err
+	}
+	message := response.Payload()
+	requestMessage := teslaFC100WCVitalsRequestPDU[1:]
+	if bytes.Equal(message, requestMessage) {
+		return TeslaFC100WCVitalsReplay{Kind: TeslaFC100WCVitalsIntermediate}, nil
+	}
+	wcMessages, err := decodeExactLengthDelimitedField(message, 6)
+	if err != nil {
+		return TeslaFC100WCVitalsReplay{}, fmt.Errorf("tesla WC vitals envelope: %w", err)
+	}
+	vitalsResponse, err := decodeExactLengthDelimitedField(wcMessages, 2)
+	if err != nil {
+		return TeslaFC100WCVitalsReplay{}, fmt.Errorf("tesla WC vitals message: %w", err)
+	}
+	vitals, err := decodeExactLengthDelimitedField(vitalsResponse, 1)
+	if err != nil {
+		return TeslaFC100WCVitalsReplay{}, fmt.Errorf("tesla WC vitals response: %w", err)
+	}
+	digest := sha256.Sum256(vitals)
+	return TeslaFC100WCVitalsReplay{
+		Kind:           TeslaFC100WCVitalsTerminal,
+		SnapshotLength: len(vitals),
+		SnapshotDigest: hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+func decodeExactLengthDelimitedField(message []byte, fieldNumber uint64) ([]byte, error) {
+	key, width, err := decodeTeslaFC100Varint(message)
+	if err != nil || key != fieldNumber<<3|2 {
+		return nil, fmt.Errorf("expected one length-delimited field")
+	}
+	length, lengthWidth, err := decodeTeslaFC100Varint(message[width:])
+	if err != nil || length > uint64(len(message)-width-lengthWidth) ||
+		int(length) != len(message)-width-lengthWidth {
+		return nil, fmt.Errorf("field length is invalid")
+	}
+	return append([]byte(nil), message[width+lengthWidth:]...), nil
+}
+
+func decodeTeslaFC100Varint(input []byte) (uint64, int, error) {
+	var value uint64
+	for index, octet := range input {
+		if index == 10 || index == 9 && octet > 1 {
+			return 0, 0, fmt.Errorf("varint overflows")
+		}
+		value |= uint64(octet&0x7f) << (7 * index)
+		if octet&0x80 == 0 {
+			return value, index + 1, nil
+		}
+	}
+	return 0, 0, fmt.Errorf("varint is truncated")
+}

--- a/tesla_fc100_wc_vitals_test.go
+++ b/tesla_fc100_wc_vitals_test.go
@@ -1,0 +1,76 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaFC100WCVitalsOperationIsExplicitlyVersionQualified(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:                     true,
+		Node:                        0x10,
+		PassiveCompatible:           true,
+		CompatibilityVersion:        TeslaHSCCompatibilityV1,
+		WCVitalsOperationVersion:    TeslaHSCWCVitalsCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admission := profile.OperationAdmissionFor(TeslaTEDAPIOperationWCVitalsV1)
+	if !admission.OutboundAllowed || admission.State != TeslaTEDAPIAdmissionAllowedWCVitals {
+		t.Fatalf("admission = %#v", admission)
+	}
+	request, policy, err := profile.EncodeQualifiedFunction(TeslaTEDAPIOperationWCVitalsV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.FunctionCode() != modbus.PrivateFunctionCode(100) ||
+		!bytes.Equal(request.Payload(), []byte{0x04, 0x32, 0x02, 0x0a, 0x00}) ||
+		policy.MaxAttempts() != 1 {
+		t.Fatalf("request/policy = %#v/%#v", request, policy)
+	}
+
+	withoutOperationVersion, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admission := withoutOperationVersion.OperationAdmissionFor(TeslaTEDAPIOperationWCVitalsV1); admission.OutboundAllowed {
+		t.Fatalf("unversioned profile admission = %#v", admission)
+	}
+	if _, _, err := withoutOperationVersion.EncodeQualifiedFunction(TeslaTEDAPIOperationWCVitalsV1); err == nil {
+		t.Fatal("unversioned profile encoded a vitals request")
+	}
+}
+
+func TestTeslaFC100WCVitalsReplayClassifiesEchoAndBoundedTerminal(t *testing.T) {
+	echo, err := DecodeTeslaFC100WCVitalsReplay([]byte{0x04, 0x32, 0x02, 0x0a, 0x00})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if echo.Kind != TeslaFC100WCVitalsIntermediate || echo.SnapshotLength != 0 || echo.SnapshotDigest != "" {
+		t.Fatalf("echo = %#v", echo)
+	}
+
+	terminal, err := DecodeTeslaFC100WCVitalsReplay([]byte{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if terminal.Kind != TeslaFC100WCVitalsTerminal || terminal.SnapshotLength != 0 ||
+		terminal.SnapshotDigest != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Fatalf("terminal = %#v", terminal)
+	}
+
+	for _, payload := range [][]byte{
+		{0x06, 0x32, 0x04, 0x12, 0x02, 0x12, 0x00},
+		{0x07, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00, 0x00},
+		{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a},
+	} {
+		if _, err := DecodeTeslaFC100WCVitalsReplay(payload); err == nil {
+			t.Fatalf("malformed terminal accepted: %x", payload)
+		}
+	}
+}

--- a/tesla_fc100_wc_vitals_test.go
+++ b/tesla_fc100_wc_vitals_test.go
@@ -52,10 +52,15 @@ func TestTeslaFC100WCVitalsOperationIsExplicitlyVersionQualified(t *testing.T) {
 		t.Fatal(err)
 	}
 	transport := &qualifiedFunctionTestTransport{}
-	if _, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+	results, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
 		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCVitalsV1,
-	}); err != nil || transport.calls != 1 {
+	})
+	if err != nil || transport.calls != 1 {
 		t.Fatalf("qualified dispatch = %v, calls = %d", err, transport.calls)
+	}
+	if len(results) != 1 || len(results[0].Payload) != 0 || results[0].Replay == nil ||
+		results[0].Replay.Kind != string(TeslaFC100WCVitalsIntermediate) {
+		t.Fatalf("echo result = %#v", results)
 	}
 
 	blockedRegistry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
@@ -69,6 +74,34 @@ func TestTeslaFC100WCVitalsOperationIsExplicitlyVersionQualified(t *testing.T) {
 		Endpoint: "rtu-a", UnitID: withoutOperationVersion.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCVitalsV1,
 	}); err == nil || blockedTransport.calls != 0 {
 		t.Fatalf("unversioned dispatch = %v, calls = %d", err, blockedTransport.calls)
+	}
+}
+
+func TestTeslaFC100WCVitalsDispatchRetainsTerminalOnlyAsRedactedReplay(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+		WCVitalsOperationVersion: TeslaHSCWCVitalsCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x08, 0x32, 0x06, 0x12, 0x04, 0x0a, 0x02, 0x08, 0x01}}}
+	results, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCVitalsV1,
+	})
+	if err != nil || len(results) != 1 || len(results[0].Payload) != 0 || results[0].Replay == nil {
+		t.Fatalf("terminal dispatch = %#v, %v", results, err)
+	}
+	replay := results[0].Replay
+	if replay.Kind != string(TeslaFC100WCVitalsTerminal) || replay.PayloadLength != 2 ||
+		replay.PayloadDigest != "fb8da7eb5b1b399e7321179dac9e9f65773d7331e1e30554e3911e4325e1ef19" {
+		t.Fatalf("terminal replay = %#v", replay)
 	}
 }
 

--- a/tesla_fc100_wc_vitals_test.go
+++ b/tesla_fc100_wc_vitals_test.go
@@ -2,6 +2,7 @@ package modbusreg
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
@@ -9,11 +10,11 @@ import (
 
 func TestTeslaFC100WCVitalsOperationIsExplicitlyVersionQualified(t *testing.T) {
 	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
-		Enabled:                     true,
-		Node:                        0x10,
-		PassiveCompatible:           true,
-		CompatibilityVersion:        TeslaHSCCompatibilityV1,
-		WCVitalsOperationVersion:    TeslaHSCWCVitalsCompatibilityV1,
+		Enabled:                  true,
+		Node:                     0x10,
+		PassiveCompatible:        true,
+		CompatibilityVersion:     TeslaHSCCompatibilityV1,
+		WCVitalsOperationVersion: TeslaHSCWCVitalsCompatibilityV1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -43,6 +44,31 @@ func TestTeslaFC100WCVitalsOperationIsExplicitlyVersionQualified(t *testing.T) {
 	}
 	if _, _, err := withoutOperationVersion.EncodeQualifiedFunction(TeslaTEDAPIOperationWCVitalsV1); err == nil {
 		t.Fatal("unversioned profile encoded a vitals request")
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{}
+	if _, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCVitalsV1,
+	}); err != nil || transport.calls != 1 {
+		t.Fatalf("qualified dispatch = %v, calls = %d", err, transport.calls)
+	}
+
+	blockedRegistry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
+		Endpoint: "rtu-a", UnitID: withoutOperationVersion.Node(), VendorProfile: TeslaHSCProfileName, Codec: withoutOperationVersion,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockedTransport := &qualifiedFunctionTestTransport{}
+	if _, err := blockedRegistry.Dispatch(context.Background(), blockedTransport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: withoutOperationVersion.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCVitalsV1,
+	}); err == nil || blockedTransport.calls != 0 {
+		t.Fatalf("unversioned dispatch = %v, calls = %d", err, blockedTransport.calls)
 	}
 }
 

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -379,9 +379,13 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 		if function != teslaHSCFunction100 {
 			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
 		}
-		if _, err := DecodeTeslaFC100WCVitalsReplay(payload); err != nil {
+		replay, err := DecodeTeslaFC100WCVitalsReplay(payload)
+		if err != nil {
 			return QualifiedFunctionResult{}, err
 		}
+		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{
+			Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest,
+		}}, nil
 	}
 	response, err := DecodeTeslaHSCResponse(function, payload)
 	if err != nil {

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -8,8 +8,13 @@ import (
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
 )
 
-// TeslaHSCCompatibilityV1 is the initial public profile compatibility gate.
-const TeslaHSCCompatibilityV1 = "tesla_hsc_modbus_v1"
+const (
+	// TeslaHSCCompatibilityV1 is the initial public profile compatibility gate.
+	TeslaHSCCompatibilityV1 = "tesla_hsc_modbus_v1"
+	// TeslaHSCWCVitalsCompatibilityV1 is the exact operation contract gate for
+	// the bounded WC vitals snapshot. It is not a general firmware claim.
+	TeslaHSCWCVitalsCompatibilityV1 = "wc3_24_44_3"
+)
 
 // TeslaHSCProfileName identifies the profile only inside registry selection.
 const TeslaHSCProfileName = "tesla_hsc"
@@ -41,6 +46,9 @@ const (
 	// TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation denies a qualified
 	// profile until a later contract proves one particular operation safe.
 	TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation TeslaTEDAPIAdmissionState = "blocked_no_admissible_operation"
+	// TeslaTEDAPIAdmissionAllowedWCVitals admits only the explicit bounded WC
+	// vitals operation after all profile and operation gates pass.
+	TeslaTEDAPIAdmissionAllowedWCVitals TeslaTEDAPIAdmissionState = "allowed_wc_vitals"
 )
 
 // TeslaTEDAPIOperationAdmission is the redacted result of local admission
@@ -53,10 +61,11 @@ type TeslaTEDAPIOperationAdmission struct {
 // TeslaHSCProfileConfig is an explicit local flavor configuration. A matching
 // node or a readable frame is not a substitute for this configuration.
 type TeslaHSCProfileConfig struct {
-	Enabled              bool
-	Node                 byte
-	PassiveCompatible    bool
-	CompatibilityVersion string
+	Enabled                  bool
+	Node                     byte
+	PassiveCompatible        bool
+	CompatibilityVersion     string
+	WCVitalsOperationVersion string
 }
 
 // TeslaHSCProfile retains the immutable profile gate decision.
@@ -351,14 +360,29 @@ func NewTeslaHSCProvenance(
 
 // EncodeQualifiedFunction denies every outbound Tesla operation until a later
 // typed, proven read-only contract adds an explicit operation allowlist.
-func (TeslaHSCProfile) EncodeQualifiedFunction(string) (modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy, error) {
-	return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
+func (profile TeslaHSCProfile) EncodeQualifiedFunction(operation string) (modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy, error) {
+	if admission := profile.OperationAdmissionFor(operation); !admission.OutboundAllowed {
+		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
+	}
+	request, err := modbus.NewPrivateFunctionRequest(teslaHSCFunction100, teslaFC100WCVitalsRequestPDU)
+	if err != nil {
+		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, err
+	}
+	return request, modbus.DefaultPrivateFunctionResponsePolicy(), nil
 }
 
 // DecodeQualifiedFunction validates only the Tesla profile normal-response
 // contract. It is available to an already selected codec and does not itself
 // grant outbound admission.
-func (TeslaHSCProfile) DecodeQualifiedFunction(_ string, function modbus.PrivateFunctionCode, payload []byte) (QualifiedFunctionResult, error) {
+func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, function modbus.PrivateFunctionCode, payload []byte) (QualifiedFunctionResult, error) {
+	if operation == TeslaTEDAPIOperationWCVitalsV1 {
+		if function != teslaHSCFunction100 {
+			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
+		}
+		if _, err := DecodeTeslaFC100WCVitalsReplay(payload); err != nil {
+			return QualifiedFunctionResult{}, err
+		}
+	}
 	response, err := DecodeTeslaHSCResponse(function, payload)
 	if err != nil {
 		return QualifiedFunctionResult{}, err


### PR DESCRIPTION
Closes #138

Public RED: the exact version-qualified operation admission, byte-exact request codec and bounded redacted replay decoder are intentionally absent.

Scope excludes generic Modbus, gateway dispatch, hardware I/O, FC101/FC102 typing, and response-value projection.