### PR TITLE
REG-TESLA: qualify bounded FC100 WC system-information replay

### DIFF
--- a/tesla_fc100_wc_system_info.go
+++ b/tesla_fc100_wc_system_info.go
@@ -1,0 +1,83 @@
+package modbusreg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+const TeslaTEDAPIOperationWCSystemInfoV1 = "tesla.hsc.fc100.wc_system_info.v1"
+
+var teslaFC100WCSystemInfoRequestPDU = []byte{4, 0x32, 2, 0x4a, 0}
+
+type TeslaFC100WCSystemInfoReplayKind string
+
+const (
+	TeslaFC100WCSystemInfoIntermediate TeslaFC100WCSystemInfoReplayKind = "intermediate"
+	TeslaFC100WCSystemInfoTerminal     TeslaFC100WCSystemInfoReplayKind = "terminal"
+)
+
+type TeslaFC100WCSystemInfoReplay struct {
+	Kind           TeslaFC100WCSystemInfoReplayKind
+	SnapshotLength int
+	SnapshotDigest string
+}
+
+func DecodeTeslaFC100WCSystemInfoReplay(payload []byte) (TeslaFC100WCSystemInfoReplay, error) {
+	r, e := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
+	if e != nil {
+		return TeslaFC100WCSystemInfoReplay{}, e
+	}
+	m := r.Payload()
+	if bytes.Equal(m, teslaFC100WCSystemInfoRequestPDU[1:]) {
+		return TeslaFC100WCSystemInfoReplay{Kind: TeslaFC100WCSystemInfoIntermediate}, nil
+	}
+	w, e := decodeExactLengthDelimitedField(m, 6)
+	if e != nil {
+		return TeslaFC100WCSystemInfoReplay{}, e
+	}
+	b, e := decodeExactLengthDelimitedField(w, 10)
+	if e != nil {
+		return TeslaFC100WCSystemInfoReplay{}, e
+	}
+	d := sha256.Sum256(b)
+	return TeslaFC100WCSystemInfoReplay{Kind: TeslaFC100WCSystemInfoTerminal, SnapshotLength: len(b), SnapshotDigest: hex.EncodeToString(d[:])}, nil
+}
+func DecodeTeslaFC100WCSystemInfoReplaySequence(p [][]byte) ([]TeslaFC100WCSystemInfoReplay, error) {
+	if len(p) == 0 || len(p) > 2 {
+		return nil, fmt.Errorf("tesla WC system-information response count is invalid")
+	}
+	out := make([]TeslaFC100WCSystemInfoReplay, 0, len(p))
+	echo, term := false, false
+	for _, v := range p {
+		x, e := DecodeTeslaFC100WCSystemInfoReplay(v)
+		if e != nil {
+			return nil, e
+		}
+		if term || (x.Kind == TeslaFC100WCSystemInfoIntermediate && echo) {
+			return nil, fmt.Errorf("tesla WC system-information response sequence is invalid")
+		}
+		if x.Kind == TeslaFC100WCSystemInfoIntermediate {
+			echo = true
+		} else {
+			term = true
+		}
+		out = append(out, x)
+	}
+	if !term {
+		return nil, fmt.Errorf("tesla WC system-information response has no terminal")
+	}
+	return out, nil
+}
+func decodeTeslaFC100WCSystemInfoSequence(p [][]byte) ([]QualifiedFunctionResult, error) {
+	r, e := DecodeTeslaFC100WCSystemInfoReplaySequence(p)
+	if e != nil {
+		return nil, e
+	}
+	out := make([]QualifiedFunctionResult, len(r))
+	for i, x := range r {
+		out[i] = QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(x.Kind), PayloadLength: x.SnapshotLength, PayloadDigest: x.SnapshotDigest}}
+	}
+	return out, nil
+}

