### PR TITLE
REG-TESLA: qualify FC100 Common system information

### DIFF
--- a/tesla_fc100_common_system_info.go
+++ b/tesla_fc100_common_system_info.go
@@ -1,0 +1,59 @@
+package modbusreg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// TeslaTEDAPIOperationCommonSystemInfoV1 identifies the explicitly qualified
+// FC100 Common system-information operation in this compatibility contract.
+const TeslaTEDAPIOperationCommonSystemInfoV1 = "tesla.hsc.fc100.common_system_info.v1"
+
+var teslaFC100CommonSystemInfoRequestPDU = []byte{0x04, 0x22, 0x02, 0x12, 0x00}
+
+// TeslaFC100CommonSystemInfoReplayKind distinguishes an echoed FC100
+// intermediate from the bounded opaque terminal body.
+type TeslaFC100CommonSystemInfoReplayKind string
+
+const (
+	TeslaFC100CommonSystemInfoIntermediate TeslaFC100CommonSystemInfoReplayKind = "intermediate"
+	TeslaFC100CommonSystemInfoTerminal     TeslaFC100CommonSystemInfoReplayKind = "terminal"
+)
+
+// TeslaFC100CommonSystemInfoReplay is a redacted replay result. It never
+// contains terminal-body bytes or field-level system-information semantics.
+type TeslaFC100CommonSystemInfoReplay struct {
+	Kind           TeslaFC100CommonSystemInfoReplayKind
+	SnapshotLength int
+	SnapshotDigest string
+}
+
+// DecodeTeslaFC100CommonSystemInfoReplay accepts only the exact FC100 echo or
+// one bounded Common family-4/tag-3 terminal. Terminal content remains opaque.
+func DecodeTeslaFC100CommonSystemInfoReplay(payload []byte) (TeslaFC100CommonSystemInfoReplay, error) {
+	response, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
+	if err != nil {
+		return TeslaFC100CommonSystemInfoReplay{}, err
+	}
+	message := response.Payload()
+	requestMessage := teslaFC100CommonSystemInfoRequestPDU[1:]
+	if bytes.Equal(message, requestMessage) {
+		return TeslaFC100CommonSystemInfoReplay{Kind: TeslaFC100CommonSystemInfoIntermediate}, nil
+	}
+	commonMessages, err := decodeExactLengthDelimitedField(message, 4)
+	if err != nil {
+		return TeslaFC100CommonSystemInfoReplay{}, fmt.Errorf("tesla Common system-information envelope: %w", err)
+	}
+	systemInfoResponse, err := decodeExactLengthDelimitedField(commonMessages, 3)
+	if err != nil {
+		return TeslaFC100CommonSystemInfoReplay{}, fmt.Errorf("tesla Common system-information message: %w", err)
+	}
+	digest := sha256.Sum256(systemInfoResponse)
+	return TeslaFC100CommonSystemInfoReplay{
+		Kind:           TeslaFC100CommonSystemInfoTerminal,
+		SnapshotLength: len(systemInfoResponse),
+		SnapshotDigest: hex.EncodeToString(digest[:]),
+	}, nil
+}

