### PR TITLE
REG-GROWATT: add bounded BMS RS-485 RTU observer

### DIFF
--- a/growatt_bms_rs485_rtu_observer.go
+++ b/growatt_bms_rs485_rtu_observer.go
@@ -1,0 +1,84 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+var ErrGrowattBMSRS485RTUObserverInvalid = errors.New("growatt BMS RTU observer is invalid")
+
+// GrowattBMSRS485RTUObserverSession is an already configured, generic RTU
+// read boundary. It owns framing, CRC, response correlation, deadlines, and
+// serialization without carrying Growatt-specific semantics.
+type GrowattBMSRS485RTUObserverSession interface {
+	ReadHolding(context.Context, byte, modbus.ReadRegistersRequest) (modbus.ReadRegistersResponse, error)
+}
+
+// GrowattBMSRS485RTUObserver performs the four fixed, read-only FC03 slices
+// for one caller-selected BMS revision and unicast unit. It owns neither
+// discovery, retries, session configuration, nor publication.
+type GrowattBMSRS485RTUObserver struct {
+	revision GrowattBMSRevisionTuple
+	unitID   byte
+	session  GrowattBMSRS485RTUObserverSession
+}
+
+// NewGrowattBMSRS485RTUObserver validates the exact caller-selected tuple and
+// binds it to a generic correlated RTU read session without opening a device.
+func NewGrowattBMSRS485RTUObserver(
+	revision GrowattBMSRevisionTuple,
+	unitID byte,
+	session GrowattBMSRS485RTUObserverSession,
+) (*GrowattBMSRS485RTUObserver, error) {
+	if session == nil || unitID == 0 || unitID > 247 ||
+		revision != (GrowattBMSRevisionTuple{
+			Family: growattBMSFamily, FileRevision: growattBMSFileRevision,
+			HeaderVersion: growattBMSHeaderVersion, CumulativeRevision: growattBMSCumulativeRevision,
+		}) {
+		return nil, ErrGrowattBMSRS485RTUObserverInvalid
+	}
+	return &GrowattBMSRS485RTUObserver{revision: revision, unitID: unitID, session: session}, nil
+}
+
+// Observe executes the exact contract slices in order and decodes them only
+// after every generic exchange is correlated and complete.
+func (observer *GrowattBMSRS485RTUObserver) Observe(ctx context.Context) (GrowattBMSTypedReadOnlyStatus, error) {
+	if observer == nil || observer.session == nil || ctx == nil {
+		return GrowattBMSTypedReadOnlyStatus{}, ErrGrowattBMSRS485RTUObserverInvalid
+	}
+	requests := [...]struct {
+		offset   uint16
+		quantity uint16
+	}{
+		{offset: 0x0001, quantity: 7},
+		{offset: 0x000d, quantity: 29},
+		{offset: 0x0100, quantity: 12},
+		{offset: 0x010d, quantity: 2},
+	}
+	slices := make([]GrowattBMSReadOnlySlice, 0, len(requests))
+	for _, spec := range requests {
+		request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, spec.offset, spec.quantity)
+		if err != nil {
+			return GrowattBMSTypedReadOnlyStatus{}, fmt.Errorf("growatt BMS RTU request: %w", err)
+		}
+		response, err := observer.session.ReadHolding(ctx, observer.unitID, request)
+		if err != nil {
+			return GrowattBMSTypedReadOnlyStatus{}, err
+		}
+		if response.Provenance != (modbus.ReadProvenance{
+			Function: modbus.FunctionReadHoldingRegisters,
+			Table:    modbus.HoldingRegisters,
+			Offset:   spec.offset,
+			Quantity: spec.quantity,
+		}) || len(response.Words) != int(spec.quantity) {
+			return GrowattBMSTypedReadOnlyStatus{}, ErrGrowattBMSRS485RTUObserverInvalid
+		}
+		slices = append(slices, GrowattBMSReadOnlySlice{Offset: spec.offset, Words: append([]uint16(nil), response.Words...)})
+	}
+	return DecodeGrowattBMSTypedReadOnlyStatus(GrowattBMSReadOnlyInput{
+		UnitID: observer.unitID, Function: FunctionReadHoldingRegisters, Revision: observer.revision, Slices: slices,
+	})
+}

