### PR TITLE
REG-TESLA: adapt qualified WC vitals executor to RTU session

### DIFF
--- a/tesla_fc100_wc_vitals_rtu_session.go
+++ b/tesla_fc100_wc_vitals_rtu_session.go
@@ -1,0 +1,59 @@
+package modbusreg
+
+import (
+	"context"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// TeslaFC100WCVitalsRTUSession is the already-configured generic RTU session
+// boundary used by the WC vitals adapter. Its Exchange result has already
+// passed generic framing, CRC, unit, function, and exception correlation.
+type TeslaFC100WCVitalsRTUSession interface {
+	Exchange(context.Context, byte, modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy) ([]modbus.RTUPrivateFunctionResponseADU, error)
+}
+
+// TeslaFC100WCVitalsRTUSessionAdapter connects one generic RTU session to the
+// explicit qualified WC vitals executor. Its public execution result never
+// exposes request or response bytes.
+type TeslaFC100WCVitalsRTUSessionAdapter struct {
+	executor *TeslaFC100WCVitalsExecutor
+}
+
+// NewTeslaFC100WCVitalsRTUSessionAdapter validates the selected profile and
+// binds it to an injected RTU session without opening or configuring a port.
+func NewTeslaFC100WCVitalsRTUSessionAdapter(
+	profile TeslaHSCProfile,
+	session TeslaFC100WCVitalsRTUSession,
+) (*TeslaFC100WCVitalsRTUSessionAdapter, error) {
+	if session == nil {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	executor, err := NewTeslaFC100WCVitalsExecutor(profile, teslaFC100WCVitalsSessionExchanger{session: session})
+	if err != nil {
+		return nil, err
+	}
+	return &TeslaFC100WCVitalsRTUSessionAdapter{executor: executor}, nil
+}
+
+// Execute invokes the fixed qualified request through one generic correlated
+// RTU exchange and returns only existing bounded redacted replays.
+func (adapter *TeslaFC100WCVitalsRTUSessionAdapter) Execute(ctx context.Context) ([]TeslaFC100WCVitalsReplay, error) {
+	if adapter == nil || adapter.executor == nil {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	return adapter.executor.Execute(ctx)
+}
+
+type teslaFC100WCVitalsSessionExchanger struct {
+	session TeslaFC100WCVitalsRTUSession
+}
+
+func (exchanger teslaFC100WCVitalsSessionExchanger) Exchange(
+	ctx context.Context,
+	unitID byte,
+	request modbus.PrivateFunctionRequest,
+	policy modbus.PrivateFunctionResponsePolicy,
+) ([]modbus.RTUPrivateFunctionResponseADU, error) {
+	return exchanger.session.Exchange(ctx, unitID, request, policy)
+}

--- a/tesla_fc100_wc_vitals_rtu_session_test.go
+++ b/tesla_fc100_wc_vitals_rtu_session_test.go
@@ -1,0 +1,97 @@
+package modbusreg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaFC100WCVitalsRTUSessionAdapterUsesCorrelatedSession(t *testing.T) {
+	session := &teslaFC100WCVitalsSessionFake{responsePayloads: [][]byte{
+		{0x04, 0x32, 0x02, 0x0a, 0x00},
+		{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00},
+	}}
+	adapter, err := NewTeslaFC100WCVitalsRTUSessionAdapter(testTeslaFC100WCVitalsQualifiedProfile(t), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replays, err := adapter.Execute(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.calls != 1 || session.unitID != 0x10 {
+		t.Fatalf("session calls/unit = %d/%#x", session.calls, session.unitID)
+	}
+	if got, want := session.request.FunctionCode(), teslaHSCFunction100; got != want {
+		t.Fatalf("request function = %d, want %d", got, want)
+	}
+	if got, want := session.request.Payload(), teslaFC100WCVitalsRequestPDU; !bytes.Equal(got, want) {
+		t.Fatalf("request payload = %x, want %x", got, want)
+	}
+	if len(replays) != 2 || replays[0].Kind != TeslaFC100WCVitalsIntermediate ||
+		replays[1].Kind != TeslaFC100WCVitalsTerminal || replays[1].SnapshotDigest == "" {
+		t.Fatalf("redacted replays = %#v", replays)
+	}
+}
+
+func TestTeslaFC100WCVitalsRTUSessionAdapterPropagatesCorrelatedException(t *testing.T) {
+	correlatedException := errors.New("correlated exception")
+	session := &teslaFC100WCVitalsSessionFake{err: correlatedException}
+	adapter, err := NewTeslaFC100WCVitalsRTUSessionAdapter(testTeslaFC100WCVitalsQualifiedProfile(t), session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replays, err := adapter.Execute(context.Background()); !errors.Is(err, correlatedException) || replays != nil {
+		t.Fatalf("exception replays/error = %#v/%v", replays, err)
+	}
+	if session.calls != 1 {
+		t.Fatalf("session calls = %d", session.calls)
+	}
+
+	if _, err := NewTeslaFC100WCVitalsRTUSessionAdapter(testTeslaFC100WCVitalsQualifiedProfile(t), nil); !errors.Is(err, ErrQualifiedFunctionNoSend) {
+		t.Fatalf("nil session error = %v", err)
+	}
+}
+
+type teslaFC100WCVitalsSessionFake struct {
+	calls            int
+	unitID           byte
+	request          modbus.PrivateFunctionRequest
+	responsePayloads [][]byte
+	err              error
+}
+
+func (session *teslaFC100WCVitalsSessionFake) Exchange(
+	_ context.Context,
+	unitID byte,
+	request modbus.PrivateFunctionRequest,
+	_ modbus.PrivateFunctionResponsePolicy,
+) ([]modbus.RTUPrivateFunctionResponseADU, error) {
+	session.calls++
+	session.unitID = unitID
+	session.request = request
+	if session.err != nil {
+		return nil, session.err
+	}
+	responses := make([]modbus.RTUPrivateFunctionResponseADU, 0, len(session.responsePayloads))
+	for _, payload := range session.responsePayloads {
+		responseRequest, err := modbus.NewPrivateFunctionRequest(request.FunctionCode(), payload)
+		if err != nil {
+			return nil, err
+		}
+		frame, err := modbus.EncodeRTUPrivateFunctionADU(unitID, responseRequest)
+		if err != nil {
+			return nil, err
+		}
+		response, err := modbus.DecodeRTUPrivateFunctionResponseADU(unitID, request, frame)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, response)
+	}
+	return responses, nil
+}


### PR DESCRIPTION
Closes #146

Public RED for a Tesla-specific adapter from an already-configured, already-correlated generic RTU session to the merged qualified WCAPIGetVitals executor.

Tests use only a fake session and require exact FC100/unit/correlation, redacted replays, and direct exception propagation. No serial backend, config/lifecycle/retry/discovery, public raw response, FC101/102, gateway, or hardware I/O.