### PR TITLE
REG-TESLA: retain WC vitals terminal body opaquely

### DIFF
--- a/tesla_fc100_wc_vitals.go
+++ b/tesla_fc100_wc_vitals.go
@@ -22,8 +22,8 @@ const (
 	TeslaFC100WCVitalsTerminal     TeslaFC100WCVitalsReplayKind = "terminal"
 )
 
-// TeslaFC100WCVitalsReplay is a bounded redacted result of the typed response
-// container decoder. Snapshot values and raw bytes are intentionally omitted.
+// TeslaFC100WCVitalsReplay is a bounded redacted result of the terminal-body
+// decoder. Snapshot values and raw bytes are intentionally omitted.
 type TeslaFC100WCVitalsReplay struct {
 	Kind           TeslaFC100WCVitalsReplayKind
 	SnapshotLength int
@@ -66,14 +66,10 @@ func DecodeTeslaFC100WCVitalsReplay(payload []byte) (TeslaFC100WCVitalsReplay, e
 	if err != nil {
 		return TeslaFC100WCVitalsReplay{}, fmt.Errorf("tesla WC vitals message: %w", err)
 	}
-	vitals, err := decodeExactLengthDelimitedField(vitalsResponse, 1)
-	if err != nil {
-		return TeslaFC100WCVitalsReplay{}, fmt.Errorf("tesla WC vitals response: %w", err)
-	}
-	digest := sha256.Sum256(vitals)
+	digest := sha256.Sum256(vitalsResponse)
 	return TeslaFC100WCVitalsReplay{
 		Kind:           TeslaFC100WCVitalsTerminal,
-		SnapshotLength: len(vitals),
+		SnapshotLength: len(vitalsResponse),
 		SnapshotDigest: hex.EncodeToString(digest[:]),
 	}, nil
 }

--- a/tesla_fc100_wc_vitals_executor_test.go
+++ b/tesla_fc100_wc_vitals_executor_test.go
@@ -11,7 +11,7 @@ func TestTeslaFC100WCVitalsExecutorUsesOneQualifiedInjectedExchange(t *testing.T
 	profile := testTeslaFC100WCVitalsQualifiedProfile(t)
 	exchanger := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{
 		{0x04, 0x32, 0x02, 0x0a, 0x00},
-		{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00},
+		{0x06, 0x32, 0x04, 0x12, 0x02, 0x08, 0x01},
 	}}
 	executor, err := NewTeslaFC100WCVitalsExecutor(profile, exchanger)
 	if err != nil {
@@ -34,7 +34,7 @@ func TestTeslaFC100WCVitalsExecutorUsesOneQualifiedInjectedExchange(t *testing.T
 	}
 	if len(replays) != 2 || replays[0].Kind != TeslaFC100WCVitalsIntermediate ||
 		replays[1].Kind != TeslaFC100WCVitalsTerminal ||
-		replays[1].SnapshotLength != 0 || replays[1].SnapshotDigest == "" {
+		replays[1].SnapshotLength != 2 || replays[1].SnapshotDigest == "" {
 		t.Fatalf("redacted replays = %#v", replays)
 	}
 }
@@ -55,7 +55,7 @@ func TestTeslaFC100WCVitalsExecutorFailsClosedBeforeOrAfterInjectedExchange(t *t
 	}
 
 	profile := testTeslaFC100WCVitalsQualifiedProfile(t)
-	badExchanger := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x06, 0x32, 0x04, 0x12, 0x02, 0x12, 0x00}}}
+	badExchanger := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x06, 0x32, 0x04, 0x0a, 0x02, 0x12, 0x00}}}
 	executor, err := NewTeslaFC100WCVitalsExecutor(profile, badExchanger)
 	if err != nil {
 		t.Fatal(err)

--- a/tesla_fc100_wc_vitals_rtu_session_test.go
+++ b/tesla_fc100_wc_vitals_rtu_session_test.go
@@ -12,7 +12,7 @@ import (
 func TestTeslaFC100WCVitalsRTUSessionAdapterUsesCorrelatedSession(t *testing.T) {
 	session := &teslaFC100WCVitalsSessionFake{responsePayloads: [][]byte{
 		{0x04, 0x32, 0x02, 0x0a, 0x00},
-		{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00},
+		{0x06, 0x32, 0x04, 0x12, 0x02, 0x08, 0x01},
 	}}
 	adapter, err := NewTeslaFC100WCVitalsRTUSessionAdapter(testTeslaFC100WCVitalsQualifiedProfile(t), session)
 	if err != nil {

--- a/tesla_fc100_wc_vitals_test.go
+++ b/tesla_fc100_wc_vitals_test.go
@@ -93,7 +93,7 @@ func TestTeslaFC100WCVitalsDispatchRetainsTerminalOnlyAsRedactedReplay(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	transport := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x08, 0x32, 0x06, 0x12, 0x04, 0x0a, 0x02, 0x08, 0x01}}}
+	transport := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x06, 0x32, 0x04, 0x12, 0x02, 0x08, 0x01}}}
 	results, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
 		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCVitalsV1,
 	})
