### PR TITLE
REG-GROWATT: retain native BMS observation context

### DIFF
--- a/growatt_bms_rs485_typed.go
+++ b/growatt_bms_rs485_typed.go
@@ -15,6 +15,7 @@ const (
 // of the exact 1xSxxP ESS V2.02 four-slice input. All unlisted words remain
 // available only through the separate opaque read-only observation.
 type GrowattBMSTypedReadOnlyStatus struct {
+	nativeObservation           *GrowattBMSReadOnlyObservation
 	Revision                    GrowattBMSRevisionTuple
 	MCUSoftwareVersion          string
 	GaugeVersion                string
@@ -36,6 +37,20 @@ type GrowattBMSTypedReadOnlyStatus struct {
 	FloatingPackVoltageVolts    float64
 	CumulativeChargeAmpHours    float64
 	CumulativeDischargeAmpHours float64
+}
+
+// NativeObservation returns the validated caller-selected unit, revision, and
+// exact FC03 slices that produced this typed status. The returned value owns
+// independent slice storage.
+func (status GrowattBMSTypedReadOnlyStatus) NativeObservation() GrowattBMSReadOnlyObservation {
+	if status.nativeObservation == nil {
+		return GrowattBMSReadOnlyObservation{}
+	}
+	return GrowattBMSReadOnlyObservation{
+		unitID:   status.nativeObservation.unitID,
+		revision: status.nativeObservation.revision,
+		slices:   cloneGrowattBMSReadOnlySlices(status.nativeObservation.slices),
+	}
 }
 
 // OutboundAllowed is permanently false. Typed observation data cannot
@@ -73,6 +88,7 @@ func DecodeGrowattBMSTypedReadOnlyStatus(input GrowattBMSReadOnlyInput) (Growatt
 		return GrowattBMSTypedReadOnlyStatus{}, fmt.Errorf("growatt BMS typed operating state is invalid")
 	}
 	return GrowattBMSTypedReadOnlyStatus{
+		nativeObservation:           &observation,
 		Revision:                    observation.Revision(),
 		MCUSoftwareVersion:          growattBMSByteVersion(identity[0]),
 		GaugeVersion:                growattBMSByteVersion(identity[1]),

--- a/growatt_bms_rs485_typed.go
+++ b/growatt_bms_rs485_typed.go
@@ -53,8 +53,8 @@ func (status GrowattBMSTypedReadOnlyStatus) NativeObservation() GrowattBMSReadOn
 	}
 }
 
-// OutboundAllowed is permanently false. Typed observation data cannot
-// authorize a BMS request or a control operation.
+// OutboundAllowed is false for this typed observation. A separate exact
+// operation contract owns any BMS request or control decision.
 func (GrowattBMSTypedReadOnlyStatus) OutboundAllowed() bool { return false }
 
 // DecodeGrowattBMSTypedReadOnlyStatus decodes only the field definitions

--- a/growatt_bms_rs485_typed_test.go
+++ b/growatt_bms_rs485_typed_test.go
@@ -39,6 +39,18 @@ func TestDecodeGrowattBMSTypedReadOnlyStatusRejectsInvalidTypedEncoding(t *testi
 	}
 }
 
+func TestGrowattBMSTypedStatusRetainsNativeObservation(t *testing.T) {
+	input := validGrowattBMSTypedReadOnlyInput()
+	status, err := DecodeGrowattBMSTypedReadOnlyStatus(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	native := status.NativeObservation()
+	if native.UnitID() != input.UnitID || native.Revision() != input.Revision || len(native.Slices()) != len(input.Slices) {
+		t.Fatalf("native observation = %#v", native)
+	}
+}
+
 func validGrowattBMSTypedReadOnlyInput() GrowattBMSReadOnlyInput {
 	input := validGrowattBMSReadOnlyInput()
 	input.Slices[0].Words = []uint16{0x0102, 0x0304, 0, 0, 0, 0, 0}

--- a/growatt_bms_rs485_typed_test.go
+++ b/growatt_bms_rs485_typed_test.go
@@ -49,6 +49,11 @@ func TestGrowattBMSTypedStatusRetainsNativeObservation(t *testing.T) {
 	if native.UnitID() != input.UnitID || native.Revision() != input.Revision || len(native.Slices()) != len(input.Slices) {
 		t.Fatalf("native observation = %#v", native)
 	}
+	nativeSlices := native.Slices()
+	nativeSlices[0].Words[0] ^= 0xffff
+	if status.NativeObservation().Slices()[0].Words[0] != input.Slices[0].Words[0] {
+		t.Fatal("native observation aliases typed status")
+	}
 }
 
 func validGrowattBMSTypedReadOnlyInput() GrowattBMSReadOnlyInput {


### PR DESCRIPTION
RED-only. The typed BMS result currently drops its validated unit/revision/slices before a consumer can project native protocol data. This PR restores a copy-safe native observation carrier; no command tuple, control operation, discovery, or I/O is added.