### PR TITLE
REG-TESLA: qualify bounded FC100 WC load-sharing-state replay

### DIFF
--- a/tesla_fc100_wc_load_sharing_state.go
+++ b/tesla_fc100_wc_load_sharing_state.go
@@ -1,0 +1,103 @@
+package modbusreg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+// TeslaTEDAPIOperationWCLoadSharingStateV1 identifies the explicitly
+// qualified FC100 WC load-sharing-state operation.
+const TeslaTEDAPIOperationWCLoadSharingStateV1 = "tesla.hsc.fc100.wc_load_sharing_state.v1"
+
+var teslaFC100WCLoadSharingStateRequestPDU = []byte{0x04, 0x32, 0x02, 0x5a, 0x00}
+
+// TeslaFC100WCLoadSharingStateReplayKind distinguishes an immediate echo from
+// the opaque, terminal load-sharing-state body.
+type TeslaFC100WCLoadSharingStateReplayKind string
+
+const (
+	TeslaFC100WCLoadSharingStateIntermediate TeslaFC100WCLoadSharingStateReplayKind = "intermediate"
+	TeslaFC100WCLoadSharingStateTerminal     TeslaFC100WCLoadSharingStateReplayKind = "terminal"
+)
+
+// TeslaFC100WCLoadSharingStateReplay retains only redacted terminal metadata.
+// It intentionally has no typed inner fields or raw body bytes.
+type TeslaFC100WCLoadSharingStateReplay struct {
+	Kind           TeslaFC100WCLoadSharingStateReplayKind
+	SnapshotLength int
+	SnapshotDigest string
+}
+
+// DecodeTeslaFC100WCLoadSharingStateReplay accepts one bounded FC100 echo or
+// one terminal F6/tag-12 opaque body.
+func DecodeTeslaFC100WCLoadSharingStateReplay(payload []byte) (TeslaFC100WCLoadSharingStateReplay, error) {
+	response, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
+	if err != nil {
+		return TeslaFC100WCLoadSharingStateReplay{}, err
+	}
+	message := response.Payload()
+	if bytes.Equal(message, teslaFC100WCLoadSharingStateRequestPDU[1:]) {
+		return TeslaFC100WCLoadSharingStateReplay{Kind: TeslaFC100WCLoadSharingStateIntermediate}, nil
+	}
+	wc, err := decodeExactLengthDelimitedField(message, 6)
+	if err != nil {
+		return TeslaFC100WCLoadSharingStateReplay{}, fmt.Errorf("tesla WC load-sharing-state envelope: %w", err)
+	}
+	body, err := decodeExactLengthDelimitedField(wc, 12)
+	if err != nil {
+		return TeslaFC100WCLoadSharingStateReplay{}, fmt.Errorf("tesla WC load-sharing-state message: %w", err)
+	}
+	digest := sha256.Sum256(body)
+	return TeslaFC100WCLoadSharingStateReplay{
+		Kind:           TeslaFC100WCLoadSharingStateTerminal,
+		SnapshotLength: len(body),
+		SnapshotDigest: hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+// DecodeTeslaFC100WCLoadSharingStateReplaySequence permits an optional
+// immediate echo followed by exactly one terminal body.
+func DecodeTeslaFC100WCLoadSharingStateReplaySequence(payloads [][]byte) ([]TeslaFC100WCLoadSharingStateReplay, error) {
+	if len(payloads) == 0 || len(payloads) > 2 {
+		return nil, fmt.Errorf("tesla WC load-sharing-state response count is invalid")
+	}
+	results := make([]TeslaFC100WCLoadSharingStateReplay, 0, len(payloads))
+	seenIntermediate, seenTerminal := false, false
+	for _, payload := range payloads {
+		replay, err := DecodeTeslaFC100WCLoadSharingStateReplay(payload)
+		if err != nil {
+			return nil, err
+		}
+		if seenTerminal || replay.Kind == TeslaFC100WCLoadSharingStateIntermediate && seenIntermediate {
+			return nil, fmt.Errorf("tesla WC load-sharing-state response sequence is invalid")
+		}
+		if replay.Kind == TeslaFC100WCLoadSharingStateIntermediate {
+			seenIntermediate = true
+		} else {
+			seenTerminal = true
+		}
+		results = append(results, replay)
+	}
+	if !seenTerminal {
+		return nil, fmt.Errorf("tesla WC load-sharing-state response has no terminal")
+	}
+	return results, nil
+}
+
+func decodeTeslaFC100WCLoadSharingStateSequence(payloads [][]byte) ([]QualifiedFunctionResult, error) {
+	replays, err := DecodeTeslaFC100WCLoadSharingStateReplaySequence(payloads)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]QualifiedFunctionResult, len(replays))
+	for index, replay := range replays {
+		results[index] = QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{
+			Kind:          string(replay.Kind),
+			PayloadLength: replay.SnapshotLength,
+			PayloadDigest: replay.SnapshotDigest,
+		}}
+	}
+	return results, nil
+}

