### PR TITLE
REG-TESLA: validate FC100 request matrix

### DIFF
--- a/tesla_fc100_request_matrix.go
+++ b/tesla_fc100_request_matrix.go
@@ -1,0 +1,190 @@
+package modbusreg
+
+import "fmt"
+
+// TeslaFC100RequestMatrix retains the complete caller-supplied request body
+// and its validated protobuf key sequence for one version-scoped operation.
+// The body is copied so later caller mutation cannot change the validation
+// result.
+type TeslaFC100RequestMatrix struct {
+	Operation   TeslaFC100Operation
+	RequestBody []byte
+	Entries     []TeslaFC100WireEntry
+}
+
+var teslaFC100EmptyRequestOperations = map[TeslaFC100Operation]struct{}{
+	TeslaFC100OperationCommonSystemInfo:      {},
+	TeslaFC100OperationCommonPerformUpdate:   {},
+	TeslaFC100OperationCommonFactoryReset:    {},
+	TeslaFC100OperationCommonClearUpdate:     {},
+	TeslaFC100OperationWCGetVitals:           {},
+	TeslaFC100OperationWCGetLifetimeStats:    {},
+	TeslaFC100OperationWCGetConfig:           {},
+	TeslaFC100OperationWCGetSystemInfo:       {},
+	TeslaFC100OperationWCGetLoadSharingState: {},
+	TeslaFC100OperationWCGetPPU:              {},
+	TeslaFC100OperationWCGetProvisional:      {},
+	TeslaFC100OperationWCGetAccessControl:    {},
+	TeslaFC100OperationWCGetRecentVehicles:   {},
+	TeslaFC100OperationWCGetOperational:      {},
+}
+
+// ValidateTeslaFC100RequestMatrix validates an operation's exact empty or
+// non-empty request form. Non-empty bodies retain all validated bytes and
+// preserve unknown protobuf fields through RequestBody and Entries.
+func ValidateTeslaFC100RequestMatrix(version string, operation TeslaFC100Operation, body []byte) (TeslaFC100RequestMatrix, error) {
+	if version != TeslaHSCFC100OperationCompatibilityV1 {
+		return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 request matrix compatibility is unsupported")
+	}
+	if _, ok := teslaFC100OperationSpecs[operation]; !ok {
+		return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 request matrix operation is unsupported")
+	}
+	if _, empty := teslaFC100EmptyRequestOperations[operation]; empty {
+		if len(body) != 0 {
+			return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 fixed request has a body")
+		}
+		return TeslaFC100RequestMatrix{Operation: operation}, nil
+	}
+	if len(body) == 0 {
+		return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 structured request body is empty")
+	}
+	entries, err := decodeTeslaFC100TEDAPIWireEntries(body)
+	if err != nil {
+		return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 structured request: %w", err)
+	}
+	switch operation {
+	case TeslaFC100OperationCommonWifiScan:
+		fields, err := decodeTeslaFC100RequestFields(body)
+		if err != nil {
+			return TeslaFC100RequestMatrix{}, err
+		}
+		if err := validateTeslaFC100WifiScanRequest(fields); err != nil {
+			return TeslaFC100RequestMatrix{}, err
+		}
+	case TeslaFC100OperationCommonConfigureWifi:
+		fields, err := decodeTeslaFC100RequestFields(body)
+		if err != nil {
+			return TeslaFC100RequestMatrix{}, err
+		}
+		if err := validateTeslaFC100ConfigureWifiRequest(fields); err != nil {
+			return TeslaFC100RequestMatrix{}, err
+		}
+	}
+	return TeslaFC100RequestMatrix{
+		Operation:   operation,
+		RequestBody: append([]byte(nil), body...),
+		Entries:     append([]TeslaFC100WireEntry(nil), entries...),
+	}, nil
+}
+
+// TeslaFC100DeterministicApplicationStatus identifies operations with a
+// version-scoped normal FC100 application result instead of a terminal body.
+func TeslaFC100DeterministicApplicationStatus(operation TeslaFC100Operation) (uint64, bool) {
+	if operation == TeslaFC100OperationWCPushPPUAuthorization {
+		return 7, true
+	}
+	return 0, false
+}
+
+type teslaFC100RequestField struct {
+	number   uint64
+	wireType uint8
+	value    []byte
+}
+
+func decodeTeslaFC100RequestFields(body []byte) ([]teslaFC100RequestField, error) {
+	fields := make([]teslaFC100RequestField, 0)
+	for offset := 0; offset < len(body); {
+		field, consumed, err := decodeTeslaFC100RequestField(body[offset:])
+		if err != nil {
+			return nil, fmt.Errorf("tesla FC100 structured request field: %w", err)
+		}
+		fields = append(fields, field)
+		offset += consumed
+	}
+	return fields, nil
+}
+
+func decodeTeslaFC100RequestField(input []byte) (teslaFC100RequestField, int, error) {
+	key, keyWidth, err := decodeTeslaFC100Varint(input)
+	if err != nil {
+		return teslaFC100RequestField{}, 0, err
+	}
+	field := key >> 3
+	wireType := uint8(key & 0x07)
+	if field == 0 || wireType > 5 {
+		return teslaFC100RequestField{}, 0, fmt.Errorf("protobuf key is invalid")
+	}
+	offset := keyWidth
+	result := teslaFC100RequestField{number: field, wireType: wireType}
+	switch wireType {
+	case 0:
+		_, width, err := decodeTeslaFC100Varint(input[offset:])
+		if err != nil {
+			return teslaFC100RequestField{}, 0, err
+		}
+		offset += width
+	case 1:
+		if len(input)-offset < 8 {
+			return teslaFC100RequestField{}, 0, fmt.Errorf("fixed64 value is truncated")
+		}
+		offset += 8
+	case 2:
+		length, width, err := decodeTeslaFC100Varint(input[offset:])
+		if err != nil || length > uint64(len(input)-offset-width) {
+			return teslaFC100RequestField{}, 0, fmt.Errorf("length-delimited value is truncated")
+		}
+		offset += width
+		result.value = append([]byte(nil), input[offset:offset+int(length)]...)
+		offset += int(length)
+	case 3, 4:
+		return teslaFC100RequestField{}, 0, fmt.Errorf("groups are not accepted in a structured request")
+	case 5:
+		if len(input)-offset < 4 {
+			return teslaFC100RequestField{}, 0, fmt.Errorf("fixed32 value is truncated")
+		}
+		offset += 4
+	}
+	return result, offset, nil
+}
+
+func validateTeslaFC100WifiScanRequest(fields []teslaFC100RequestField) error {
+	known := false
+	for _, field := range fields {
+		if field.number >= 1 && field.number <= 3 {
+			if field.wireType != 0 {
+				return fmt.Errorf("tesla FC100 Wi-Fi scan field %d has invalid wire type", field.number)
+			}
+			known = true
+		}
+	}
+	if !known {
+		return fmt.Errorf("tesla FC100 Wi-Fi scan lacks a known structural field")
+	}
+	return nil
+}
+
+func validateTeslaFC100ConfigureWifiRequest(fields []teslaFC100RequestField) error {
+	known := false
+	for _, field := range fields {
+		switch field.number {
+		case 1:
+			if field.wireType != 0 {
+				return fmt.Errorf("tesla FC100 configure Wi-Fi enabled has invalid wire type")
+			}
+			known = true
+		case 2:
+			if field.wireType != 2 {
+				return fmt.Errorf("tesla FC100 configure Wi-Fi config has invalid wire type")
+			}
+			if _, err := decodeTeslaFC100RequestFields(field.value); err != nil {
+				return fmt.Errorf("tesla FC100 configure Wi-Fi config: %w", err)
+			}
+			known = true
+		}
+	}
+	if !known {
+		return fmt.Errorf("tesla FC100 configure Wi-Fi lacks a known structural field")
+	}
+	return nil
+}