--- a/growatt_bms_rs485_rtu_observer_test.go
+++ b/growatt_bms_rs485_rtu_observer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGrowattBMSRS485RTUObserverReadsExactSlicesInOrder(t *testing.T) {
-	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords()}
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: -1, mismatchAt: -1}
 	observer, err := NewGrowattBMSRS485RTUObserver(
 		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
 		7,
@@ -33,6 +33,9 @@ func TestGrowattBMSRS485RTUObserverReadsExactSlicesInOrder(t *testing.T) {
 			if got[index] != want[index] {
 				t.Fatalf("calls=%#v", got)
 			}
+			if session.functions[index] != modbus.FunctionReadHoldingRegisters {
+				t.Fatalf("functions=%#v", session.functions)
+			}
 		}
 	}
 	if session.unitID != 7 {
@@ -41,7 +44,7 @@ func TestGrowattBMSRS485RTUObserverReadsExactSlicesInOrder(t *testing.T) {
 }
 
 func TestGrowattBMSRS485RTUObserverStopsWithoutPartialStatus(t *testing.T) {
-	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: 1}
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: 1, mismatchAt: -1}
 	observer, err := NewGrowattBMSRS485RTUObserver(
 		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
 		7,
@@ -58,7 +61,7 @@ func TestGrowattBMSRS485RTUObserverStopsWithoutPartialStatus(t *testing.T) {
 }
 
 func TestGrowattBMSRS485RTUObserverRejectsMismatchedResponse(t *testing.T) {
-	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), mismatchAt: 2}
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: -1, mismatchAt: 2}
 	observer, err := NewGrowattBMSRS485RTUObserver(
 		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
 		7,
@@ -75,7 +78,7 @@ func TestGrowattBMSRS485RTUObserverRejectsMismatchedResponse(t *testing.T) {
 }
 
 func TestGrowattBMSRS485RTUObserverRejectsInvalidCallerSelectionBeforeRead(t *testing.T) {
-	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords()}
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: -1, mismatchAt: -1}
 	if observer, err := NewGrowattBMSRS485RTUObserver(GrowattBMSRevisionTuple{}, 0, session); err == nil || observer != nil || len(session.calls) != 0 {
 		t.Fatalf("observer/error/calls=%#v/%v/%#v", observer, err, session.calls)
 	}