--- a/tesla_fc100_wc_load_sharing_state_test.go
+++ b/tesla_fc100_wc_load_sharing_state_test.go
@@ -1,0 +1,37 @@
+package modbusreg
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaFC100WCLoadSharingStateIsVersionQualifiedAndAtomic(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1, WCLoadSharingStateOperationVersion: TeslaHSCWCLoadSharingStateCompatibilityV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, policy, err := profile.EncodeQualifiedFunction(TeslaTEDAPIOperationWCLoadSharingStateV1)
+	if err != nil || request.FunctionCode() != modbus.PrivateFunctionCode(100) || !bytes.Equal(request.Payload(), []byte{0x04, 0x32, 0x02, 0x5a, 0x00}) || policy.MaxAttempts() != 1 {
+		t.Fatalf("request/policy = %#v/%#v, %v", request, policy, err)
+	}
+	registry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Codec: profile}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	selector := QualifiedFunctionSelector{Endpoint: "rtu-a", UnitID: profile.Node(), VendorProfile: TeslaHSCProfileName, Operation: TeslaTEDAPIOperationWCLoadSharingStateV1}
+	valid := &qualifiedFunctionTestTransport{responsePayloads: [][]byte{{0x04, 0x32, 0x02, 0x5a, 0x00}, {0x06, 0x32, 0x04, 0x62, 0x02, 0x08, 0x01}}}
+	results, err := registry.Dispatch(context.Background(), valid, selector)
+	if err != nil || len(results) != 2 || results[0].Replay == nil || results[1].Replay == nil {
+		t.Fatalf("valid dispatch = %#v, %v", results, err)
+	}
+	for _, payloads := range [][][]byte{{{0x04, 0x32, 0x02, 0x5a, 0x00}}, {{0x06, 0x32, 0x04, 0x62, 0x02, 0x08, 0x01}, {0x04, 0x32, 0x02, 0x5a, 0x00}}, {{0x06, 0x32, 0x04, 0x0a, 0x02, 0x08, 0x01}}} {
+		transport := &qualifiedFunctionTestTransport{responsePayloads: payloads}
+		results, err := registry.Dispatch(context.Background(), transport, selector)
+		if err == nil || len(results) != 0 {
+			t.Fatalf("invalid dispatch = %#v, %v", results, err)
+		}
+	}
+}

--- a/tesla_fc100_wc_load_sharing_state_test.go
+++ b/tesla_fc100_wc_load_sharing_state_test.go
@@ -34,4 +34,16 @@ func TestTeslaFC100WCLoadSharingStateIsVersionQualifiedAndAtomic(t *testing.T) {
 			t.Fatalf("invalid dispatch = %#v, %v", results, err)
 		}
 	}
