### PR TITLE
REG-TESLA: add legacy Wall Connector RS-485 native codec

### DIFF
--- a/tesla_legacy_wall_connector.go
+++ b/tesla_legacy_wall_connector.go
@@ -92,7 +92,7 @@ type TeslaLegacyWallConnectorFrame struct {
 func DecodeTeslaLegacyWallConnectorFrame(
 	wire []byte,
 ) (TeslaLegacyWallConnectorFrame, error) {
-	if len(wire) < 5 || len(wire) > maxTeslaLegacyWallConnectorMessage+2 {
+	if len(wire) < 5 || len(wire) > maxTeslaLegacyWallConnectorMessage*2+2 {
 		return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector frame size is invalid")
 	}
 	if wire[0] != 0xc0 || wire[len(wire)-1] != 0xc0 {

--- a/tesla_legacy_wall_connector.go
+++ b/tesla_legacy_wall_connector.go
@@ -1,0 +1,258 @@
+package modbusreg
+
+import "fmt"
+
+const maxTeslaLegacyWallConnectorMessage = 256
+
+// TeslaLegacyWallConnectorCompatibility identifies the evidence tier selected
+// for the legacy, pre-Gen3 Wall Connector RS-485 family.
+type TeslaLegacyWallConnectorCompatibility string
+
+const (
+	TeslaLegacyWallConnectorBuildConfirmed   TeslaLegacyWallConnectorCompatibility = "build_confirmed"
+	TeslaLegacyWallConnectorFamilyCompatible TeslaLegacyWallConnectorCompatibility = "family_compatible"
+	TeslaLegacyWallConnectorUnknown          TeslaLegacyWallConnectorCompatibility = "unknown"
+)
+
+// TeslaLegacyWallConnectorGeneration records the deliberately non-exclusive
+// legacy generation classification.
+type TeslaLegacyWallConnectorGeneration string
+
+const TeslaLegacyWallConnectorGenerationCandidate TeslaLegacyWallConnectorGeneration = "pre_gen3_candidate"
+
+// TeslaLegacyWallConnectorProfileConfig selects a legacy protocol tier without
+// treating a Tesla name or Gen3 profile as compatibility evidence.
+type TeslaLegacyWallConnectorProfileConfig struct {
+	Enabled       bool
+	Compatibility TeslaLegacyWallConnectorCompatibility
+}
+
+// TeslaLegacyWallConnectorProfile is independent from the Gen3 HSC profile.
+type TeslaLegacyWallConnectorProfile struct {
+	config TeslaLegacyWallConnectorProfileConfig
+}
+
+// NewTeslaLegacyWallConnectorProfile validates the explicit legacy selection.
+func NewTeslaLegacyWallConnectorProfile(
+	config TeslaLegacyWallConnectorProfileConfig,
+) (TeslaLegacyWallConnectorProfile, error) {
+	switch config.Compatibility {
+	case TeslaLegacyWallConnectorBuildConfirmed,
+		TeslaLegacyWallConnectorFamilyCompatible,
+		TeslaLegacyWallConnectorUnknown:
+	default:
+		return TeslaLegacyWallConnectorProfile{}, fmt.Errorf("tesla legacy Wall Connector compatibility is invalid")
+	}
+	return TeslaLegacyWallConnectorProfile{config: config}, nil
+}
+
+// Generation returns the non-exclusive legacy generation classification.
+func (TeslaLegacyWallConnectorProfile) Generation() TeslaLegacyWallConnectorGeneration {
+	return TeslaLegacyWallConnectorGenerationCandidate
+}
+
+// Compatibility returns the immutable evidence tier selected for this profile.
+func (profile TeslaLegacyWallConnectorProfile) Compatibility() TeslaLegacyWallConnectorCompatibility {
+	return profile.config.Compatibility
+}
+
+// TeslaLegacyDirection identifies an offline request or response record.
+type TeslaLegacyDirection string
+
+const (
+	TeslaLegacyWallConnectorRequest  TeslaLegacyDirection = "request"
+	TeslaLegacyWallConnectorResponse TeslaLegacyDirection = "response"
+)
+
+// TeslaLegacyCommand is the two-byte legacy command identity.
+type TeslaLegacyCommand struct {
+	Prefix byte
+	Opcode byte
+}
+
+// TeslaLegacyOperation names only the documented link and heartbeat forms.
+type TeslaLegacyOperation string
+
+const (
+	TeslaLegacyOperationUnknown            TeslaLegacyOperation = "unknown"
+	TeslaLegacyOperationPrimaryDiscovery   TeslaLegacyOperation = "primary_discovery"
+	TeslaLegacyOperationSecondaryDiscovery TeslaLegacyOperation = "secondary_discovery"
+	TeslaLegacyOperationPrimaryHeartbeat   TeslaLegacyOperation = "primary_heartbeat"
+	TeslaLegacyOperationSecondaryHeartbeat TeslaLegacyOperation = "secondary_heartbeat"
+)
+
+// TeslaLegacyWallConnectorFrame is a validated, unescaped legacy frame.
+type TeslaLegacyWallConnectorFrame struct {
+	command TeslaLegacyCommand
+	payload []byte
+}
+
+// DecodeTeslaLegacyWallConnectorFrame validates one complete SLIP-like wire
+// frame. It neither opens a serial transport nor interprets unknown payloads.
+func DecodeTeslaLegacyWallConnectorFrame(
+	wire []byte,
+) (TeslaLegacyWallConnectorFrame, error) {
+	if len(wire) < 5 || len(wire) > maxTeslaLegacyWallConnectorMessage+2 {
+		return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector frame size is invalid")
+	}
+	if wire[0] != 0xc0 || wire[len(wire)-1] != 0xc0 {
+		return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector frame delimiters are invalid")
+	}
+	message := make([]byte, 0, len(wire)-2)
+	for index := 1; index < len(wire)-1; index++ {
+		value := wire[index]
+		switch value {
+		case 0xc0:
+			return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector frame contains an unescaped delimiter")
+		case 0xdb:
+			if index+1 >= len(wire)-1 {
+				return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector frame escape is incomplete")
+			}
+			index++
+			switch wire[index] {
+			case 0xdc:
+				message = append(message, 0xc0)
+			case 0xdd:
+				message = append(message, 0xdb)
+			default:
+				return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector frame escape is invalid")
+			}
+		default:
+			message = append(message, value)
+		}
+	}
+	if len(message) < 3 || len(message) > maxTeslaLegacyWallConnectorMessage {
+		return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector message size is invalid")
+	}
+	if message[len(message)-1] != teslaLegacyWallConnectorChecksum(message[:len(message)-1]) {
+		return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector checksum is invalid")
+	}
+	command := TeslaLegacyCommand{Prefix: message[0], Opcode: message[1]}
+	if !teslaLegacyCommandPrefix(command.Prefix) {
+		return TeslaLegacyWallConnectorFrame{}, fmt.Errorf("tesla legacy Wall Connector command prefix is invalid")
+	}
+	return TeslaLegacyWallConnectorFrame{
+		command: command,
+		payload: append([]byte(nil), message[2:len(message)-1]...),
+	}, nil
+}
+
+// EncodeTeslaLegacyWallConnectorFrame constructs one bounded legacy wire frame
+// for offline testing or a future separately authorized transport dispatch.
+func EncodeTeslaLegacyWallConnectorFrame(command TeslaLegacyCommand, payload []byte) ([]byte, error) {
+	if !teslaLegacyCommandPrefix(command.Prefix) {
+		return nil, fmt.Errorf("tesla legacy Wall Connector command prefix is invalid")
+	}
+	if len(payload)+3 > maxTeslaLegacyWallConnectorMessage {
+		return nil, fmt.Errorf("tesla legacy Wall Connector message exceeds bound")
+	}
+	message := make([]byte, 0, len(payload)+3)
+	message = append(message, command.Prefix, command.Opcode)
+	message = append(message, payload...)
+	message = append(message, teslaLegacyWallConnectorChecksum(message))
+	wire := make([]byte, 0, len(message)*2+2)
+	wire = append(wire, 0xc0)
+	for _, value := range message {
+		switch value {
+		case 0xc0:
+			wire = append(wire, 0xdb, 0xdc)
+		case 0xdb:
+			wire = append(wire, 0xdb, 0xdd)
+		default:
+			wire = append(wire, value)
+		}
+	}
+	wire = append(wire, 0xc0)
+	return wire, nil
+}
+
+func teslaLegacyWallConnectorChecksum(message []byte) byte {
+	var sum byte
+	for _, value := range message[1:] {
+		sum += value
+	}
+	return sum
+}
+
+func teslaLegacyCommandPrefix(prefix byte) bool {
+	return prefix == 0xfb || prefix == 0xfc || prefix == 0xfd
+}
+
+// Command returns the two-byte native command identity.
+func (frame TeslaLegacyWallConnectorFrame) Command() TeslaLegacyCommand {
+	return frame.command
+}
+
+// Payload returns an independent copy of the complete native payload.
+func (frame TeslaLegacyWallConnectorFrame) Payload() []byte {
+	return append([]byte(nil), frame.payload...)
+}
+
+// Operation returns a name only for the documented link and heartbeat forms.
+func (frame TeslaLegacyWallConnectorFrame) Operation() TeslaLegacyOperation {
+	switch frame.command {
+	case TeslaLegacyCommand{Prefix: 0xfc, Opcode: 0xe1}:
+		return TeslaLegacyOperationPrimaryDiscovery
+	case TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe2}, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe2}:
+		return TeslaLegacyOperationSecondaryDiscovery
+	case TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}:
+		return TeslaLegacyOperationPrimaryHeartbeat
+	case TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}:
+		return TeslaLegacyOperationSecondaryHeartbeat
+	default:
+		return TeslaLegacyOperationUnknown
+	}
+}
+
+// TeslaLegacyWallConnectorRecord is a native offline request or response
+// record. It intentionally keeps its payload rather than reducing it to a
+// digest or inferred field set.
+type TeslaLegacyWallConnectorRecord struct {
+	compatibility TeslaLegacyWallConnectorCompatibility
+	direction     TeslaLegacyDirection
+	command       TeslaLegacyCommand
+	operation     TeslaLegacyOperation
+	payload       []byte
+}
+
+// NativeRecord retains one validated legacy frame under the selected profile.
+func (profile TeslaLegacyWallConnectorProfile) NativeRecord(
+	direction TeslaLegacyDirection,
+	frame TeslaLegacyWallConnectorFrame,
+) (TeslaLegacyWallConnectorRecord, error) {
+	if !profile.config.Enabled {
+		return TeslaLegacyWallConnectorRecord{}, fmt.Errorf("tesla legacy Wall Connector profile is disabled")
+	}
+	if direction != TeslaLegacyWallConnectorRequest && direction != TeslaLegacyWallConnectorResponse {
+		return TeslaLegacyWallConnectorRecord{}, fmt.Errorf("tesla legacy Wall Connector direction is invalid")
+	}
+	return TeslaLegacyWallConnectorRecord{
+		compatibility: profile.Compatibility(), direction: direction, command: frame.Command(),
+		operation: frame.Operation(), payload: frame.Payload(),
+	}, nil
+}
+
+// Compatibility returns the selected legacy evidence tier.
+func (record TeslaLegacyWallConnectorRecord) Compatibility() TeslaLegacyWallConnectorCompatibility {
+	return record.compatibility
+}
+
+// Direction returns whether the native record is a request or response.
+func (record TeslaLegacyWallConnectorRecord) Direction() TeslaLegacyDirection {
+	return record.direction
+}
+
+// Command returns the complete native command identity.
+func (record TeslaLegacyWallConnectorRecord) Command() TeslaLegacyCommand {
+	return record.command
+}
+
+// Operation returns a named operation only when its command form is documented.
+func (record TeslaLegacyWallConnectorRecord) Operation() TeslaLegacyOperation {
+	return record.operation
+}
+
+// Payload returns an independent copy of the exact native payload.
+func (record TeslaLegacyWallConnectorRecord) Payload() []byte {
+	return append([]byte(nil), record.payload...)
+}

