### PR TITLE
REG-GROWATT: observe native Protocol II identity tuple

### DIFF
--- a/growatt_protocol_ii_identity.go
+++ b/growatt_protocol_ii_identity.go
@@ -39,6 +39,7 @@ type GrowattProtocolIIIdentityObservation struct {
 	profile         GrowattProtocolIIIdentityProfile
 	slices          []GrowattProtocolIIIdentitySlice
 	firmwareText    string
+	serialText      string
 	deviceType      uint16
 	modelBuild      [2]uint16
 	protocolVersion uint16
@@ -52,6 +53,7 @@ func (o GrowattProtocolIIIdentityObservation) Slices() []GrowattProtocolIIIdenti
 	return cloneGrowattProtocolIIIdentitySlices(o.slices)
 }
 func (o GrowattProtocolIIIdentityObservation) FirmwareText() string    { return o.firmwareText }
+func (o GrowattProtocolIIIdentityObservation) SerialText() string      { return o.serialText }
 func (o GrowattProtocolIIIdentityObservation) DeviceType() uint16      { return o.deviceType }
 func (o GrowattProtocolIIIdentityObservation) ModelBuild() [2]uint16   { return o.modelBuild }
 func (o GrowattProtocolIIIdentityObservation) ProtocolVersion() uint16 { return o.protocolVersion }