+	ungated, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockedRegistry, err := NewQualifiedFunctionRegistry([]QualifiedFunctionProfile{{Endpoint: "rtu-a", UnitID: ungated.Node(), VendorProfile: TeslaHSCProfileName, Codec: ungated}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blockedTransport := &qualifiedFunctionTestTransport{}
+	if _, err := blockedRegistry.Dispatch(context.Background(), blockedTransport, selector); err == nil || blockedTransport.calls != 0 {
+		t.Fatalf("ungated dispatch = %v, calls = %d", err, blockedTransport.calls)
+	}
 }

--- a/tesla_fc100_wc_vitals.go
+++ b/tesla_fc100_wc_vitals.go
@@ -59,6 +59,10 @@ func (profile TeslaHSCProfile) OperationAdmissionFor(operation string) TeslaTEDA
 		if profile.config.WCSystemInfoOperationVersion == TeslaHSCWCSystemInfoCompatibilityV1 {
 			return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionAllowedWCSystemInfo, OutboundAllowed: true}
 		}
+	case TeslaTEDAPIOperationWCLoadSharingStateV1:
+		if profile.config.WCLoadSharingStateOperationVersion == TeslaHSCWCLoadSharingStateCompatibilityV1 {
+			return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionAllowedWCLoadSharingState, OutboundAllowed: true}
+		}
 	}
 	return TeslaTEDAPIOperationAdmission{State: TeslaTEDAPIAdmissionBlockedNoAdmissibleOperation}
 }

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -21,6 +21,9 @@ const (
 	// the bounded WC lifetime snapshot.
 	TeslaHSCWCLifetimeCompatibilityV1   = "wc3_24_44_3"
 	TeslaHSCWCSystemInfoCompatibilityV1 = "wc3_24_44_3"
+	// TeslaHSCWCLoadSharingStateCompatibilityV1 is the exact operation
+	// contract gate for the bounded WC load-sharing-state replay.
+	TeslaHSCWCLoadSharingStateCompatibilityV1 = "wc3_24_44_3"
 )
 
 // TeslaHSCProfileName identifies the profile only inside registry selection.
@@ -58,9 +61,10 @@ const (
 	TeslaTEDAPIAdmissionAllowedWCVitals TeslaTEDAPIAdmissionState = "allowed_wc_vitals"
 	// TeslaTEDAPIAdmissionAllowedCommonSystemInfo admits only the explicit
 	// bounded Common system-information operation after all gates pass.
-	TeslaTEDAPIAdmissionAllowedCommonSystemInfo TeslaTEDAPIAdmissionState = "allowed_common_system_info"
-	TeslaTEDAPIAdmissionAllowedWCLifetime       TeslaTEDAPIAdmissionState = "allowed_wc_lifetime"
-	TeslaTEDAPIAdmissionAllowedWCSystemInfo     TeslaTEDAPIAdmissionState = "allowed_wc_system_info"
+	TeslaTEDAPIAdmissionAllowedCommonSystemInfo   TeslaTEDAPIAdmissionState = "allowed_common_system_info"
+	TeslaTEDAPIAdmissionAllowedWCLifetime         TeslaTEDAPIAdmissionState = "allowed_wc_lifetime"
+	TeslaTEDAPIAdmissionAllowedWCSystemInfo       TeslaTEDAPIAdmissionState = "allowed_wc_system_info"
+	TeslaTEDAPIAdmissionAllowedWCLoadSharingState TeslaTEDAPIAdmissionState = "allowed_wc_load_sharing_state"
 )
 
 // TeslaTEDAPIOperationAdmission is the redacted result of local admission