--- a/tesla_fc100_common_system_info_test.go
+++ b/tesla_fc100_common_system_info_test.go
@@ -1,0 +1,104 @@
+package modbusreg
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaFC100CommonSystemInfoIsExplicitlyVersionQualified(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled:                    true,
+		Node:                       0x10,
+		PassiveCompatible:          true,
+		CompatibilityVersion:       TeslaHSCCompatibilityV1,
+		SystemInfoOperationVersion: TeslaHSCSystemInfoCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	admission := profile.OperationAdmissionFor(TeslaTEDAPIOperationCommonSystemInfoV1)
+	if !admission.OutboundAllowed || admission.State != TeslaTEDAPIAdmissionAllowedCommonSystemInfo {
+		t.Fatalf("admission = %#v", admission)
+	}
+	request, policy, err := profile.EncodeQualifiedFunction(TeslaTEDAPIOperationCommonSystemInfoV1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.FunctionCode() != modbus.PrivateFunctionCode(100) ||
+		!bytes.Equal(request.Payload(), []byte{0x04, 0x22, 0x02, 0x12, 0x00}) ||
+		policy.MaxAttempts() != 1 {
+		t.Fatalf("request/policy = %#v/%#v", request, policy)
+	}
+
+	withoutOperationVersion, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
+		Endpoint: "rtu-a", UnitID: withoutOperationVersion.Node(), VendorProfile: TeslaHSCProfileName, Codec: withoutOperationVersion,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: withoutOperationVersion.Node(), VendorProfile: TeslaHSCProfileName,
+		Operation: TeslaTEDAPIOperationCommonSystemInfoV1,
+	}); err == nil || transport.calls != 0 {
+		t.Fatalf("unversioned dispatch = %v, calls = %d", err, transport.calls)
+	}
+}
+
+func TestTeslaFC100CommonSystemInfoRetainsTerminalOnlyAsRedactedReplay(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+		SystemInfoOperationVersion: TeslaHSCSystemInfoCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x06, 0x22, 0x04, 0x1a, 0x02, 0x08, 0x01}}}
+	results, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName,
+		Operation: TeslaTEDAPIOperationCommonSystemInfoV1,
+	})
+	if err != nil || transport.calls != 1 || len(results) != 1 || len(results[0].Payload) != 0 || results[0].Replay == nil {
+		t.Fatalf("terminal dispatch = %#v, %v, calls = %d", results, err, transport.calls)
+	}
+	replay := results[0].Replay
+	if replay.Kind != string(TeslaFC100CommonSystemInfoTerminal) || replay.PayloadLength != 2 ||
+		replay.PayloadDigest != "fb8da7eb5b1b399e7321179dac9e9f65773d7331e1e30554e3911e4325e1ef19" {
+		t.Fatalf("terminal replay = %#v", replay)
+	}
+}
+
+func TestTeslaFC100CommonSystemInfoClassifiesExactEchoAndRejectsMalformedTerminal(t *testing.T) {
+	echo, err := DecodeTeslaFC100CommonSystemInfoReplay([]byte{0x04, 0x22, 0x02, 0x12, 0x00})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if echo.Kind != TeslaFC100CommonSystemInfoIntermediate || echo.SnapshotLength != 0 || echo.SnapshotDigest != "" {
+		t.Fatalf("echo = %#v", echo)
+	}
+
+	for _, payload := range [][]byte{
+		{0x06, 0x22, 0x04, 0x12, 0x02, 0x08, 0x01},
+		{0x07, 0x22, 0x04, 0x1a, 0x02, 0x08, 0x01, 0x00},
+		{0x06, 0x22, 0x04, 0x1a, 0x02, 0x08},
+	} {
+		if _, err := DecodeTeslaFC100CommonSystemInfoReplay(payload); err == nil {
+			t.Fatalf("malformed terminal accepted: %x", payload)
+		}
+	}
+}

--- a/tesla_fc100_wc_vitals.go
+++ b/tesla_fc100_wc_vitals.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 )
 
-// TeslaTEDAPIOperationWCVitalsV1 identifies the only explicitly qualified
-// FC100 operation in this compatibility contract.
+// TeslaTEDAPIOperationWCVitalsV1 identifies the explicitly qualified FC100
+// WC vitals operation in this compatibility contract.
 const TeslaTEDAPIOperationWCVitalsV1 = "tesla.hsc.fc100.wc_vitals.v1"
 
 var teslaFC100WCVitalsRequestPDU = []byte{0x04, 0x32, 0x02, 0x0a, 0x00}
@@ -36,14 +36,23 @@ func (profile TeslaHSCProfile) OperationAdmissionFor(operation string) TeslaTEDA
 	if profile.Disposition() != TeslaHSCQualifiedReadOnly {
 		return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedProfile}
 	}
-	if operation != TeslaTEDAPIOperationWCVitalsV1 ||
-		profile.config.WCVitalsOperationVersion != TeslaHSCWCVitalsCompatibilityV1 {
-		return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation}
+	switch operation {
+	case TeslaTEDAPIOperationWCVitalsV1:
+		if profile.config.WCVitalsOperationVersion == TeslaHSCWCVitalsCompatibilityV1 {
+			return TeslaTEDAPIOperationAdmission{
+				State:           TeslaTEDAPIAdmissionAllowedWCVitals,
+				OutboundAllowed: true,
+			}
+		}
+	case TeslaTEDAPIOperationCommonSystemInfoV1:
+		if profile.config.SystemInfoOperationVersion == TeslaHSCSystemInfoCompatibilityV1 {
+			return TeslaTEDAPIOperationAdmission{
+				State:           TeslaTEDAPIAdmissionAllowedCommonSystemInfo,
+				OutboundAllowed: true,
+			}
+		}
 	}