--- a/tesla_fc100_request_matrix.go
+++ b/tesla_fc100_request_matrix.go
@@ -39,6 +39,9 @@ func ValidateTeslaFC100RequestMatrix(version string, operation TeslaFC100Operati
 	if _, ok := teslaFC100OperationSpecs[operation]; !ok {
 		return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 request matrix operation is unsupported")
 	}
+	if _, err := BuildTeslaFC100OperationRequest(version, operation, body); err != nil {
+		return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 request matrix bound: %w", err)
+	}
 	if _, empty := teslaFC100EmptyRequestOperations[operation]; empty {
 		if len(body) != 0 {
 			return TeslaFC100RequestMatrix{}, fmt.Errorf("tesla FC100 fixed request has a body")
@@ -137,8 +140,14 @@ func decodeTeslaFC100RequestField(input []byte) (teslaFC100RequestField, int, er
 		offset += width
 		result.value = append([]byte(nil), input[offset:offset+int(length)]...)
 		offset += int(length)
-	case 3, 4:
-		return teslaFC100RequestField{}, 0, fmt.Errorf("groups are not accepted in a structured request")
+	case 3:
+		width, err := skipTeslaFC100RequestGroup(input[offset:], field)
+		if err != nil {
+			return teslaFC100RequestField{}, 0, err
+		}
+		offset += width
+	case 4:
+		return teslaFC100RequestField{}, 0, fmt.Errorf("unexpected protobuf end group")
 	case 5:
 		if len(input)-offset < 4 {
 			return teslaFC100RequestField{}, 0, fmt.Errorf("fixed32 value is truncated")
@@ -146,6 +155,33 @@ func decodeTeslaFC100RequestField(input []byte) (teslaFC100RequestField, int, er
 		offset += 4
 	}
 	return result, offset, nil
+}
+
+func skipTeslaFC100RequestGroup(input []byte, groupField uint64) (int, error) {
+	offset := 0
+	for offset < len(input) {
+		key, keyWidth, err := decodeTeslaFC100Varint(input[offset:])
+		if err != nil {
+			return 0, err
+		}
+		field := key >> 3
+		wireType := uint8(key & 0x07)
+		if field == 0 || wireType > 5 {
+			return 0, fmt.Errorf("protobuf group key is invalid")
+		}
+		if wireType == 4 {
+			if field != groupField {
+				return 0, fmt.Errorf("protobuf group boundary is invalid")
+			}
+			return offset + keyWidth, nil
+		}
+		_, width, err := decodeTeslaFC100RequestField(input[offset:])
+		if err != nil {
+			return 0, err
+		}
+		offset += width
+	}
+	return 0, fmt.Errorf("protobuf group boundary is truncated")
 }
 
 func validateTeslaFC100WifiScanRequest(fields []teslaFC100RequestField) error {

--- a/tesla_fc100_request_matrix_test.go
+++ b/tesla_fc100_request_matrix_test.go
@@ -33,8 +33,10 @@ func TestTeslaFC100RequestMatrixValidatesStructuredAndOpaqueBodies(t *testing.T)
 		{"C12 enabled", TeslaFC100OperationCommonConfigureWifi, []byte{0x08, 0x01}, false},
 		{"C12 wifi string", TeslaFC100OperationCommonConfigureWifi, []byte{0x12, 0x03, 0x0a, 0x01, 'x'}, false},
 		{"C12 malformed nested", TeslaFC100OperationCommonConfigureWifi, []byte{0x12, 0x01, 0x0a}, true},
+		{"C12 unknown group retained", TeslaFC100OperationCommonConfigureWifi, []byte{0x08, 0x01, 0x1b, 0x20, 0x01, 0x1c}, false},
 		{"opaque malformed", TeslaFC100OperationWCConfigureSettings, []byte{0x80}, true},
 		{"opaque unknown retained", TeslaFC100OperationWCConfigureSettings, []byte{0x7a, 0x02, 0xaa, 0xbb}, false},
+		{"opaque over FC100 bound", TeslaFC100OperationWCConfigureSettings, bytes.Repeat([]byte{0x08, 0x01}, 126), true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			matrix, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, test.operation, test.body)

--- a/tesla_fc100_request_matrix_test.go
+++ b/tesla_fc100_request_matrix_test.go
@@ -1,9 +1,49 @@
 package modbusreg
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestTeslaFC100RequestMatrixRecognizesFixedAndStructuredRequests(t *testing.T) {
-	if _, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, TeslaFC100OperationWCGetConfig, nil); err != nil { t.Fatal(err) }
-	if _, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, TeslaFC100OperationCommonWifiScan, nil); err == nil { t.Fatal("empty C10 accepted") }
-	if status, ok := TeslaFC100DeterministicApplicationStatus(TeslaFC100OperationWCPushPPUAuthorization); !ok || status != 7 { t.Fatalf("W35 status = %d, %v", status, ok) }
+	matrix, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, TeslaFC100OperationWCGetConfig, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matrix.RequestBody != nil || len(matrix.Entries) != 0 {
+		t.Fatalf("fixed matrix = %#v", matrix)
+	}
+	if _, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, TeslaFC100OperationCommonWifiScan, nil); err == nil {
+		t.Fatal("empty C10 accepted")
+	}
+	if status, ok := TeslaFC100DeterministicApplicationStatus(TeslaFC100OperationWCPushPPUAuthorization); !ok || status != 7 {
+		t.Fatalf("W35 status = %d, %v", status, ok)
+	}
+}
+
+func TestTeslaFC100RequestMatrixValidatesStructuredAndOpaqueBodies(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		operation TeslaFC100Operation
+		body      []byte
+		wantError bool
+	}{
+		{"C10 known varint", TeslaFC100OperationCommonWifiScan, []byte{0x08, 0x01}, false},
+		{"C10 wrong wire", TeslaFC100OperationCommonWifiScan, []byte{0x0a, 0x00}, true},
+		{"C12 enabled", TeslaFC100OperationCommonConfigureWifi, []byte{0x08, 0x01}, false},
+		{"C12 wifi string", TeslaFC100OperationCommonConfigureWifi, []byte{0x12, 0x03, 0x0a, 0x01, 'x'}, false},
+		{"C12 malformed nested", TeslaFC100OperationCommonConfigureWifi, []byte{0x12, 0x01, 0x0a}, true},
+		{"opaque malformed", TeslaFC100OperationWCConfigureSettings, []byte{0x80}, true},
+		{"opaque unknown retained", TeslaFC100OperationWCConfigureSettings, []byte{0x7a, 0x02, 0xaa, 0xbb}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			matrix, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, test.operation, test.body)
+			if (err != nil) != test.wantError {
+				t.Fatalf("ValidateTeslaFC100RequestMatrix() error = %v, wantError %v", err, test.wantError)
+			}
+			if err == nil && !bytes.Equal(matrix.RequestBody, test.body) {
+				t.Fatalf("body = %x, want %x", matrix.RequestBody, test.body)
+			}
+		})
+	}
 }

--- a/tesla_fc100_request_matrix_test.go
+++ b/tesla_fc100_request_matrix_test.go
@@ -1,0 +1,9 @@
+package modbusreg
+
+import "testing"
+
+func TestTeslaFC100RequestMatrixRecognizesFixedAndStructuredRequests(t *testing.T) {
+	if _, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, TeslaFC100OperationWCGetConfig, nil); err != nil { t.Fatal(err) }
+	if _, err := ValidateTeslaFC100RequestMatrix(TeslaHSCFC100OperationCompatibilityV1, TeslaFC100OperationCommonWifiScan, nil); err == nil { t.Fatal("empty C10 accepted") }
+	if status, ok := TeslaFC100DeterministicApplicationStatus(TeslaFC100OperationWCPushPPUAuthorization); !ok || status != 7 { t.Fatalf("W35 status = %d, %v", status, ok) }
+}


### PR DESCRIPTION
Closes #167.\n\nRED: d203c4f4a7b7d7d1f1a2c4416fc0cdc09dbb75a4.\nGREEN: validates exact empty requests, non-empty structural requests, bounded protobuf wire forms, native unknown-body retention, and the deterministic WC authorization status.