--- a/tesla_legacy_wall_connector_test.go
+++ b/tesla_legacy_wall_connector_test.go
@@ -90,3 +90,23 @@ func TestTeslaLegacyWallConnectorRejectsMalformedFramesBeforeReplay(t *testing.T
 		}
 	}
 }
+
+func TestTeslaLegacyWallConnectorRoundTripsMaximumEscapedMessage(t *testing.T) {
+	payload := bytes.Repeat([]byte{0xc0}, maxTeslaLegacyWallConnectorMessage-3)
+	wire, err := EncodeTeslaLegacyWallConnectorFrame(
+		TeslaLegacyCommand{Prefix: 0xfc, Opcode: 0xa1}, payload,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(wire) <= maxTeslaLegacyWallConnectorMessage+2 {
+		t.Fatalf("wire length=%d does not exercise escape expansion", len(wire))
+	}
+	frame, err := DecodeTeslaLegacyWallConnectorFrame(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(frame.Payload(), payload) {
+		t.Fatalf("payload=%x want=%x", frame.Payload(), payload)
+	}
+}

--- a/tesla_legacy_wall_connector_test.go
+++ b/tesla_legacy_wall_connector_test.go
@@ -1,0 +1,61 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestTeslaLegacyWallConnectorCodecPreservesNativeFrames(t *testing.T) {
+	profile, err := NewTeslaLegacyWallConnectorProfile(TeslaLegacyWallConnectorProfileConfig{
+		Enabled: true, Compatibility: TeslaLegacyWallConnectorFamilyCompatible,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.Generation() != TeslaLegacyWallConnectorGenerationCandidate {
+		t.Fatalf("generation=%q", profile.Generation())
+	}
+
+	request, err := EncodeTeslaLegacyWallConnectorFrame(
+		TeslaLegacyCommand{Prefix: 0xfc, Opcode: 0xa1}, []byte{0xc0, 0xdb},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRequest := []byte{0xc0, 0xfc, 0xa1, 0xdb, 0xdc, 0xdb, 0xdd, 0x3c, 0xc0}
+	if !bytes.Equal(request, wantRequest) {
+		t.Fatalf("request=%x want=%x", request, wantRequest)
+	}
+
+	decoded, err := DecodeTeslaLegacyWallConnectorFrame(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Command() != (TeslaLegacyCommand{Prefix: 0xfc, Opcode: 0xa1}) ||
+		!bytes.Equal(decoded.Payload(), []byte{0xc0, 0xdb}) ||
+		decoded.Operation() != TeslaLegacyOperationUnknown {
+		t.Fatalf("decoded=%#v", decoded)
+	}
+
+	record, err := profile.NativeRecord(TeslaLegacyWallConnectorResponse, decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Compatibility() != TeslaLegacyWallConnectorFamilyCompatible ||
+		!bytes.Equal(record.Payload(), []byte{0xc0, 0xdb}) {
+		t.Fatalf("record=%#v", record)
+	}
+}
+
+func TestTeslaLegacyWallConnectorRejectsMalformedFramesBeforeReplay(t *testing.T) {
+	for _, wire := range [][]byte{
+		{0xc0, 0xfb, 0xe0, 0x01, 0xe0, 0xc0}, // bad checksum
+		{0xc0, 0xfb, 0xe0, 0xdb, 0xc0},       // incomplete escape
+		{0xfb, 0xe0, 0x01, 0xe1, 0xc0},       // missing opening delimiter
+	} {
+		if _, err := DecodeTeslaLegacyWallConnectorFrame(wire); err == nil {
+			t.Fatalf("wire=%x accepted", wire)
+		}
+	}
+}
+

--- a/tesla_legacy_wall_connector_test.go
+++ b/tesla_legacy_wall_connector_test.go
@@ -45,6 +45,38 @@ func TestTeslaLegacyWallConnectorCodecPreservesNativeFrames(t *testing.T) {
 		!bytes.Equal(record.Payload(), []byte{0xc0, 0xdb}) {
 		t.Fatalf("record=%#v", record)
 	}
+	payload := record.Payload()
+	payload[0] = 0
+	if !bytes.Equal(record.Payload(), []byte{0xc0, 0xdb}) {
+		t.Fatalf("record payload was not copied: %x", record.Payload())
+	}
+}
+
+func TestTeslaLegacyWallConnectorNamesOnlyDocumentedLinkCommands(t *testing.T) {
+	tests := []struct {
+		command TeslaLegacyCommand
+		want    TeslaLegacyOperation
+	}{
+		{TeslaLegacyCommand{Prefix: 0xfc, Opcode: 0xe1}, TeslaLegacyOperationPrimaryDiscovery},
+		{TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe2}, TeslaLegacyOperationSecondaryDiscovery},
+		{TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe2}, TeslaLegacyOperationSecondaryDiscovery},
+		{TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, TeslaLegacyOperationPrimaryHeartbeat},
+		{TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, TeslaLegacyOperationSecondaryHeartbeat},
+		{TeslaLegacyCommand{Prefix: 0xfc, Opcode: 0xa3}, TeslaLegacyOperationUnknown},
+	}
+	for _, test := range tests {
+		wire, err := EncodeTeslaLegacyWallConnectorFrame(test.command, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		frame, err := DecodeTeslaLegacyWallConnectorFrame(wire)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if frame.Operation() != test.want {
+			t.Fatalf("command=%#v operation=%q want=%q", test.command, frame.Operation(), test.want)
+		}
+	}
 }
 
 func TestTeslaLegacyWallConnectorRejectsMalformedFramesBeforeReplay(t *testing.T) {
@@ -58,4 +90,3 @@ func TestTeslaLegacyWallConnectorRejectsMalformedFramesBeforeReplay(t *testing.T
 		}
 	}
 }
-


### PR DESCRIPTION
Closes #173.

## RED checkpoint
`go test ./...` fails because the standalone legacy Wall Connector codec/profile symbols do not exist.

The target is the SLIP-like legacy RS-485 family only; it neither imports nor falls back to Gen3 HSC/FC100–102. GREEN will retain native command/payload bytes and provide offline encode/decode/replay support only.

Docs gate: Project-Helianthus/helianthus-docs-modbus#120 merged. No serial I/O, live transmit, credentials, deployment, gateway, or semantic promotion.