@@ -116,7 +116,7 @@ func TestTeslaFC100WCVitalsReplayClassifiesEchoAndBoundedTerminal(t *testing.T) 
 		t.Fatalf("echo = %#v", echo)
 	}
 
-	terminal, err := DecodeTeslaFC100WCVitalsReplay([]byte{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00})
+	terminal, err := DecodeTeslaFC100WCVitalsReplay([]byte{0x04, 0x32, 0x02, 0x12, 0x00})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func TestTeslaFC100WCVitalsReplayClassifiesEchoAndBoundedTerminal(t *testing.T) 
 	}
 
 	for _, payload := range [][]byte{
-		{0x06, 0x32, 0x04, 0x12, 0x02, 0x12, 0x00},
+		{0x06, 0x32, 0x04, 0x0a, 0x02, 0x12, 0x00},
 		{0x07, 0x32, 0x04, 0x12, 0x02, 0x0a, 0x00, 0x00},
 		{0x06, 0x32, 0x04, 0x12, 0x02, 0x0a},
 	} {

--- a/tesla_fc100_wc_vitals_test.go
+++ b/tesla_fc100_wc_vitals_test.go
@@ -3,6 +3,8 @@ package modbusreg
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
@@ -130,6 +132,21 @@ func TestTeslaFC100WCVitalsReplayClassifiesEchoAndBoundedTerminal(t *testing.T) 
 	} {
 		if _, err := DecodeTeslaFC100WCVitalsReplay(payload); err == nil {
 			t.Fatalf("malformed terminal accepted: %x", payload)
+		}
+	}
+}
+
+func TestTeslaFC100WCVitalsReplayRetainsCompleteOpaqueTerminalBody(t *testing.T) {
+	for _, body := range [][]byte{{0x08, 0x01}, {0x00, 0x00}} {
+		payload := append([]byte{byte(len(body) + 4), 0x32, byte(len(body) + 2), 0x12, byte(len(body))}, body...)
+		replay, err := DecodeTeslaFC100WCVitalsReplay(payload)
+		if err != nil {
+			t.Fatalf("opaque terminal body %x: %v", body, err)
+		}
+		digest := sha256.Sum256(body)
+		if replay.Kind != TeslaFC100WCVitalsTerminal || replay.SnapshotLength != len(body) ||
+			replay.SnapshotDigest != hex.EncodeToString(digest[:]) {
+			t.Fatalf("opaque terminal body %x replay = %#v", body, replay)
 		}
 	}
 }


### PR DESCRIPTION
Closes #148

Public RED: a qualified FC100 terminal body is currently assumed to contain an inner member. This change requires the existing replay to retain the complete bounded family-6/tag-2 body as length and digest only.

Docs PR #90 is the merge dependency. Scope preserves operation/version gates, request, executor/session adapter and FC101/102; no raw output, generic transport, gateway, or hardware I/O.