### PR TITLE
REG-TESLA: construct bounded HSC request PDUs

### DIFF
--- a/tesla_hsc_request.go
+++ b/tesla_hsc_request.go
@@ -1,0 +1,46 @@
+package modbusreg
+
+import (
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// TeslaHSCSyntacticRequest is one bounded HSC request PDU. It is only a
+// syntax value: it carries no operation admission or transport authority.
+type TeslaHSCSyntacticRequest struct {
+	function modbus.PrivateFunctionCode
+	payload  []byte
+}
+
+// NewTeslaHSCSyntacticRequest constructs the exact-length L|nested request
+// PDU used by FC100, FC101, and FC102. It does not select an operation,
+// construct a generic transport request, or permit wire transmission.
+func NewTeslaHSCSyntacticRequest(
+	function modbus.PrivateFunctionCode,
+	nested []byte,
+) (TeslaHSCSyntacticRequest, error) {
+	if !isTeslaHSCFunction(function) {
+		return TeslaHSCSyntacticRequest{}, fmt.Errorf("tesla HSC function is unsupported")
+	}
+	if len(nested) >= maxTeslaHSCPayload {
+		return TeslaHSCSyntacticRequest{}, fmt.Errorf("tesla HSC nested payload exceeds bound")
+	}
+	payload := make([]byte, len(nested)+1)
+	payload[0] = byte(len(nested))
+	copy(payload[1:], nested)
+	if _, err := DecodeTeslaHSCRequestEnvelope(function, payload); err != nil {
+		return TeslaHSCSyntacticRequest{}, err
+	}
+	return TeslaHSCSyntacticRequest{function: function, payload: payload}, nil
+}
+
+// Function returns the vendor function selected for this syntactic PDU.
+func (request TeslaHSCSyntacticRequest) Function() modbus.PrivateFunctionCode {
+	return request.function
+}
+
+// Payload returns an independent copy of the exact-length L|nested PDU.
+func (request TeslaHSCSyntacticRequest) Payload() []byte {
+	return append([]byte(nil), request.payload...)
+}

--- a/tesla_hsc_request_test.go
+++ b/tesla_hsc_request_test.go
@@ -1,0 +1,75 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestNewTeslaHSCSyntacticRequestBuildsExactLengthEnvelope(t *testing.T) {
+	maximum := bytes.Repeat([]byte{0xa5}, maxTeslaHSCPayload-1)
+	for _, test := range []struct {
+		name     string
+		function modbus.PrivateFunctionCode
+		nested   []byte
+	}{
+		{name: "fc100_empty", function: teslaHSCFunction100},
+		{name: "fc101_nested", function: teslaHSCFunction101, nested: []byte{0x0a, 0x00}},
+		{name: "fc102_maximum", function: teslaHSCFunction102, nested: maximum},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			request, err := NewTeslaHSCSyntacticRequest(test.function, test.nested)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := request.Function(), test.function; got != want {
+				t.Fatalf("function = %d, want %d", got, want)
+			}
+			payload := request.Payload()
+			if got, want := len(payload), len(test.nested)+1; got != want {
+				t.Fatalf("payload length = %d, want %d", got, want)
+			}
+			if got, want := payload[0], byte(len(test.nested)); got != want {
+				t.Fatalf("length prefix = %d, want %d", got, want)
+			}
+			if got, want := payload[1:], test.nested; !bytes.Equal(got, want) {
+				t.Fatalf("nested payload = %x, want %x", got, want)
+			}
+			envelope, err := DecodeTeslaHSCRequestEnvelope(test.function, payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := envelope.Payload(), test.nested; !bytes.Equal(got, want) {
+				t.Fatalf("decoded nested payload = %x, want %x", got, want)
+			}
+		})
+	}
+}
+
+func TestNewTeslaHSCSyntacticRequestFailsClosedAndDoesNotAdmit(t *testing.T) {
+	if _, err := NewTeslaHSCSyntacticRequest(modbus.PrivateFunctionCode(99), nil); err == nil {
+		t.Fatal("unsupported function accepted")
+	}
+	if _, err := NewTeslaHSCSyntacticRequest(teslaHSCFunction101, make([]byte, maxTeslaHSCPayload)); err == nil {
+		t.Fatal("oversized nested payload accepted")
+	}
+
+	request, err := NewTeslaHSCSyntacticRequest(teslaHSCFunction101, []byte{0xff})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := request.Payload()
+	payload[0] = 0
+	if got, want := request.Payload(), []byte{1, 0xff}; !bytes.Equal(got, want) {
+		t.Fatalf("request payload was mutated through copy: %x", got)
+	}
+
+	profile := testTeslaDirectionalProfile(t)
+	if profile.OutboundAllowed() {
+		t.Fatal("syntactic request construction enabled outbound transport")
+	}
+	if _, _, err := profile.EncodeQualifiedFunction("tesla.hsc.fc101.syntactic.v1"); err == nil {
+		t.Fatal("syntactic request construction admitted an operation")
+	}
+}


### PR DESCRIPTION
Closes #142

Defines the RED contract for bounded syntactic `L|nested` request PDU construction across FC100–FC102. This node adds no transport exchange, operation admission, typed field decoding, or live I/O.