@@ -73,14 +77,15 @@ type TeslaTEDAPIOperationAdmission struct {
 // TeslaHSCProfileConfig is an explicit local flavor configuration. A matching
 // node or a readable frame is not a substitute for this configuration.
 type TeslaHSCProfileConfig struct {
-	Enabled                      bool
-	Node                         byte
-	PassiveCompatible            bool
-	CompatibilityVersion         string
-	WCVitalsOperationVersion     string
-	SystemInfoOperationVersion   string
-	WCLifetimeOperationVersion   string
-	WCSystemInfoOperationVersion string
+	Enabled                            bool
+	Node                               byte
+	PassiveCompatible                  bool
+	CompatibilityVersion               string
+	WCVitalsOperationVersion           string
+	SystemInfoOperationVersion         string
+	WCLifetimeOperationVersion         string
+	WCSystemInfoOperationVersion       string
+	WCLoadSharingStateOperationVersion string
 }
 
 // TeslaHSCProfile retains the immutable profile gate decision.
@@ -389,6 +394,8 @@ func (profile TeslaHSCProfile) EncodeQualifiedFunction(operation string) (modbus
 		payload = teslaFC100WCLifetimeRequestPDU
 	case TeslaTEDAPIOperationWCSystemInfoV1:
 		payload = teslaFC100WCSystemInfoRequestPDU
+	case TeslaTEDAPIOperationWCLoadSharingStateV1:
+		payload = teslaFC100WCLoadSharingStateRequestPDU
 	default:
 		return modbus.PrivateFunctionRequest{}, modbus.PrivateFunctionResponsePolicy{}, fmt.Errorf("tesla HSC operation is not admitted")
 	}
@@ -447,6 +454,16 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunction(operation string, functio
 		}
 		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest}}, nil
 	}
+	if operation == TeslaTEDAPIOperationWCLoadSharingStateV1 {
+		if function != teslaHSCFunction100 {
+			return QualifiedFunctionResult{}, fmt.Errorf("tesla HSC operation response function is invalid")
+		}
+		replay, err := DecodeTeslaFC100WCLoadSharingStateReplay(payload)
+		if err != nil {
+			return QualifiedFunctionResult{}, err
+		}
+		return QualifiedFunctionResult{Replay: &QualifiedFunctionReplay{Kind: string(replay.Kind), PayloadLength: replay.SnapshotLength, PayloadDigest: replay.SnapshotDigest}}, nil
+	}
 	response, err := DecodeTeslaHSCResponse(function, payload)
 	if err != nil {
 		return QualifiedFunctionResult{}, err
@@ -465,6 +482,8 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunctionSequence(operation string,
 		replays, err = DecodeTeslaFC100WCLifetimeReplaySequence(payloads)
 	case TeslaTEDAPIOperationWCSystemInfoV1:
 		return decodeTeslaFC100WCSystemInfoSequence(payloads)
+	case TeslaTEDAPIOperationWCLoadSharingStateV1:
+		return decodeTeslaFC100WCLoadSharingStateSequence(payloads)
 	default:
 		return nil, fmt.Errorf("tesla HSC operation response sequence is invalid")
 	}
@@ -479,7 +498,9 @@ func (profile TeslaHSCProfile) DecodeQualifiedFunctionSequence(operation string,
 }
 
 func (TeslaHSCProfile) HandlesQualifiedFunctionSequence(operation string) bool {
-	return operation == TeslaTEDAPIOperationWCLifetimeV1 || operation == TeslaTEDAPIOperationWCSystemInfoV1
+	return operation == TeslaTEDAPIOperationWCLifetimeV1 ||
+		operation == TeslaTEDAPIOperationWCSystemInfoV1 ||
+		operation == TeslaTEDAPIOperationWCLoadSharingStateV1
 }
 
 // PayloadLength returns the retained opaque payload length.


### PR DESCRIPTION
## Scope

Adds the explicitly version-gated FC100 WC load-sharing-state request and bounded replay contract: exact request PDU, optional echo, and one F6/tag-12 opaque terminal body retained only as length and digest.

## Safety boundary

No serial, device, or live I/O. No typed inner fields, raw terminal bytes, FC101/FC102 behavior, gateway integration, or general operation admission. An unversioned profile fails before the transport is called.

## Evidence

- Public RED: `d3d8d5cf2719cfdba80f37d4364482e4375461b9`
- Local GREEN: `GOWORK=off go test ./...`; `./scripts/ci_local.sh`
- Docs gate: Project-Helianthus/helianthus-docs-modbus#98, merged at `0fec926d6d6e5dac86ae06d6bb0ec45a5ab959b0`.
