### PR TITLE
REG-TESLA: execute qualified WC vitals through injected exchange

### DIFF
--- a/tesla_fc100_wc_vitals_executor.go
+++ b/tesla_fc100_wc_vitals_executor.go
@@ -1,0 +1,57 @@
+package modbusreg
+
+import (
+	"context"
+	"fmt"
+)
+
+// TeslaFC100WCVitalsExecutor invokes the single qualified WC vitals operation
+// through an already-correlated RTU exchange boundary. It owns neither a
+// serial endpoint nor a general operation admission path.
+type TeslaFC100WCVitalsExecutor struct {
+	profile   TeslaHSCProfile
+	exchanger QualifiedFunctionExchanger
+}
+
+// NewTeslaFC100WCVitalsExecutor validates the exact version-qualified WC
+// vitals operation without invoking an exchange. An unqualified profile is
+// rejected before the injected exchange boundary can be called.
+func NewTeslaFC100WCVitalsExecutor(
+	profile TeslaHSCProfile,
+	exchanger QualifiedFunctionExchanger,
+) (*TeslaFC100WCVitalsExecutor, error) {
+	if exchanger == nil || !profile.OperationAdmissionFor(TeslaTEDAPIOperationWCVitalsV1).OutboundAllowed {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	return &TeslaFC100WCVitalsExecutor{profile: profile, exchanger: exchanger}, nil
+}
+
+// Execute constructs the fixed qualified FC100 request, invokes one injected
+// already-correlated RTU exchange, and returns only bounded redacted replays.
+// It does not open a serial endpoint, expose response bytes, or select any
+// fallback operation.
+func (executor *TeslaFC100WCVitalsExecutor) Execute(ctx context.Context) ([]TeslaFC100WCVitalsReplay, error) {
+	if executor == nil || ctx == nil || executor.exchanger == nil {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	request, policy, err := executor.profile.EncodeQualifiedFunction(TeslaTEDAPIOperationWCVitalsV1)
+	if err != nil {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	responses, err := executor.exchanger.Exchange(ctx, executor.profile.Node(), request, policy)
+	if err != nil {
+		return nil, err
+	}
+	if len(responses) == 0 || len(responses) > 8 {
+		return nil, fmt.Errorf("tesla WC vitals response count is invalid")
+	}
+	replays := make([]TeslaFC100WCVitalsReplay, 0, len(responses))
+	for _, response := range responses {
+		replay, err := DecodeTeslaFC100WCVitalsReplay(response.Payload())
+		if err != nil {
+			return nil, err
+		}
+		replays = append(replays, replay)
+	}
+	return replays, nil
+}

--- a/tesla_fc100_wc_vitals_executor_test.go
+++ b/tesla_fc100_wc_vitals_executor_test.go
@@ -1,0 +1,81 @@
+package modbusreg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestTeslaFC100WCVitalsExecutorUsesOneQualifiedInjectedExchange(t *testing.T) {
+	profile := testTeslaFC100WCVitalsQualifiedProfile(t)
+	exchanger := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{
+		{0x04, 0x32, 0x02, 0x0a, 0x00},
+		{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00},
+	}}
+	executor, err := NewTeslaFC100WCVitalsExecutor(profile, exchanger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replays, err := executor.Execute(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exchanger.calls != 1 || len(exchanger.requests) != 1 {
+		t.Fatalf("injected exchanges = %d, requests = %d", exchanger.calls, len(exchanger.requests))
+	}
+	request := exchanger.requests[0]
+	if got, want := request.FunctionCode(), teslaHSCFunction100; got != want {
+		t.Fatalf("request function = %d, want %d", got, want)
+	}
+	if got, want := request.Payload(), teslaFC100WCVitalsRequestPDU; !bytes.Equal(got, want) {
+		t.Fatalf("request payload = %x, want %x", got, want)
+	}
+	if len(replays) != 2 || replays[0].Kind != TeslaFC100WCVitalsIntermediate ||
+		replays[1].Kind != TeslaFC100WCVitalsTerminal ||
+		replays[1].SnapshotLength != 0 || replays[1].SnapshotDigest == "" {
+		t.Fatalf("redacted replays = %#v", replays)
+	}
+}
+
+func TestTeslaFC100WCVitalsExecutorFailsClosedBeforeOrAfterInjectedExchange(t *testing.T) {
+	unqualified, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockedExchanger := &qualifiedFunctionTestTransport{}
+	if _, err := NewTeslaFC100WCVitalsExecutor(unqualified, blockedExchanger); !errors.Is(err, ErrQualifiedFunctionNoSend) {
+		t.Fatalf("unqualified executor error = %v", err)
+	}
+	if blockedExchanger.calls != 0 {
+		t.Fatalf("unqualified executor exchanges = %d", blockedExchanger.calls)
+	}
+
+	profile := testTeslaFC100WCVitalsQualifiedProfile(t)
+	badExchanger := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x06, 0x32, 0x04, 0x12, 0x02, 0x12, 0x00}}}
+	executor, err := NewTeslaFC100WCVitalsExecutor(profile, badExchanger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replays, err := executor.Execute(context.Background()); err == nil || replays != nil {
+		t.Fatalf("malformed correlated response = %#v, %v", replays, err)
+	}
+	if badExchanger.calls != 1 {
+		t.Fatalf("malformed response exchanges = %d", badExchanger.calls)
+	}
+}
+
+func testTeslaFC100WCVitalsQualifiedProfile(t *testing.T) TeslaHSCProfile {
+	t.Helper()
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+		WCVitalsOperationVersion: TeslaHSCWCVitalsCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return profile
+}


### PR DESCRIPTION
Closes #144

Public RED for an explicit fake-only executor of the existing version-qualified WCAPIGetVitals operation. The executor may construct the fixed qualified FC100 request and invoke exactly one already-correlated injected RTU exchange, then returns only redacted replay metadata.

Excludes serial/config/lifecycle/discovery/retry, raw output, FC101/FC102 fallback, general admission, gateway, and real I/O. Existing docs #84 contract is unchanged.