--- a/tesla_fc100_wc_system_info_test.go
+++ b/tesla_fc100_wc_system_info_test.go
@@ -2,6 +2,7 @@ package modbusreg
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	modbus "github.com/Project-Helianthus/helianthus-modbus"
@@ -24,5 +25,41 @@ func TestTeslaFC100WCSystemInfoIsVersionQualifiedAndSequenceBounded(t *testing.T
 		if _, err := DecodeTeslaFC100WCSystemInfoReplaySequence(invalid); err == nil {
 			t.Fatalf("invalid sequence accepted: %x", invalid)
 		}
+	}
+}
+
+func TestTeslaFC100WCSystemInfoDispatchIsGatedAndAtomic(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1, WCSystemInfoOperationVersion: TeslaHSCWCSystemInfoCompatibilityV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := QualifiedFunctionSelector{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCSystemInfoV1}
+	valid := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x04, 0x32, 0x02, 0x4a, 0x00}, {0x06, 0x32, 0x04, 0x52, 0x02, 0x08, 0x01}}}
+	results, err := registry.Dispatch(context.Background(), valid, selector)
+	if err != nil || len(results) != 2 || results[0].Replay == nil || results[1].Replay == nil {
+		t.Fatalf("valid dispatch = %#v, %v", results, err)
+	}
+	for _, payloads := range [][][]byte{{{0x04, 0x32, 0x02, 0x4a, 0x00}}, {{0x06, 0x32, 0x04, 0x52, 0x02, 0x08, 0x01}, {0x04, 0x32, 0x02, 0x4a, 0x00}}, {{0x06, 0x32, 0x04, 0x0a, 0x02, 0x08, 0x01}}} {
+		transport := &qualifiedFunctionTestTransport{responsePayloads: payloads}
+		results, err := registry.Dispatch(context.Background(), transport, selector)
+		if err == nil || len(results) != 0 {
+			t.Fatalf("invalid dispatch = %#v, %v", results, err)
+		}
+	}
+	ungated, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocked, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{Endpoint: "rtu-a", UnitID: ungated.Node(), VendorProfile: TeslaHSCProfileName, Codec: ungated}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &qualifiedFunctionTestTransport{}
+	if _, err := blocked.Dispatch(context.Background(), transport, selector); err == nil || transport.calls != 0 {
+		t.Fatalf("ungated dispatch = %v, calls=%d", err, transport.calls)
 	}
 }

--- a/tesla_fc100_wc_system_info_test.go
+++ b/tesla_fc100_wc_system_info_test.go
@@ -1,0 +1,28 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaFC100WCSystemInfoIsVersionQualifiedAndSequenceBounded(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1, WCSystemInfoOperationVersion: TeslaHSCWCSystemInfoCompatibilityV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, policy, err := profile.EncodeQualifiedFunction(TeslaTEDAPIOperationWCSystemInfoV1)
+	if err != nil || request.FunctionCode() != modbus.PrivateFunctionCode(100) || !bytes.Equal(request.Payload(), []byte{0x04, 0x32, 0x02, 0x4a, 0x00}) || policy.MaxAttempts() != 1 {
+		t.Fatalf("request/policy = %#v/%#v, %v", request, policy, err)
+	}
+	results, err := DecodeTeslaFC100WCSystemInfoReplaySequence([][]byte{{0x04, 0x32, 0x02, 0x4a, 0x00}, {0x06, 0x32, 0x04, 0x52, 0x02, 0x08, 0x01}})
+	if err != nil || len(results) != 2 || results[0].Kind != TeslaFC100WCSystemInfoIntermediate || results[1].Kind != TeslaFC100WCSystemInfoTerminal || results[1].SnapshotLength != 2 || results[1].SnapshotDigest == "" {
+		t.Fatalf("results = %#v, %v", results, err)
+	}
+	for _, invalid := range [][][]byte{{{0x04, 0x32, 0x02, 0x4a, 0x00}}, {{0x06, 0x32, 0x04, 0x52, 0x02, 0x08, 0x01}, {0x04, 0x32, 0x02, 0x4a, 0x00}}, {{0x06, 0x32, 0x04, 0x0a, 0x02, 0x08, 0x01}}} {
+		if _, err := DecodeTeslaFC100WCSystemInfoReplaySequence(invalid); err == nil {
+			t.Fatalf("invalid sequence accepted: %x", invalid)
+		}
+	}
+}

--- a/tesla_fc100_wc_vitals.go
+++ b/tesla_fc100_wc_vitals.go
@@ -55,6 +55,10 @@ func (profile TeslaHSCProfile) OperationAdmissionFor(operation string) TeslaTEDA
 		if profile.config.WCLifetimeOperationVersion == TeslaHSCWCLifetimeCompatibilityV1 {
 			return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionAllowedWCLifetime, OutboundAllowed: true}
 		}
+	case TeslaTEDAPIOperationWCSystemInfoV1:
+		if profile.config.WCSystemInfoOperationVersion == TeslaHSCWCSystemInfoCompatibilityV1 {
+			return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionAllowedWCSystemInfo, OutboundAllowed: true}
+		}
 	}
 	return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation}
 }

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -19,7 +19,8 @@ const (
 	TeslaHSCSystemInfoCompatibilityV1 = "wc3_24_44_3"
 	// TeslaHSCWCLifetimeCompatibilityV1 is the exact operation contract gate for
 	// the bounded WC lifetime snapshot.
-	TeslaHSCWCLifetimeCompatibilityV1 = "wc3_24_44_3"
+	TeslaHSCWCLifetimeCompatibilityV1   = "wc3_24_44_3"
+	TeslaHSCWCSystemInfoCompatibilityV1 = "wc3_24_44_3"
 )
 
 // TeslaHSCProfileName identifies the profile only inside registry selection.
