### PR TITLE
REG-TESLA: qualify bounded FC100 WC lifetime replay

### DIFF
--- a/qualified_function_registry.go
+++ b/qualified_function_registry.go
@@ -43,6 +43,11 @@ type QualifiedFunctionCodec interface {
 	DecodeQualifiedFunction(string, modbus.PrivateFunctionCode, []byte) (QualifiedFunctionResult, error)
 }
 
+type qualifiedFunctionSequenceCodec interface {
+	HandlesQualifiedFunctionSequence(string) bool
+	DecodeQualifiedFunctionSequence(string, modbus.PrivateFunctionCode, [][]byte) ([]QualifiedFunctionResult, error)
+}
+
 // QualifiedFunctionProfile binds one codec to one endpoint and unit identity.
 type QualifiedFunctionProfile struct {
 	Endpoint      string
@@ -113,6 +118,13 @@ func (registry *QualifiedFunctionRegistry) Dispatch(
 	if err != nil {
 		return nil, err
 	}
+	if codec, ok := selected.Codec.(qualifiedFunctionSequenceCodec); ok && codec.HandlesQualifiedFunctionSequence(selector.Operation) {
+		results, err := codec.DecodeQualifiedFunctionSequence(selector.Operation, request.FunctionCode(), responsePayloads(responses))
+		if err != nil {
+			return nil, err
+		}
+		return cloneQualifiedFunctionResults(results), nil
+	}
 	results := make([]QualifiedFunctionResult, 0, len(responses))
 	for _, response := range responses {
 		result, err := selected.Codec.DecodeQualifiedFunction(
@@ -123,12 +135,27 @@ func (registry *QualifiedFunctionRegistry) Dispatch(
 		if err != nil {
 			return nil, err
 		}
-		result.Payload = append([]byte(nil), result.Payload...)
-		if result.Replay != nil {
-			replay := *result.Replay
-			result.Replay = &replay
-		}
 		results = append(results, result)
 	}
-	return results, nil
+	return cloneQualifiedFunctionResults(results), nil
+}
+
+func responsePayloads(responses []modbus.RTUPrivateFunctionResponseADU) [][]byte {
+	payloads := make([][]byte, len(responses))
+	for i := range responses {
+		payloads[i] = responses[i].Payload()
+	}
+	return payloads
+}
+func cloneQualifiedFunctionResults(results []QualifiedFunctionResult) []QualifiedFunctionResult {
+	copied := make([]QualifiedFunctionResult, len(results))
+	for i := range results {
+		copied[i] = results[i]
+		copied[i].Payload = append([]byte(nil), results[i].Payload...)
+		if results[i].Replay != nil {
+			replay := *results[i].Replay
+			copied[i].Replay = &replay
+		}
+	}
+	return copied
 }

--- a/tesla_fc100_wc_lifetime.go
+++ b/tesla_fc100_wc_lifetime.go
@@ -66,5 +66,8 @@ func DecodeTeslaFC100WCLifetimeReplaySequence(payloads [][]byte) ([]TeslaFC100WC
 		}
 		results = append(results, replay)
 	}
+	if !seenTerminal {
+		return nil, fmt.Errorf("tesla WC lifetime response has no terminal")
+	}
 	return results, nil
 }

--- a/tesla_fc100_wc_lifetime.go
+++ b/tesla_fc100_wc_lifetime.go
@@ -1,0 +1,70 @@
+package modbusreg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+const TeslaTEDAPIOperationWCLifetimeV1 = "tesla.hsc.fc100.wc_lifetime.v1"
+
+var teslaFC100WCLifetimeRequestPDU = []byte{0x04, 0x32, 0x02, 0x1a, 0x00}
+
+type TeslaFC100WCLifetimeReplayKind string
+
+const (
+	TeslaFC100WCLifetimeIntermediate TeslaFC100WCLifetimeReplayKind = "intermediate"
+	TeslaFC100WCLifetimeTerminal     TeslaFC100WCLifetimeReplayKind = "terminal"
+)
+
+type TeslaFC100WCLifetimeReplay struct {
+	Kind           TeslaFC100WCLifetimeReplayKind
+	SnapshotLength int
+	SnapshotDigest string
+}
+
+func DecodeTeslaFC100WCLifetimeReplay(payload []byte) (TeslaFC100WCLifetimeReplay, error) {
+	response, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
+	if err != nil {
+		return TeslaFC100WCLifetimeReplay{}, err
+	}
+	message := response.Payload()
+	if bytes.Equal(message, teslaFC100WCLifetimeRequestPDU[1:]) {
+		return TeslaFC100WCLifetimeReplay{Kind: TeslaFC100WCLifetimeIntermediate}, nil
+	}
+	wc, err := decodeExactLengthDelimitedField(message, 6)
+	if err != nil {
+		return TeslaFC100WCLifetimeReplay{}, fmt.Errorf("tesla WC lifetime envelope: %w", err)
+	}
+	body, err := decodeExactLengthDelimitedField(wc, 4)
+	if err != nil {
+		return TeslaFC100WCLifetimeReplay{}, fmt.Errorf("tesla WC lifetime message: %w", err)
+	}
+	digest := sha256.Sum256(body)
+	return TeslaFC100WCLifetimeReplay{Kind: TeslaFC100WCLifetimeTerminal, SnapshotLength: len(body), SnapshotDigest: hex.EncodeToString(digest[:])}, nil
+}
+
+func DecodeTeslaFC100WCLifetimeReplaySequence(payloads [][]byte) ([]TeslaFC100WCLifetimeReplay, error) {
+	if len(payloads) == 0 || len(payloads) > 2 {
+		return nil, fmt.Errorf("tesla WC lifetime response count is invalid")
+	}
+	results := make([]TeslaFC100WCLifetimeReplay, 0, len(payloads))
+	seenIntermediate, seenTerminal := false, false
+	for _, payload := range payloads {
+		replay, err := DecodeTeslaFC100WCLifetimeReplay(payload)
+		if err != nil {
+			return nil, err
+		}
+		if seenTerminal || replay.Kind == TeslaFC100WCLifetimeIntermediate && seenIntermediate || replay.Kind == TeslaFC100WCLifetimeTerminal && seenTerminal {
+			return nil, fmt.Errorf("tesla WC lifetime response sequence is invalid")
+		}
+		if replay.Kind == TeslaFC100WCLifetimeIntermediate {
+			seenIntermediate = true
+		} else {
+			seenTerminal = true
+		}
+		results = append(results, replay)
+	}
+	return results, nil
+}

--- a/tesla_fc100_wc_lifetime_test.go
+++ b/tesla_fc100_wc_lifetime_test.go
@@ -61,3 +61,21 @@ func TestTeslaFC100WCLifetimeReplaySequenceIsBoundedAndOpaque(t *testing.T) {
 		}
 	}
 }