@@ -60,7 +62,7 @@ func (o GrowattProtocolIIIdentityObservation) ProtocolVersion() uint16 { return 
 // control operation or another Modbus request.
 func (GrowattProtocolIIIdentityObservation) OutboundAllowed() bool { return false }
 
-// DecodeGrowattProtocolIIIdentity validates the four individually bounded
+// DecodeGrowattProtocolIIIdentity validates the five individually bounded
 // FC03 identity slices allowed by the Protocol II v1.24 TL3-X contract.
 func DecodeGrowattProtocolIIIdentity(input GrowattProtocolIIIdentityInput) (GrowattProtocolIIIdentityObservation, error) {
 	if input.UnitID == 0 || input.UnitID == 255 || input.Function != FunctionReadHoldingRegisters ||
@@ -68,7 +70,7 @@ func DecodeGrowattProtocolIIIdentity(input GrowattProtocolIIIdentityInput) (Grow
 		return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity is invalid")
 	}
 
-	want := [...]struct{ offset, words uint16 }{{9, 6}, {43, 1}, {82, 2}, {88, 1}}
+	want := [...]struct{ offset, words uint16 }{{9, 6}, {23, 5}, {43, 1}, {82, 2}, {88, 1}}
 	if len(input.Slices) != len(want) {
 		return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity slice count is invalid")
 	}
@@ -78,12 +80,16 @@ func DecodeGrowattProtocolIIIdentity(input GrowattProtocolIIIdentityInput) (Grow
 			return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity slice %d is invalid", index)
 		}
 	}
-	if input.Slices[1].Words[0] != input.Profile.DeviceType ||
-		[2]uint16{input.Slices[2].Words[0], input.Slices[2].Words[1]} != input.Profile.ModelBuild ||
-		input.Slices[3].Words[0] != input.Profile.ProtocolVersion {
+	if input.Slices[2].Words[0] != input.Profile.DeviceType ||
+		[2]uint16{input.Slices[3].Words[0], input.Slices[3].Words[1]} != input.Profile.ModelBuild ||
+		input.Slices[4].Words[0] != input.Profile.ProtocolVersion {
 		return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity tuple disagrees with caller profile")
 	}
 	firmware, err := growattProtocolIIASCII(input.Slices[0].Words)
+	if err != nil {
+		return GrowattProtocolIIIdentityObservation{}, err
+	}
+	serial, err := growattProtocolIIASCII(input.Slices[1].Words)
 	if err != nil {
 		return GrowattProtocolIIIdentityObservation{}, err
 	}
@@ -93,9 +99,10 @@ func DecodeGrowattProtocolIIIdentity(input GrowattProtocolIIIdentityInput) (Grow
 		profile:         input.Profile,
 		slices:          cloneGrowattProtocolIIIdentitySlices(input.Slices),
 		firmwareText:    firmware,
-		deviceType:      input.Slices[1].Words[0],
-		modelBuild:      [2]uint16{input.Slices[2].Words[0], input.Slices[2].Words[1]},
-		protocolVersion: input.Slices[3].Words[0],
+		serialText:      serial,
+		deviceType:      input.Slices[2].Words[0],
+		modelBuild:      [2]uint16{input.Slices[3].Words[0], input.Slices[3].Words[1]},
+		protocolVersion: input.Slices[4].Words[0],
 	}, nil
 }
 

--- a/growatt_protocol_ii_identity.go
+++ b/growatt_protocol_ii_identity.go
@@ -58,8 +58,8 @@ func (o GrowattProtocolIIIdentityObservation) DeviceType() uint16      { return 
 func (o GrowattProtocolIIIdentityObservation) ModelBuild() [2]uint16   { return o.modelBuild }
 func (o GrowattProtocolIIIdentityObservation) ProtocolVersion() uint16 { return o.protocolVersion }
 
-// OutboundAllowed is permanently false: identity evidence cannot authorize a
-// control operation or another Modbus request.
+// OutboundAllowed is false for this identity observation. It cannot authorize
+// a separate Modbus request; an operation-specific contract owns that decision.
 func (GrowattProtocolIIIdentityObservation) OutboundAllowed() bool { return false }
 
 // DecodeGrowattProtocolIIIdentity validates the five individually bounded

--- a/growatt_protocol_ii_identity_test.go
+++ b/growatt_protocol_ii_identity_test.go
@@ -14,6 +14,9 @@ func TestGrowattProtocolIIIdentityAcceptsOnlyAnExplicitFC03FixtureProfile(t *tes
 	if got := observation.FirmwareText(); got != "FW-1" {
 		t.Fatalf("FirmwareText() = %q, want %q", got, "FW-1")
 	}
+	if got := observation.SerialText(); got != "SN-0001" {
+		t.Fatalf("SerialText() = %q, want %q", got, "SN-0001")
+	}
 	if got := observation.DeviceType(); got != 0x1234 {
 		t.Fatalf("DeviceType() = %#x, want %#x", got, uint16(0x1234))
 	}
@@ -66,9 +69,9 @@ func TestGrowattProtocolIIIdentityRejectsOutOfContractInputs(t *testing.T) {
 		"serial range": func(input *GrowattProtocolIIIdentityInput) {
 			input.Slices[0] = GrowattProtocolIIIdentitySlice{Offset: 23, Words: make([]uint16, 6)}
 		},
-		"wrong device type": func(input *GrowattProtocolIIIdentityInput) { input.Slices[1].Words[0] = 0xbeef },
-		"wrong model build": func(input *GrowattProtocolIIIdentityInput) { input.Slices[2].Words[1] = 0xbeef },
-		"wrong protocol":    func(input *GrowattProtocolIIIdentityInput) { input.Slices[3].Words[0] = 0x0123 },
+		"wrong device type": func(input *GrowattProtocolIIIdentityInput) { input.Slices[2].Words[0] = 0xbeef },
+		"wrong model build": func(input *GrowattProtocolIIIdentityInput) { input.Slices[3].Words[1] = 0xbeef },
+		"wrong protocol":    func(input *GrowattProtocolIIIdentityInput) { input.Slices[4].Words[0] = 0x0123 },
 		"interior nul": func(input *GrowattProtocolIIIdentityInput) {
 			input.Slices[0].Words[0] = 0x4600
 			input.Slices[0].Words[1] = 0x5731
@@ -97,6 +100,7 @@ func validGrowattProtocolIIIdentityInput() GrowattProtocolIIIdentityInput {
 		},
 		Slices: []GrowattProtocolIIIdentitySlice{
 			{Offset: 9, Words: []uint16{0x4657, 0x2d31, 0, 0, 0, 0}},
+			{Offset: 23, Words: []uint16{0x534e, 0x2d30, 0x3030, 0x3100, 0}},
 			{Offset: 43, Words: []uint16{0x1234}},
 			{Offset: 82, Words: []uint16{0x4d41, 0x5831}},
 			{Offset: 88, Words: []uint16{0x0124}},

--- a/growatt_protocol_ii_rtu_observer.go
+++ b/growatt_protocol_ii_rtu_observer.go
@@ -1,0 +1,61 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+var ErrGrowattProtocolIIIdentityRTUObserverInvalid = errors.New("growatt Protocol II identity RTU observer is invalid")
+
+// GrowattProtocolIIIdentityRTUObserverSession is an already-configured,
+// generic correlated FC03 boundary. It owns serial configuration, framing,
+// correlation, deadlines, and real-device access.
+type GrowattProtocolIIIdentityRTUObserverSession interface {
+	ReadHolding(context.Context, byte, modbus.ReadRegistersRequest) (modbus.ReadRegistersResponse, error)
+}
+
+// GrowattProtocolIIIdentityRTUObserver composes one caller-selected native
+// identity tuple from its five exact FC03 reads. It does not discover units,
+// retry, broadcast, configure a transport, or execute a control operation.
+type GrowattProtocolIIIdentityRTUObserver struct {
+	profile GrowattProtocolIIIdentityProfile
+	unitID  byte
+	session GrowattProtocolIIIdentityRTUObserverSession
+}
+
+func NewGrowattProtocolIIIdentityRTUObserver(
+	profile GrowattProtocolIIIdentityProfile,
+	unitID byte,
+	session GrowattProtocolIIIdentityRTUObserverSession,
+) (*GrowattProtocolIIIdentityRTUObserver, error) {
+	if session == nil || unitID == 0 || unitID > 247 || !validGrowattProtocolIIIdentityProfile(profile) {
+		return nil, ErrGrowattProtocolIIIdentityRTUObserverInvalid
+	}
+	return &GrowattProtocolIIIdentityRTUObserver{profile: profile, unitID: unitID, session: session}, nil
+}
+
+func (observer *GrowattProtocolIIIdentityRTUObserver) Observe(ctx context.Context) (GrowattProtocolIIIdentityObservation, error) {
+	if observer == nil || observer.session == nil || ctx == nil {
+		return GrowattProtocolIIIdentityObservation{}, ErrGrowattProtocolIIIdentityRTUObserverInvalid
+	}
+	requests := [...]struct{ offset, quantity uint16 }{{9, 6}, {23, 5}, {43, 1}, {82, 2}, {88, 1}}
+	slices := make([]GrowattProtocolIIIdentitySlice, 0, len(requests))
+	for _, spec := range requests {
+		request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadHoldingRegisters, spec.offset, spec.quantity)
+		if err != nil {
+			return GrowattProtocolIIIdentityObservation{}, fmt.Errorf("growatt Protocol II identity request: %w", err)
+		}
+		response, err := observer.session.ReadHolding(ctx, observer.unitID, request)
+		if err != nil {
+			return GrowattProtocolIIIdentityObservation{}, err
+		}
+		if response.Provenance != (modbus.ReadProvenance{Function: modbus.FunctionReadHoldingRegisters, Table: modbus.HoldingRegisters, Offset: spec.offset, Quantity: spec.quantity}) || len(response.Words) != int(spec.quantity) {
+			return GrowattProtocolIIIdentityObservation{}, ErrGrowattProtocolIIIdentityRTUObserverInvalid
+		}
+		slices = append(slices, GrowattProtocolIIIdentitySlice{Offset: spec.offset, Words: append([]uint16(nil), response.Words...)})
+	}
+	return DecodeGrowattProtocolIIIdentity(GrowattProtocolIIIdentityInput{UnitID: observer.unitID, Function: FunctionReadHoldingRegisters, Profile: observer.profile, Slices: slices})
+}

--- a/growatt_protocol_ii_rtu_observer_test.go
+++ b/growatt_protocol_ii_rtu_observer_test.go
@@ -52,7 +52,7 @@ func TestGrowattProtocolIIIdentityRTUObserverStopsOnFirstFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if observation, err := observer.Observe(context.Background()); err == nil || observation != (GrowattProtocolIIIdentityObservation{}) || len(session.calls) != 3 {
+	if observation, err := observer.Observe(context.Background()); err == nil || observation.UnitID() != 0 || len(observation.Slices()) != 0 || len(session.calls) != 3 {
 		t.Fatalf("observation/err/calls=%#v/%v/%#v", observation, err, session.calls)
 	}
 }

--- a/growatt_protocol_ii_rtu_observer_test.go
+++ b/growatt_protocol_ii_rtu_observer_test.go
@@ -1,0 +1,95 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestGrowattProtocolIIIdentityRTUObserverRetainsCompleteNativeTuple(t *testing.T) {
+	session := &growattProtocolIIIdentityRTUSessionFake{words: growattProtocolIIIdentityRTUWords(), failAt: -1}
+	profile := GrowattProtocolIIIdentityProfile{
+		Schema:          growattProtocolIIIdentitySchema,
+		Family:          "MAX",
+		DeviceType:      0x1234,
+		ModelBuild:      [2]uint16{0x4d41, 0x5831},
+		ProtocolVersion: 0x0124,
+	}
+	observer, err := NewGrowattProtocolIIIdentityRTUObserver(profile, 7, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observation, err := observer.Observe(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.UnitID() != 7 || observation.FirmwareText() != "FW-1" || observation.SerialText() != "SN-0001" ||
+		observation.DeviceType() != profile.DeviceType || observation.ModelBuild() != profile.ModelBuild ||
+		observation.ProtocolVersion() != profile.ProtocolVersion {
+		t.Fatalf("observation=%#v", observation)
+	}
+	wantCalls := [][2]uint16{{9, 6}, {23, 5}, {43, 1}, {82, 2}, {88, 1}}
+	if !reflect.DeepEqual(session.calls, wantCalls) {
+		t.Fatalf("calls=%#v want=%#v", session.calls, wantCalls)
+	}
+	if len(observation.Slices()) != len(wantCalls) || observation.Slices()[1].Offset != 23 ||
+		!reflect.DeepEqual(observation.Slices()[1].Words, session.words[23]) {
+		t.Fatalf("slices=%#v", observation.Slices())
+	}
+}
+
+func TestGrowattProtocolIIIdentityRTUObserverStopsOnFirstFailure(t *testing.T) {
+	session := &growattProtocolIIIdentityRTUSessionFake{words: growattProtocolIIIdentityRTUWords(), failAt: 2}
+	profile := GrowattProtocolIIIdentityProfile{
+		Schema: growattProtocolIIIdentitySchema, Family: "MAX", DeviceType: 0x1234,
+		ModelBuild: [2]uint16{0x4d41, 0x5831}, ProtocolVersion: 0x0124,
+	}
+	observer, err := NewGrowattProtocolIIIdentityRTUObserver(profile, 7, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation, err := observer.Observe(context.Background()); err == nil || observation != (GrowattProtocolIIIdentityObservation{}) || len(session.calls) != 3 {
+		t.Fatalf("observation/err/calls=%#v/%v/%#v", observation, err, session.calls)
+	}
+}
+
+type growattProtocolIIIdentityRTUSessionFake struct {
+	words  map[uint16][]uint16
+	calls  [][2]uint16
+	failAt int
+}
+
+func (session *growattProtocolIIIdentityRTUSessionFake) ReadHolding(
+	_ context.Context,
+	unitID byte,
+	request modbus.ReadRegistersRequest,
+) (modbus.ReadRegistersResponse, error) {
+	if unitID != 7 || request.Function() != modbus.FunctionReadHoldingRegisters {
+		return modbus.ReadRegistersResponse{}, errors.New("unexpected native request")
+	}
+	session.calls = append(session.calls, [2]uint16{request.Offset(), request.Quantity()})
+	if len(session.calls)-1 == session.failAt {
+		return modbus.ReadRegistersResponse{}, errors.New("correlated read failed")
+	}
+	words := session.words[request.Offset()]
+	pdu := make([]byte, 2+len(words)*2)
+	pdu[0], pdu[1] = byte(modbus.FunctionReadHoldingRegisters), byte(len(words)*2)
+	for index, word := range words {
+		pdu[2+index*2], pdu[3+index*2] = byte(word>>8), byte(word)
+	}
+	return modbus.DecodeReadRegistersResponse(request, pdu)
+}
+
+func growattProtocolIIIdentityRTUWords() map[uint16][]uint16 {
+	return map[uint16][]uint16{
+		9:  {0x4657, 0x2d31, 0, 0, 0, 0},
+		23: {0x534e, 0x2d30, 0x3030, 0x3100, 0},
+		43: {0x1234},
+		82: {0x4d41, 0x5831},
+		88: {0x0124},
+	}
+}


### PR DESCRIPTION
## Scope

Caller-supplied Growatt Protocol II v1.24 TL3-X native identity observer. It performs only the documented correlated FC03 tuple: `9/6`, `23/5`, `43/1`, `82/2`, `88/1`, preserves native serial/slices/unit, and fails without a partial observation.

No detector, scanner, retry, broadcast, transport configuration, generic control command, or runtime wiring is added. An exact operation-specific contract owns any future send decision.

## Evidence

- RED: `7fe6b255da16577f63b7bd794839ad33cfe52c4a` observed failing in GitHub CI run `32933497285`.
- Current HEAD: `66b66ad` (authority wording corrected after first GREEN).
- Local: `./scripts/ci_local.sh` passed (scope/mutation 14, gofmt, vet, build, race, lint).
- Docs gate: docs-modbus #102 merged at `8da26b6c84d114bb654a9b0cd859029a2611a8ed`.

## Risk

The observer is fake-session tested only; live Modbus I/O and control are out of scope.
