### PR TITLE
Decode typed Growatt 1xSxxP BMS RS-485 status

### DIFF
--- a/growatt_bms_rs485_typed.go
+++ b/growatt_bms_rs485_typed.go
@@ -1,0 +1,117 @@
+package modbusreg
+
+import "fmt"
+
+type GrowattBMSOperatingState string
+
+const (
+	GrowattBMSStateSoftStarting GrowattBMSOperatingState = "soft_starting"
+	GrowattBMSStateStandby      GrowattBMSOperatingState = "standby"
+	GrowattBMSStateCharging     GrowattBMSOperatingState = "charging"
+	GrowattBMSStateDischarging  GrowattBMSOperatingState = "discharging"
+)
+
+// GrowattBMSTypedReadOnlyStatus is the bounded, observation-only projection
+// of the exact 1xSxxP ESS V2.02 four-slice input. All unlisted words remain
+// available only through the separate opaque read-only observation.
+type GrowattBMSTypedReadOnlyStatus struct {
+	Revision                    GrowattBMSRevisionTuple
+	MCUSoftwareVersion          string
+	GaugeVersion                string
+	BMSCompany                  uint8
+	BMSGeneration               uint8
+	PackCompany                 uint8
+	PackGeneration              uint8
+	OperatingState              GrowattBMSOperatingState
+	SOCPercent                  uint8
+	PackVoltageVolts            float64
+	PackCurrentAmps             float64
+	TemperatureCelsius          int16
+	RemainingCapacityAmpHours   float64
+	FullChargeCapacityAmpHours  float64
+	CycleCount                  uint16
+	ContinuousChargeSeconds     uint16
+	CurrentCycleChargeAmpHours  float64
+	AverageCellVoltageVolts     float64
+	FloatingPackVoltageVolts    float64
+	CumulativeChargeAmpHours    float64
+	CumulativeDischargeAmpHours float64
+}
+
+// OutboundAllowed is permanently false. Typed observation data cannot
+// authorize a BMS request or a control operation.
+func (GrowattBMSTypedReadOnlyStatus) OutboundAllowed() bool { return false }
+
+// DecodeGrowattBMSTypedReadOnlyStatus decodes only the field definitions
+// fixed by the exact Growatt BMS V2.02 contract. It has no transport or
+// detection behavior and returns no partial status on malformed input.
+func DecodeGrowattBMSTypedReadOnlyStatus(input GrowattBMSReadOnlyInput) (GrowattBMSTypedReadOnlyStatus, error) {
+	observation, err := DecodeGrowattBMSReadOnlyObservation(input)
+	if err != nil {
+		return GrowattBMSTypedReadOnlyStatus{}, err
+	}
+	wordsByOffset := make(map[uint16][]uint16, len(observation.Slices()))
+	for _, slice := range observation.Slices() {
+		wordsByOffset[slice.Offset] = slice.Words
+	}
+	identity := wordsByOffset[0x0001]
+	status := wordsByOffset[0x000d]
+	extension := wordsByOffset[0x0100]
+	if len(identity) != 7 || len(status) != 29 || len(extension) != 12 {
+		return GrowattBMSTypedReadOnlyStatus{}, fmt.Errorf("growatt BMS typed status slices are invalid")
+	}
+	stateWord, socWord, temperatureWord := status[6], status[8], status[11]
+	if stateWord>>8 != 0 || socWord>>8 != 0 || uint8(socWord) > 100 {
+		return GrowattBMSTypedReadOnlyStatus{}, fmt.Errorf("growatt BMS typed status byte encoding is invalid")
+	}
+	temperature := int16(temperatureWord)
+	if temperature < -127 || temperature > 127 {
+		return GrowattBMSTypedReadOnlyStatus{}, fmt.Errorf("growatt BMS typed temperature is invalid")
+	}
+	operatingState, ok := growattBMSOperatingState(uint8(stateWord))
+	if !ok {
+		return GrowattBMSTypedReadOnlyStatus{}, fmt.Errorf("growatt BMS typed operating state is invalid")
+	}
+	return GrowattBMSTypedReadOnlyStatus{
+		Revision:                    observation.Revision(),
+		MCUSoftwareVersion:          growattBMSByteVersion(identity[0]),
+		GaugeVersion:                growattBMSByteVersion(identity[1]),
+		BMSCompany:                  uint8(status[0]),
+		BMSGeneration:               uint8(status[0] >> 8),
+		PackCompany:                 uint8(status[1]),
+		PackGeneration:              uint8(status[1] >> 8),
+		OperatingState:              operatingState,
+		SOCPercent:                  uint8(socWord),
+		PackVoltageVolts:            float64(status[9]) / 100,
+		PackCurrentAmps:             float64(int16(status[10])) / 100,
+		TemperatureCelsius:          temperature,
+		RemainingCapacityAmpHours:   float64(status[13]) / 100,
+		FullChargeCapacityAmpHours:  float64(status[14]) / 100,
+		CycleCount:                  status[17],
+		ContinuousChargeSeconds:     extension[0],
+		CurrentCycleChargeAmpHours:  float64(extension[1]) / 10,
+		AverageCellVoltageVolts:     float64(extension[2]) / 1000,
+		FloatingPackVoltageVolts:    float64(extension[4]) / 10,
+		CumulativeChargeAmpHours:    float64(extension[5]) / 10,
+		CumulativeDischargeAmpHours: float64(extension[6]) / 10,
+	}, nil
+}
+
+func growattBMSByteVersion(word uint16) string {
+	return fmt.Sprintf("%d.%d", word>>8, uint8(word))
+}
+
+func growattBMSOperatingState(bits uint8) (GrowattBMSOperatingState, bool) {
+	switch bits & 0x03 {
+	case 0:
+		return GrowattBMSStateSoftStarting, true
+	case 1:
+		return GrowattBMSStateStandby, true
+	case 2:
+		return GrowattBMSStateCharging, true
+	case 3:
+		return GrowattBMSStateDischarging, true
+	default:
+		return "", false
+	}
+}

