### PR TITLE
REG-TESLA: retain native FC101 and FC102 records

### DIFF
--- a/tesla_hsc_native.go
+++ b/tesla_hsc_native.go
@@ -1,0 +1,48 @@
+package modbusreg
+
+import (
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// TeslaHSCNativeRecord retains one bounded FC101 or FC102 native message.
+// Its payload is deliberately anonymous: numeric protobuf structure may be
+// inspected by callers without assigning field names or units.
+type TeslaHSCNativeRecord struct {
+	function modbus.PrivateFunctionCode
+	payload  []byte
+}
+
+// BuildTeslaHSCNativeRequest constructs a syntactically valid native FC101 or
+// FC102 request. It performs no exchange and accepts locally mutating message
+// shapes as opaque caller-supplied bytes.
+func BuildTeslaHSCNativeRequest(function modbus.PrivateFunctionCode, message []byte) (modbus.PrivateFunctionRequest, error) {
+	if function != teslaHSCFunction101 && function != teslaHSCFunction102 {
+		return modbus.PrivateFunctionRequest{}, fmt.Errorf("tesla HSC native function is unsupported")
+	}
+	if len(message) > 251 {
+		return modbus.PrivateFunctionRequest{}, fmt.Errorf("tesla HSC native message exceeds bound")
+	}
+	payload := append([]byte{byte(len(message))}, message...)
+	return modbus.NewPrivateFunctionRequest(function, payload)
+}
+
+// DecodeTeslaHSCNativeRecord retains a normal FC101 or FC102 terminal exactly
+// as received. Generic Modbus exception frames remain owned by transport.
+func DecodeTeslaHSCNativeRecord(version string, function modbus.PrivateFunctionCode, payload []byte) (TeslaHSCNativeRecord, error) {
+	if version != TeslaHSCCompatibilityV1 {
+		return TeslaHSCNativeRecord{}, fmt.Errorf("tesla HSC native compatibility is unsupported")
+	}
+	if function != teslaHSCFunction101 && function != teslaHSCFunction102 {
+		return TeslaHSCNativeRecord{}, fmt.Errorf("tesla HSC native function is unsupported")
+	}
+	response, err := DecodeTeslaHSCResponse(function, payload)
+	if err != nil {
+		return TeslaHSCNativeRecord{}, err
+	}
+	return TeslaHSCNativeRecord{function: function, payload: response.Payload()}, nil
+}
+
+func (record TeslaHSCNativeRecord) Function() modbus.PrivateFunctionCode { return record.function }
+func (record TeslaHSCNativeRecord) Payload() []byte                      { return append([]byte(nil), record.payload...) }

--- a/tesla_hsc_native_test.go
+++ b/tesla_hsc_native_test.go
@@ -3,6 +3,8 @@ package modbusreg
 import (
 	"bytes"
 	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
 )
 
 func TestTeslaHSCNativeRecordsRetainFC101AndFC102Payloads(t *testing.T) {
@@ -19,5 +21,44 @@ func TestTeslaHSCNativeRecordsRetainFC101AndFC102Payloads(t *testing.T) {
 	}
 	if got := record.Payload(); !bytes.Equal(got, []byte{0x0a, 0x00}) {
 		t.Fatalf("payload=%x", got)
+	}
+}
+
+func TestTeslaHSCNativeRequestAndResponseBounds(t *testing.T) {
+	maxRequest := bytes.Repeat([]byte{0xa5}, 251)
+	request, err := BuildTeslaHSCNativeRequest(teslaHSCFunction102, maxRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := request.Payload(); len(got) != 252 || got[0] != 251 || !bytes.Equal(got[1:], maxRequest) {
+		t.Fatalf("maximum request = %x", got)
+	}
+	if _, err := BuildTeslaHSCNativeRequest(teslaHSCFunction101, append(maxRequest, 0)); err == nil {
+		t.Fatal("accepted 252-byte native request message")
+	}
+	if request, err := BuildTeslaHSCNativeRequest(teslaHSCFunction101, nil); err != nil || !bytes.Equal(request.Payload(), []byte{0}) {
+		t.Fatalf("empty request = %x, %v", request.Payload(), err)
+	}
+
+	maximumResponse := bytes.Repeat([]byte{0x5a}, 252)
+	record, err := DecodeTeslaHSCNativeRecord(TeslaHSCCompatibilityV1, teslaHSCFunction101, maximumResponse)
+	if err != nil || !bytes.Equal(record.Payload(), maximumResponse) {
+		t.Fatalf("maximum response = %x, %v", record.Payload(), err)
+	}
+	if _, err := DecodeTeslaHSCNativeRecord(TeslaHSCCompatibilityV1, teslaHSCFunction102, append(maximumResponse, 0)); err == nil {
+		t.Fatal("accepted oversized native response")
+	}
+}
+
+func TestTeslaHSCNativeRecordRejectsUnsupportedAndExceptionFunctions(t *testing.T) {
+	if _, err := BuildTeslaHSCNativeRequest(teslaHSCFunction100, nil); err == nil {
+		t.Fatal("accepted FC100 as a native request")
+	}
+	if _, err := DecodeTeslaHSCNativeRecord("other", teslaHSCFunction101, nil); err == nil {
+		t.Fatal("accepted unsupported compatibility")
+	}
+	exceptionFunction := modbus.PrivateFunctionCode(byte(teslaHSCFunction101) | 0x80)
+	if _, err := DecodeTeslaHSCNativeRecord(TeslaHSCCompatibilityV1, exceptionFunction, []byte{4}); err == nil {
+		t.Fatal("decoded transport exception as native record")
 	}
 }

--- a/tesla_hsc_native_test.go
+++ b/tesla_hsc_native_test.go
@@ -1,0 +1,23 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTeslaHSCNativeRecordsRetainFC101AndFC102Payloads(t *testing.T) {
+	request, err := BuildTeslaHSCNativeRequest(teslaHSCFunction101, []byte{0x0a, 0x02, 0x08, 0x01})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := request.Payload(), []byte{0x04, 0x0a, 0x02, 0x08, 0x01}; !bytes.Equal(got, want) {
+		t.Fatalf("request=%x want=%x", got, want)
+	}
+	record, err := DecodeTeslaHSCNativeRecord(TeslaHSCCompatibilityV1, teslaHSCFunction102, []byte{0x0a, 0x00})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := record.Payload(); !bytes.Equal(got, []byte{0x0a, 0x00}) {
+		t.Fatalf("payload=%x", got)
+	}
+}


### PR DESCRIPTION
Closes #164.\n\nRED: prior public test-only branch revision established the missing native request/record API.\nGREEN: validates bounded FC101/FC102 length-prefixed request construction and retains normal response payload bytes in native records. No serial backend or real hardware I/O.