+
+func TestTeslaFC100WCLifetimeDispatchRejectsInvalidCompleteSequence(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1, WCLifetimeOperationVersion: TeslaHSCWCLifetimeCompatibilityV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, payloads := range [][][]byte{{{0x06, 0x32, 0x04, 0x22, 0x02, 0x08, 0x01}, {0x04, 0x32, 0x02, 0x1a, 0x00}}, {{0x06, 0x32, 0x04, 0x1a, 0x02, 0x08, 0x01}}} {
+		transport := &qualifiedFunctionTestTransport{responsePayloads: payloads}
+		results, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCLifetimeV1})
+		if err == nil || len(results) != 0 {
+			t.Fatalf("invalid dispatch = %#v, %v", results, err)
+		}
+	}
+}

--- a/tesla_fc100_wc_lifetime_test.go
+++ b/tesla_fc100_wc_lifetime_test.go
@@ -1,0 +1,63 @@
+package modbusreg
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaFC100WCLifetimeIsVersionQualifiedAndNoSendWhenUngated(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+		WCLifetimeOperationVersion: TeslaHSCWCLifetimeCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, policy, err := profile.EncodeQualifiedFunction(TeslaTEDAPIOperationWCLifetimeV1)
+	if err != nil || request.FunctionCode() != modbus.PrivateFunctionCode(100) ||
+		!bytes.Equal(request.Payload(), []byte{0x04, 0x32, 0x02, 0x1a, 0x00}) || policy.MaxAttempts() != 1 {
+		t.Fatalf("request/policy/error = %#v/%#v/%v", request, policy, err)
+	}
+	blocked, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{
+		Endpoint: "rtu-a", UnitID: blocked.Node(), VendorProfile: TeslaHSCProfileName, Codec: blocked,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{}
+	if _, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{
+		Endpoint: "rtu-a", UnitID: blocked.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCLifetimeV1,
+	}); err == nil || transport.calls != 0 {
+		t.Fatalf("ungated dispatch = %v, calls = %d", err, transport.calls)
+	}
+}
+
+func TestTeslaFC100WCLifetimeReplaySequenceIsBoundedAndOpaque(t *testing.T) {
+	results, err := DecodeTeslaFC100WCLifetimeReplaySequence([][]byte{
+		{0x04, 0x32, 0x02, 0x1a, 0x00},
+		{0x06, 0x32, 0x04, 0x22, 0x02, 0x08, 0x01},
+	})
+	if err != nil || len(results) != 2 || results[0].Kind != TeslaFC100WCLifetimeIntermediate ||
+		results[1].Kind != TeslaFC100WCLifetimeTerminal || results[1].SnapshotLength != 2 || results[1].SnapshotDigest == "" {
+		t.Fatalf("sequence = %#v, %v", results, err)
+	}
+	for _, invalid := range [][][]byte{
+		{{0x04, 0x32, 0x02, 0x1a, 0x00}, {0x04, 0x32, 0x02, 0x1a, 0x00}},
+		{{0x06, 0x32, 0x04, 0x22, 0x02, 0x08, 0x01}, {0x06, 0x32, 0x04, 0x22, 0x02, 0x08, 0x01}},
+		{{0x06, 0x32, 0x04, 0x22, 0x02, 0x08, 0x01}, {0x04, 0x32, 0x02, 0x1a, 0x00}},
+		{{0x06, 0x32, 0x04, 0x1a, 0x02, 0x08, 0x01}},
+	} {
+		if _, err := DecodeTeslaFC100WCLifetimeReplaySequence(invalid); err == nil {
+			t.Fatalf("invalid sequence accepted: %x", invalid)
+		}
+	}
+}

