### PR TITLE
REG-TESLA: decode opaque FC100 WC PPU settings replay

### DIFF
--- a/tesla_fc100_wc_ppu_settings.go
+++ b/tesla_fc100_wc_ppu_settings.go
@@ -24,21 +24,26 @@ type TeslaFC100WCPPUSettingsReplay struct {
 
 // TeslaFC100WCPPUSettingsReplayDecoder decodes injected offline replay only.
 // It owns no request construction, exchange, serial endpoint, or admission.
-type TeslaFC100WCPPUSettingsReplayDecoder struct{}
+type TeslaFC100WCPPUSettingsReplayDecoder struct {
+	valid bool
+}
 
 func NewTeslaFC100WCPPUSettingsReplayDecoder(profile TeslaHSCProfile) (*TeslaFC100WCPPUSettingsReplayDecoder, error) {
 	if profile.Disposition() != TeslaHSCQualifiedReadOnly ||
 		profile.config.WCPPUSettingsReplayVersion != TeslaHSCWCPPUSettingsReplayCompatibilityV1 {
 		return nil, ErrQualifiedFunctionNoSend
 	}
-	return &TeslaFC100WCPPUSettingsReplayDecoder{}, nil
+	return &TeslaFC100WCPPUSettingsReplayDecoder{valid: true}, nil
 }
 
-func (TeslaFC100WCPPUSettingsReplayDecoder) Decode(payloads [][]byte) ([]TeslaFC100WCPPUSettingsReplay, error) {
-	return DecodeTeslaFC100WCPPUSettingsReplaySequence(payloads)
+func (decoder *TeslaFC100WCPPUSettingsReplayDecoder) Decode(payloads [][]byte) ([]TeslaFC100WCPPUSettingsReplay, error) {
+	if decoder == nil || !decoder.valid {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	return decodeTeslaFC100WCPPUSettingsReplaySequence(payloads)
 }
 
-func DecodeTeslaFC100WCPPUSettingsReplay(payload []byte) (TeslaFC100WCPPUSettingsReplay, error) {
+func decodeTeslaFC100WCPPUSettingsReplay(payload []byte) (TeslaFC100WCPPUSettingsReplay, error) {
 	response, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
 	if err != nil {
 		return TeslaFC100WCPPUSettingsReplay{}, err
@@ -59,14 +64,14 @@ func DecodeTeslaFC100WCPPUSettingsReplay(payload []byte) (TeslaFC100WCPPUSetting
 	return TeslaFC100WCPPUSettingsReplay{Kind: TeslaFC100WCPPUSettingsTerminal, SnapshotLength: len(body), SnapshotDigest: hex.EncodeToString(digest[:])}, nil
 }
 
-func DecodeTeslaFC100WCPPUSettingsReplaySequence(payloads [][]byte) ([]TeslaFC100WCPPUSettingsReplay, error) {
+func decodeTeslaFC100WCPPUSettingsReplaySequence(payloads [][]byte) ([]TeslaFC100WCPPUSettingsReplay, error) {
 	if len(payloads) == 0 || len(payloads) > 2 {
 		return nil, fmt.Errorf("tesla WC PPU settings response count is invalid")
 	}
 	results := make([]TeslaFC100WCPPUSettingsReplay, 0, len(payloads))
 	seenIntermediate, seenTerminal := false, false
 	for _, payload := range payloads {
-		replay, err := DecodeTeslaFC100WCPPUSettingsReplay(payload)
+		replay, err := decodeTeslaFC100WCPPUSettingsReplay(payload)
 		if err != nil {
 			return nil, err
 		}

--- a/tesla_fc100_wc_ppu_settings.go
+++ b/tesla_fc100_wc_ppu_settings.go
@@ -1,0 +1,87 @@
+package modbusreg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+var teslaFC100WCPPUSettingsRequestPDU = []byte{0x05, 0x32, 0x03, 0xba, 0x01, 0x00}
+
+type TeslaFC100WCPPUSettingsReplayKind string
+
+const (
+	TeslaFC100WCPPUSettingsIntermediate TeslaFC100WCPPUSettingsReplayKind = "intermediate"
+	TeslaFC100WCPPUSettingsTerminal     TeslaFC100WCPPUSettingsReplayKind = "terminal"
+)
+
+type TeslaFC100WCPPUSettingsReplay struct {
+	Kind           TeslaFC100WCPPUSettingsReplayKind
+	SnapshotLength int
+	SnapshotDigest string
+}
+
+// TeslaFC100WCPPUSettingsReplayDecoder decodes injected offline replay only.
+// It owns no request construction, exchange, serial endpoint, or admission.
+type TeslaFC100WCPPUSettingsReplayDecoder struct{}
+
+func NewTeslaFC100WCPPUSettingsReplayDecoder(profile TeslaHSCProfile) (*TeslaFC100WCPPUSettingsReplayDecoder, error) {
+	if profile.Disposition() != TeslaHSCQualifiedReadOnly ||
+		profile.config.WCPPUSettingsReplayVersion != TeslaHSCWCPPUSettingsReplayCompatibilityV1 {
+		return nil, ErrQualifiedFunctionNoSend
+	}
+	return &TeslaFC100WCPPUSettingsReplayDecoder{}, nil
+}
+
+func (TeslaFC100WCPPUSettingsReplayDecoder) Decode(payloads [][]byte) ([]TeslaFC100WCPPUSettingsReplay, error) {
+	return DecodeTeslaFC100WCPPUSettingsReplaySequence(payloads)
+}
+
+func DecodeTeslaFC100WCPPUSettingsReplay(payload []byte) (TeslaFC100WCPPUSettingsReplay, error) {
+	response, err := DecodeTeslaHSCResponse(teslaHSCFunction100, payload)
+	if err != nil {
+		return TeslaFC100WCPPUSettingsReplay{}, err
+	}
+	message := response.Payload()
+	if bytes.Equal(message, teslaFC100WCPPUSettingsRequestPDU[1:]) {
+		return TeslaFC100WCPPUSettingsReplay{Kind: TeslaFC100WCPPUSettingsIntermediate}, nil
+	}
+	wc, err := decodeExactLengthDelimitedField(message, 6)
+	if err != nil {
+		return TeslaFC100WCPPUSettingsReplay{}, fmt.Errorf("tesla WC PPU settings envelope: %w", err)
+	}
+	body, err := decodeExactLengthDelimitedField(wc, 24)
+	if err != nil {
+		return TeslaFC100WCPPUSettingsReplay{}, fmt.Errorf("tesla WC PPU settings message: %w", err)
+	}
+	digest := sha256.Sum256(body)
+	return TeslaFC100WCPPUSettingsReplay{Kind: TeslaFC100WCPPUSettingsTerminal, SnapshotLength: len(body), SnapshotDigest: hex.EncodeToString(digest[:])}, nil
+}
+
+func DecodeTeslaFC100WCPPUSettingsReplaySequence(payloads [][]byte) ([]TeslaFC100WCPPUSettingsReplay, error) {
+	if len(payloads) == 0 || len(payloads) > 2 {
+		return nil, fmt.Errorf("tesla WC PPU settings response count is invalid")
+	}
+	results := make([]TeslaFC100WCPPUSettingsReplay, 0, len(payloads))
+	seenIntermediate, seenTerminal := false, false
+	for _, payload := range payloads {
+		replay, err := DecodeTeslaFC100WCPPUSettingsReplay(payload)
+		if err != nil {
+			return nil, err
+		}
+		if seenTerminal || replay.Kind == TeslaFC100WCPPUSettingsIntermediate && seenIntermediate {
+			return nil, fmt.Errorf("tesla WC PPU settings response sequence is invalid")
+		}
+		if replay.Kind == TeslaFC100WCPPUSettingsIntermediate {
+			seenIntermediate = true
+		} else {
+			seenTerminal = true
+		}
+		results = append(results, replay)
+	}
+	if !seenTerminal {
+		return nil, fmt.Errorf("tesla WC PPU settings response has no terminal")
+	}
+	return results, nil
+}

--- a/tesla_fc100_wc_ppu_settings_test.go
+++ b/tesla_fc100_wc_ppu_settings_test.go
@@ -43,4 +43,8 @@ func TestTeslaFC100WCPPUSettingsReplayIsVersionGatedAndOpaque(t *testing.T) {
 	if _, err := NewTeslaFC100WCPPUSettingsReplayDecoder(ungated); err == nil {
 		t.Fatal("ungated profile created a PPU replay decoder")
 	}
+	var zero TeslaFC100WCPPUSettingsReplayDecoder
+	if got, err := zero.Decode([][]byte{{0x06, 0x32, 0x04, 0xc2, 0x01, 0x01, 0x08}}); err == nil || got != nil {
+		t.Fatalf("zero-value decoder = %#v, %v", got, err)
+	}
 }

--- a/tesla_fc100_wc_ppu_settings_test.go
+++ b/tesla_fc100_wc_ppu_settings_test.go
@@ -1,0 +1,46 @@
+package modbusreg
+
+import "testing"
+
+func TestTeslaFC100WCPPUSettingsReplayIsVersionGatedAndOpaque(t *testing.T) {
+	profile, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+		WCPPUSettingsReplayVersion: TeslaHSCWCPPUSettingsReplayCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder, err := NewTeslaFC100WCPPUSettingsReplayDecoder(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replays, err := decoder.Decode([][]byte{
+		{0x05, 0x32, 0x03, 0xba, 0x01, 0x00},
+		{0x06, 0x32, 0x04, 0xc2, 0x01, 0x01, 0x08},
+	})
+	if err != nil || len(replays) != 2 ||
+		replays[0].Kind != TeslaFC100WCPPUSettingsIntermediate ||
+		replays[1].Kind != TeslaFC100WCPPUSettingsTerminal ||
+		replays[1].SnapshotLength != 1 || replays[1].SnapshotDigest == "" {
+		t.Fatalf("replays = %#v, %v", replays, err)
+	}
+	for _, invalid := range [][][]byte{
+		{{0x05, 0x32, 0x03, 0xba, 0x01, 0x00}},
+		{{0x06, 0x32, 0x04, 0xc2, 0x01, 0x01, 0x08}, {0x05, 0x32, 0x03, 0xba, 0x01, 0x00}},
+		{{0x08, 0x32, 0x06, 0xc2, 0x01, 0x01, 0x08, 0xca, 0x01, 0x00}},
+	} {
+		if got, err := decoder.Decode(invalid); err == nil || got != nil {
+			t.Fatalf("invalid replay = %#v, %v", got, err)
+		}
+	}
+
+	ungated, err := NewTeslaHSCProfile(TeslaHSCProfileConfig{
+		Enabled: true, Node: 0x10, PassiveCompatible: true, CompatibilityVersion: TeslaHSCCompatibilityV1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewTeslaFC100WCPPUSettingsReplayDecoder(ungated); err == nil {
+		t.Fatal("ungated profile created a PPU replay decoder")
+	}
+}

--- a/tesla_hsc.go
+++ b/tesla_hsc.go
@@ -23,7 +23,8 @@ const (
 	TeslaHSCWCSystemInfoCompatibilityV1 = "wc3_24_44_3"
 	// TeslaHSCWCLoadSharingStateCompatibilityV1 is the exact operation
 	// contract gate for the bounded WC load-sharing-state replay.
-	TeslaHSCWCLoadSharingStateCompatibilityV1 = "wc3_24_44_3"
+	TeslaHSCWCLoadSharingStateCompatibilityV1  = "wc3_24_44_3"
+	TeslaHSCWCPPUSettingsReplayCompatibilityV1 = "wc3_24_44_3"
 )
 
 // TeslaHSCProfileName identifies the profile only inside registry selection.
@@ -86,6 +87,7 @@ type TeslaHSCProfileConfig struct {
 	WCLifetimeOperationVersion         string
 	WCSystemInfoOperationVersion       string
 	WCLoadSharingStateOperationVersion string
+	WCPPUSettingsReplayVersion         string
 }
 
 // TeslaHSCProfile retains the immutable profile gate decision.


### PR DESCRIPTION
## Scope

Docs-gated offline/injected replay decoder for FC100 WC GetPpuSettings: exact PDU, version-qualified decoder, optional echo, and one exclusive F6/tag-24 opaque terminal retained only as length/digest.

## Safety boundary

No `QualifiedFunctionRegistry.Dispatch`, exchanger, request construction, serial/hardware I/O, live transport dispatch, configuration values/fields/identifiers, MCP/gateway, FC101/FC102, setter, or control. The decoder accepts supplied replay payloads only.

## Evidence

- Public RED: `bb6cde3e96a67ac05aec667912d8609be8e14ec1`
- Local GREEN: `GOWORK=off go test ./...`; `./scripts/ci_local.sh`; `git diff --check`
- Docs gate: Project-Helianthus/helianthus-docs-modbus#100 merged `1f475d923f4eff67a96beea51c34ae7fdf3d1676`
- Issue: #160