@@ -59,6 +60,7 @@ const (
 	// bounded Common system-information operation after all gates pass.
 	TeslaTEDAPIAdmissionAllowedCommonSystemInfo TeslaTEDAPIAdmissionState = "allowed_common_system_info"
 	TeslaTEDAPIAdmissionAllowedWCLifetime       TeslaTEDAPIAdmissionState = "allowed_wc_lifetime"
+	TeslaTEDAPIAdmissionAllowedWCSystemInfo     TeslaTEDAPIAdmissionState = "allowed_wc_system_info"
 )
 
 // TeslaTEDAPIOperationAdmission is the redacted result of local admission
@@ -71,13 +73,14 @@ type TeslaTEDAPIOperationAdmission struct {
 // TeslaHSCProfileConfig is an explicit local flavor configuration. A matching
 // node or a readable frame is not a substitute for this configuration.
 type TeslaHSCProfileConfig struct {
-	Enabled                    bool
-	Node                       byte
-	PassiveCompatible          bool
-	CompatibilityVersion       string
-	WCVitalsOperationVersion   string
-	SystemInfoOperationVersion string
-	WCLifetimeOperationVersion string
+	Enabled                      bool
+	Node                         byte
+	PassiveCompatible            bool
+	CompatibilityVersion         string
+	WCVitalsOperationVersion     string
+	SystemInfoOperationVersion   string
+	WCLifetimeOperationVersion   string
+	WCSystemInfoOperationVersion string
 }
 
 // TeslaHSCProfile retains the immutable profile gate decision.
@@ -384,6 +387,8 @@ func (profile TeslaHSCProfile) EncodeQualifiedFunction(operation string) (modbus
 		payload = teslaFC100CommonSystemInfoRequestPDU
 	case TeslaTEDAPIOperationWCLifetimeV1:
 		payload = teslaFC100WCLifetimeRequestPDU
+	case TeslaTEDAPIOperationWCSystemInfoV1:
+		payload = teslaFC100WCSystemInfoRequestPDU
 	default:
 		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
 	}
@@ -432,6 +437,16 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 		}
 		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest}}, nil
 	}
+	if operation == TeslaTEDAPIOperationWCSystemInfoV1 {
+		if function != teslaHSCFunction100 {
+			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
+		}
+		replay, err := DecodeTeslaFC100WCSystemInfoReplay(payload)
+		if err != nil {
+			return QualifiedFunctionResult{}, err
+		}
+		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest}}, nil
+	}
 	response, err := DecodeTeslaHSCResponse(function, payload)
 	if err != nil {
 		return QualifiedFunctionResult{}, err
@@ -440,10 +455,19 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 }
 
 func (profile TeslaHSCProfile) DecodeQualifiedFunctionSequence(operation string, function modbus.PrivateFunctionCode, payloads [][]byte) ([]QualifiedFunctionResult, error) {
-	if operation != TeslaTEDAPIOperationWCLifetimeV1 || function != teslaHSCFunction100 {
+	if function != teslaHSCFunction100 {
 		return nil, fmt.Errorf("tesla HSC operation response sequence is invalid")
 	}
-	replays, err := DecodeTeslaFC100WCLifetimeReplaySequence(payloads)
+	var replays []TeslaFC100WCLifetimeReplay
+	var err error
+	switch operation {
+	case TeslaTEDAPIOperationWCLifetimeV1:
+		replays, err = DecodeTeslaFC100WCLifetimeReplaySequence(payloads)
+	case TeslaTEDAPIOperationWCSystemInfoV1:
+		return decodeTeslaFC100WCSystemInfoSequence(payloads)
+	default:
+		return nil, fmt.Errorf("tesla HSC operation response sequence is invalid")
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -455,7 +479,7 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunctionSequence(operation string,
 }
 
 func (TeslaHSCProfile) HandlesQualifiedFunctionSequence(operation string) bool {
-	return operation == TeslaTEDAPIOperationWCLifetimeV1
+	return operation == TeslaTEDAPIOperationWCLifetimeV1 || operation == TeslaTEDAPIOperationWCSystemInfoV1
 }
 
 // PayloadLength returns the retained opaque payload length.


### PR DESCRIPTION
Closes #156

RED-first docs-gated WC system-information exact PDU and opaque bounded replay.

No fields, FC101/FC102, generic transport, gateway or I/O.