--- a/tesla_fc100_wc_lifetime_test.go
+++ b/tesla_fc100_wc_lifetime_test.go
@@ -78,4 +78,9 @@ func TestTeslaFC100WCLifetimeDispatchRejectsInvalidCompleteSequence(t *testing.T
 			t.Fatalf("invalid dispatch = %#v, %v", results, err)
 		}
 	}
+	transport := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x04, 0x32, 0x02, 0x1a, 0x00}}}
+	results, err := registry.Dispatch(context.Background(), transport, QualifiedFunctionSelector{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCLifetimeV1})
+	if err == nil || len(results) != 0 {
+		t.Fatalf("echo-only dispatch = %#v, %v", results, err)
+	}
 }

--- a/tesla_fc100_wc_vitals.go
+++ b/tesla_fc100_wc_vitals.go
@@ -51,6 +51,10 @@ func (profile TeslaHSCProfile) OperationAdmissionFor(operation string) TeslaTEDA
 				OutboundAllowed: true,
 			}
 		}
+	case TeslaTEDAPIOperationWCLifetimeV1:
+		if profile.config.WCLifetimeOperationVersion == TeslaHSCWCLifetimeCompatibilityV1 {
+			return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionAllowedWCLifetime, OutboundAllowed: true}
+		}
 	}
 	return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation}
 }

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -439,6 +439,25 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 	return QualifiedFunctionResult{Payload: response.Payload()}, nil
 }
 