@@ -84,6 +87,7 @@ func TestGrowattBMSRS485RTUObserverRejectsInvalidCallerSelectionBeforeRead(t *te
 type growattBMSRTUSessionFake struct {
 	wordsByOffset map[uint16][]uint16
 	calls         [][2]uint16
+	functions     []modbus.FunctionCode
 	unitID        byte
 	failAt        int
 	mismatchAt    int
@@ -96,6 +100,7 @@ func (session *growattBMSRTUSessionFake) ReadHolding(
 ) (modbus.ReadRegistersResponse, error) {
 	session.unitID = unitID
 	session.calls = append(session.calls, [2]uint16{request.Offset(), request.Quantity()})
+	session.functions = append(session.functions, request.Function())
 	index := len(session.calls) - 1
 	if index == session.failAt {
 		return modbus.ReadRegistersResponse{}, errors.New("correlated read failed")

--- a/growatt_bms_rs485_rtu_observer_test.go
+++ b/growatt_bms_rs485_rtu_observer_test.go
@@ -1,0 +1,134 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestGrowattBMSRS485RTUObserverReadsExactSlicesInOrder(t *testing.T) {
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords()}
+	observer, err := NewGrowattBMSRS485RTUObserver(
+		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
+		7,
+		session,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := observer.Observe(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.SOCPercent != 75 || status.OperatingState != GrowattBMSStateCharging || status.OutboundAllowed() {
+		t.Fatalf("status=%#v", status)
+	}
+	if got, want := session.calls, [][2]uint16{{0x0001, 7}, {0x000d, 29}, {0x0100, 12}, {0x010d, 2}}; len(got) != len(want) {
+		t.Fatalf("calls=%#v", got)
+	} else {
+		for index := range want {
+			if got[index] != want[index] {
+				t.Fatalf("calls=%#v", got)
+			}
+		}
+	}
+	if session.unitID != 7 {
+		t.Fatalf("unit_id=%d", session.unitID)
+	}
+}
+
+func TestGrowattBMSRS485RTUObserverStopsWithoutPartialStatus(t *testing.T) {
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: 1}
+	observer, err := NewGrowattBMSRS485RTUObserver(
+		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
+		7,
+		session,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := observer.Observe(context.Background())
+	if err == nil || status != (GrowattBMSTypedReadOnlyStatus{}) || len(session.calls) != 2 {
+		t.Fatalf("status/error/calls=%#v/%v/%#v", status, err, session.calls)
+	}
+}
+
+func TestGrowattBMSRS485RTUObserverRejectsMismatchedResponse(t *testing.T) {
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), mismatchAt: 2}
+	observer, err := NewGrowattBMSRS485RTUObserver(
+		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
+		7,
+		session,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := observer.Observe(context.Background())
+	if err == nil || status != (GrowattBMSTypedReadOnlyStatus{}) || len(session.calls) != 3 {
+		t.Fatalf("status/error/calls=%#v/%v/%#v", status, err, session.calls)
+	}
+}
+
+func TestGrowattBMSRS485RTUObserverRejectsInvalidCallerSelectionBeforeRead(t *testing.T) {
+	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords()}
+	if observer, err := NewGrowattBMSRS485RTUObserver(GrowattBMSRevisionTuple{}, 0, session); err == nil || observer != nil || len(session.calls) != 0 {
+		t.Fatalf("observer/error/calls=%#v/%v/%#v", observer, err, session.calls)
+	}
+}
+
+type growattBMSRTUSessionFake struct {
+	wordsByOffset map[uint16][]uint16
+	calls         [][2]uint16
+	unitID        byte
+	failAt        int
+	mismatchAt    int
+}
+
+func (session *growattBMSRTUSessionFake) ReadHolding(
+	_ context.Context,
+	unitID byte,
+	request modbus.ReadRegistersRequest,
+) (modbus.ReadRegistersResponse, error) {
+	session.unitID = unitID
+	session.calls = append(session.calls, [2]uint16{request.Offset(), request.Quantity()})
+	index := len(session.calls) - 1
+	if index == session.failAt {
+		return modbus.ReadRegistersResponse{}, errors.New("correlated read failed")
+	}
+	words := session.wordsByOffset[request.Offset()]
+	response, err := modbus.DecodeReadRegistersResponse(request, growattBMSRTUReadPDU(words))
+	if err != nil {
+		return modbus.ReadRegistersResponse{}, err
+	}
+	if index == session.mismatchAt {
+		response.Provenance.Offset++
+	}
+	return response, nil
+}
+
+func growattBMSRTUReadPDU(words []uint16) []byte {
+	pdu := make([]byte, 2+len(words)*2)
+	pdu[0] = byte(modbus.FunctionReadHoldingRegisters)
+	pdu[1] = byte(len(words) * 2)
+	for index, word := range words {
+		pdu[2+index*2], pdu[3+index*2] = byte(word>>8), byte(word)
+	}
+	return pdu
+}
+
+func growattBMSRTUFixtureWords() map[uint16][]uint16 {
+	identity := make([]uint16, 7)
+	identity[0], identity[1] = 0x0102, 0x0304
+	status := make([]uint16, 29)
+	status[0], status[1] = 0x0204, 0x0301
+	status[6], status[8], status[9], status[10], status[11] = 2, 75, 5200, 0xff9c, 25
+	status[13], status[14], status[17] = 3200, 5000, 110
+	extension := make([]uint16, 12)
+	extension[0], extension[1], extension[2], extension[4], extension[5], extension[6] = 100, 123, 3300, 512, 5, 6
+	return map[uint16][]uint16{0x0001: identity, 0x000d: status, 0x0100: extension, 0x010d: {0, 0}}
+}

--- a/growatt_bms_rs485_rtu_observer_test.go
+++ b/growatt_bms_rs485_rtu_observer_test.go
@@ -77,6 +77,25 @@ func TestGrowattBMSRS485RTUObserverRejectsMismatchedResponse(t *testing.T) {
 	}
 }
 
+func TestGrowattBMSRS485RTUObserverRejectsShortFC03Response(t *testing.T) {
+	words := growattBMSRTUFixtureWords()
+	words[0x0100] = words[0x0100][:11]
+	session := &growattBMSRTUSessionFake{wordsByOffset: words, failAt: -1, mismatchAt: -1}
+	observer, err := NewGrowattBMSRS485RTUObserver(
+		GrowattBMSRevisionTuple{Family: "1xSxxP ESS", FileRevision: "Rev2.01", HeaderVersion: "V2.0", CumulativeRevision: "2.02"},
+		7,
+		session,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := observer.Observe(context.Background())
+	if err == nil || status != (GrowattBMSTypedReadOnlyStatus{}) || len(session.calls) != 3 {
+		t.Fatalf("status/error/calls=%#v/%v/%#v", status, err, session.calls)
+	}
+}
+
 func TestGrowattBMSRS485RTUObserverRejectsInvalidCallerSelectionBeforeRead(t *testing.T) {
 	session := &growattBMSRTUSessionFake{wordsByOffset: growattBMSRTUFixtureWords(), failAt: -1, mismatchAt: -1}
 	if observer, err := NewGrowattBMSRS485RTUObserver(GrowattBMSRevisionTuple{}, 0, session); err == nil || observer != nil || len(session.calls) != 0 {


### PR DESCRIPTION
RED-first contract for an injected, generic correlated RTU read session. It requires four fixed FC03 reads and no partial result. No transport, discovery, retry, control, raw API, or live I/O scope.