-	return TeslaTEDAPIOperationAdmission{
-		State:           TeslaTEDAPIAdmissionAllowedWCVitals,
-		OutboundAllowed: true,
-	}
+	return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation}
 }
 
 // DecodeTeslaFC100WCVitalsReplay decodes the exact FC100 WC vitals operation

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -14,6 +14,9 @@ const (
 	// TeslaHSCWCVitalsCompatibilityV1 is the exact operation contract gate for
 	// the bounded WC vitals snapshot. It is not a general firmware claim.
 	TeslaHSCWCVitalsCompatibilityV1 = "wc3_24_44_3"
+	// TeslaHSCSystemInfoCompatibilityV1 is the exact operation contract gate
+	// for the bounded Common system-information snapshot.
+	TeslaHSCSystemInfoCompatibilityV1 = "wc3_24_44_3"
 )
 
 // TeslaHSCProfileName identifies the profile only inside registry selection.
@@ -49,6 +52,9 @@ const (
 	// TeslaTEDAPIAdmissionAllowedWCVitals admits only the explicit bounded WC
 	// vitals operation after all profile and operation gates pass.
 	TeslaTEDAPIAdmissionAllowedWCVitals TeslaTEDAPIAdmissionState = "allowed_wc_vitals"
+	// TeslaTEDAPIAdmissionAllowedCommonSystemInfo admits only the explicit
+	// bounded Common system-information operation after all gates pass.
+	TeslaTEDAPIAdmissionAllowedCommonSystemInfo TeslaTEDAPIAdmissionState = "allowed_common_system_info"
 )
 
 // TeslaTEDAPIOperationAdmission is the redacted result of local admission
@@ -61,11 +67,12 @@ type TeslaTEDAPIOperationAdmission struct {
 // TeslaHSCProfileConfig is an explicit local flavor configuration. A matching
 // node or a readable frame is not a substitute for this configuration.
 type TeslaHSCProfileConfig struct {
-	Enabled                  bool
-	Node                     byte
-	PassiveCompatible        bool
-	CompatibilityVersion     string
-	WCVitalsOperationVersion string
+	Enabled                    bool
+	Node                       byte
+	PassiveCompatible          bool
+	CompatibilityVersion       string
+	WCVitalsOperationVersion   string
+	SystemInfoOperationVersion string
 }
 
 // TeslaHSCProfile retains the immutable profile gate decision.
@@ -358,13 +365,22 @@ func NewTeslaHSCProvenance(
 	}
 }
 
-// EncodeQualifiedFunction denies every outbound Tesla operation until a later
-// typed, proven read-only contract adds an explicit operation allowlist.
+// EncodeQualifiedFunction constructs only an explicitly qualified, bounded
+// read-only operation. Every unknown operation remains no-send.
 func (profile TeslaHSCProfile) EncodeQualifiedFunction(operation string) (modbus.PrivateFunctionRequest, modbus.PrivateFunctionResponsePolicy, error) {
 	if admission := profile.OperationAdmissionFor(operation); !admission.OutboundAllowed {
 		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
 	}
-	request, err := modbus.NewPrivateFunctionRequest(teslaHSCFunction100, teslaFC100WCVitalsRequestPDU)
+	var payload []byte
+	switch operation {
+	case TeslaTEDAPIOperationWCVitalsV1:
+		payload = teslaFC100WCVitalsRequestPDU
+	case TeslaTEDAPIOperationCommonSystemInfoV1:
+		payload = teslaFC100CommonSystemInfoRequestPDU
+	default:
+		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
+	}
+	request, err := modbus.NewPrivateFunctionRequest(teslaHSCFunction100, payload)
 	if err != nil {
 		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, err
 	}
@@ -380,6 +396,18 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
 		}
 		replay, err := DecodeTeslaFC100WCVitalsReplay(payload)
+		if err != nil {
+			return QualifiedFunctionResult{}, err
+		}
+		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{
+			Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest,
+		}}, nil
+	}
+	if operation == TeslaTEDAPIOperationCommonSystemInfoV1 {
+		if function != teslaHSCFunction100 {
+			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
+		}
+		replay, err := DecodeTeslaFC100CommonSystemInfoReplay(payload)
 		if err != nil {
 			return QualifiedFunctionResult{}, err
 		}


### PR DESCRIPTION
Closes #152

RED-first, docs-gated FC100 Common/GetSystemInfo codec and profile contract.

Scope: exact PDU, version/profile gate, redacted F4/tag-3 terminal replay, and fake-only dispatch coverage.

No typed response fields, raw payload projection, FC101/FC102 change, generic transport change, gateway wiring, hardware I/O, or control.