--- a/growatt_bms_rs485_typed_test.go
+++ b/growatt_bms_rs485_typed_test.go
@@ -1,0 +1,57 @@
+package modbusreg
+
+import "testing"
+
+func TestDecodeGrowattBMSTypedReadOnlyStatusProjectsOnlyExactV202Fields(t *testing.T) {
+	status, err := DecodeGrowattBMSTypedReadOnlyStatus(validGrowattBMSTypedReadOnlyInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.MCUSoftwareVersion != "1.2" || status.GaugeVersion != "3.4" ||
+		status.BMSCompany != 4 || status.BMSGeneration != 2 ||
+		status.PackCompany != 1 || status.PackGeneration != 3 ||
+		status.OperatingState != GrowattBMSStateCharging || status.SOCPercent != 75 ||
+		status.PackVoltageVolts != 52 || status.PackCurrentAmps != -1 ||
+		status.TemperatureCelsius != 25 || status.RemainingCapacityAmpHours != 32 ||
+		status.FullChargeCapacityAmpHours != 50 || status.CycleCount != 110 ||
+		status.ContinuousChargeSeconds != 100 || status.CurrentCycleChargeAmpHours != 12.3 ||
+		status.AverageCellVoltageVolts != 3.3 || status.FloatingPackVoltageVolts != 51.2 ||
+		status.CumulativeChargeAmpHours != 0.5 || status.CumulativeDischargeAmpHours != 0.6 ||
+		status.OutboundAllowed() {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestDecodeGrowattBMSTypedReadOnlyStatusRejectsInvalidTypedEncoding(t *testing.T) {
+	for name, mutate := range map[string]func(*GrowattBMSReadOnlyInput){
+		"status high byte": func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[6] = 0x0102 },
+		"status enum":      func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[6] = 0x0004 },
+		"SOC high byte":    func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[8] = 0x0101 },
+		"SOC range":        func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[8] = 101 },
+		"temperature":      func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[11] = 128 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := validGrowattBMSTypedReadOnlyInput()
+			mutate(&input)
+			if _, err := DecodeGrowattBMSTypedReadOnlyStatus(input); err == nil {
+				t.Fatal("accepted invalid typed encoding")
+			}
+		})
+	}
+}
+
+func validGrowattBMSTypedReadOnlyInput() GrowattBMSReadOnlyInput {
+	input := validGrowattBMSReadOnlyInput()
+	input.Slices[0].Words = []uint16{0x0102, 0x0304, 0, 0, 0, 0, 0}
+	input.Slices[1].Words = []uint16{
+		0x0204, 0x0301, 0, 0,
+		0, 0, 0x0002, 0,
+		75, 5200, 0xff9c, 25,
+		0, 3200, 5000, 0,
+		0, 110, 0, 0,
+		0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0,
+	}
+	input.Slices[2].Words = []uint16{100, 123, 3300, 0, 512, 5, 6, 0, 0, 0, 0, 0}
+	return input
+}

--- a/growatt_bms_rs485_typed_test.go
+++ b/growatt_bms_rs485_typed_test.go
@@ -25,7 +25,6 @@ func TestDecodeGrowattBMSTypedReadOnlyStatusProjectsOnlyExactV202Fields(t *testi
 func TestDecodeGrowattBMSTypedReadOnlyStatusRejectsInvalidTypedEncoding(t *testing.T) {
 	for name, mutate := range map[string]func(*GrowattBMSReadOnlyInput){
 		"status high byte": func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[6] = 0x0102 },
-		"status enum":      func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[6] = 0x0004 },
 		"SOC high byte":    func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[8] = 0x0101 },
 		"SOC range":        func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[8] = 101 },
 		"temperature":      func(input *GrowattBMSReadOnlyInput) { input.Slices[1].Words[11] = 128 },
@@ -49,7 +48,7 @@ func validGrowattBMSTypedReadOnlyInput() GrowattBMSReadOnlyInput {
 		75, 5200, 0xff9c, 25,
 		0, 3200, 5000, 0,
 		0, 110, 0, 0,
-		0, 0, 0, 0, 0,
+		0, 0, 0, 0,
 		0, 0, 0, 0, 0,
 	}
 	input.Slices[2].Words = []uint16{100, 123, 3300, 0, 512, 5, 6, 0, 0, 0, 0, 0}


### PR DESCRIPTION
## RED

Commit requires the absent typed decoder and its strict encoding rejection behavior.

## Scope

Caller-supplied exact revision tuple plus the four existing bounded FC03 slices only. No detector, catalog, transport, runtime admission, control, outbound path, or source endpoint.

## Docs gate

Companion docs PR #88 defines the public typed field contract. This PR will not merge before that gate.