+func (profile TeslaHSCProfile) DecodeQualifiedFunctionSequence(operation string, function modbus.PrivateFunctionCode, payloads [][]byte) ([]QualifiedFunctionResult, error) {
+	if operation != TeslaTEDAPIOperationWCLifetimeV1 || function != teslaHSCFunction100 {
+		return nil, fmt.Errorf("tesla HSC operation response sequence is invalid")
+	}
+	replays, err := DecodeTeslaFC100WCLifetimeReplaySequence(payloads)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]QualifiedFunctionResult, len(replays))
+	for i, replay := range replays {
+		results[i] = QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest}}
+	}
+	return results, nil
+}
+
+func (TeslaHSCProfile) HandlesQualifiedFunctionSequence(operation string) bool {
+	return operation == TeslaTEDAPIOperationWCLifetimeV1
+}
+
 // PayloadLength returns the retained opaque payload length.
 func (provenance TeslaHSCProvenance) PayloadLength() int {
 	return provenance.payloadLength

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -17,6 +17,9 @@ const (
 	// TeslaHSCSystemInfoCompatibilityV1 is the exact operation contract gate
 	// for the bounded Common system-information snapshot.
 	TeslaHSCSystemInfoCompatibilityV1 = "wc3_24_44_3"
+	// TeslaHSCWCLifetimeCompatibilityV1 is the exact operation contract gate for
+	// the bounded WC lifetime snapshot.
+	TeslaHSCWCLifetimeCompatibilityV1 = "wc3_24_44_3"
 )
 
 // TeslaHSCProfileName identifies the profile only inside registry selection.
@@ -55,6 +58,7 @@ const (
 	// TeslaTEDAPIAdmissionAllowedCommonSystemInfo admits only the explicit
 	// bounded Common system-information operation after all gates pass.
 	TeslaTEDAPIAdmissionAllowedCommonSystemInfo TeslaTEDAPIAdmissionState = "allowed_common_system_info"
+	TeslaTEDAPIAdmissionAllowedWCLifetime       TeslaTEDAPIAdmissionState = "allowed_wc_lifetime"
 )
 
 // TeslaTEDAPIOperationAdmission is the redacted result of local admission
@@ -73,6 +77,7 @@ type TeslaHSCProfileConfig struct {
 	CompatibilityVersion       string
 	WCVitalsOperationVersion   string
 	SystemInfoOperationVersion string
+	WCLifetimeOperationVersion string
 }
 
 // TeslaHSCProfile retains the immutable profile gate decision.
@@ -377,6 +382,8 @@ func (profile TeslaHSCProfile) EncodeQualifiedFunction(operation string) (modbus
 		payload = teslaFC100WCVitalsRequestPDU
 	case TeslaTEDAPIOperationCommonSystemInfoV1:
 		payload = teslaFC100CommonSystemInfoRequestPDU
+	case TeslaTEDAPIOperationWCLifetimeV1:
+		payload = teslaFC100WCLifetimeRequestPDU
 	default:
 		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
 	}
@@ -414,6 +421,16 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{
 			Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest,
 		}}, nil
+	}
+	if operation == TeslaTEDAPIOperationWCLifetimeV1 {
+		if function != teslaHSCFunction100 {
+			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
+		}
+		replay, err := DecodeTeslaFC100WCLifetimeReplay(payload)
+		if err != nil {
+			return QualifiedFunctionResult{}, err
+		}
+		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest}}, nil
 	}
 	response, err := DecodeTeslaHSCResponse(function, payload)
 	if err != nil {


### PR DESCRIPTION
Closes #154

Docs gate: Project-Helianthus/helianthus-docs-modbus#94 (merged at f1d857b56f37da07cadcd20805e7c25de1c12916).

RED-first docs-gated WC lifetime exact PDU and bounded opaque replay sequence.

No fields, FC101/FC102, generic transport, gateway or I/O.