### PR TITLE
REG-TESLA: qualify Gen3 HSC version capability profiles

### DIFF
--- a/tesla_gen3_hsc_profile.go
+++ b/tesla_gen3_hsc_profile.go
@@ -1,0 +1,53 @@
+package modbusreg
+
+import "strings"
+
+// TeslaGen3HSCVersionDisposition is the evidence state of a Gen3 version.
+type TeslaGen3HSCVersionDisposition string
+
+const (
+	TeslaGen3HSCVersionKnownObservation    TeslaGen3HSCVersionDisposition = "known_observation"
+	TeslaGen3HSCVersionCompatibleCandidate TeslaGen3HSCVersionDisposition = "compatible_candidate"
+	TeslaGen3HSCVersionUnknown             TeslaGen3HSCVersionDisposition = "unknown"
+)
+
+// TeslaGen3HSCProfileConfig declares independently evaluated Gen3 predicates.
+type TeslaGen3HSCProfileConfig struct {
+	Enabled                bool
+	Version                string
+	ActivationCapable      bool
+	PrivateFunctionCapable bool
+	OperationCapable       bool
+}
+
+// TeslaGen3HSCProfile never derives a capability from a version label alone.
+type TeslaGen3HSCProfile struct {
+	config      TeslaGen3HSCProfileConfig
+	disposition TeslaGen3HSCVersionDisposition
+}
+
+// NewTeslaGen3HSCProfile creates a distinct Gen3 capability profile.
+func NewTeslaGen3HSCProfile(config TeslaGen3HSCProfileConfig) (TeslaGen3HSCProfile, error) {
+	disposition := TeslaGen3HSCVersionUnknown
+	if strings.TrimSpace(config.Version) != "" {
+		switch config.Version {
+		case "24.28.3", "24.44.3":
+			disposition = TeslaGen3HSCVersionKnownObservation
+		default:
+			disposition = TeslaGen3HSCVersionCompatibleCandidate
+		}
+	}
+	return TeslaGen3HSCProfile{config: config, disposition: disposition}, nil
+}
+
+// VersionDisposition returns the separate version-evidence state.
+func (profile TeslaGen3HSCProfile) VersionDisposition() TeslaGen3HSCVersionDisposition {
+	return profile.disposition
+}
+
+// ExchangeEligible requires every independently declared Gen3 predicate.
+func (profile TeslaGen3HSCProfile) ExchangeEligible() bool {
+	return profile.config.Enabled && profile.disposition != TeslaGen3HSCVersionUnknown &&
+		profile.config.ActivationCapable && profile.config.PrivateFunctionCapable &&
+		profile.config.OperationCapable
+}

--- a/tesla_gen3_hsc_profile.go
+++ b/tesla_gen3_hsc_profile.go
@@ -44,7 +44,7 @@ func NewTeslaGen3HSCProfile(config TeslaGen3HSCProfileConfig) (TeslaGen3HSCProfi
 	version := strings.TrimSpace(config.Version)
 	if version != "" {
 		switch version {
-		case "24.28.3", "24.44.3":
+		case "24.28.3", "24.44.3", "wc3_24_28_3", "wc3_24_44_3":
 			disposition = TeslaGen3HSCVersionKnownObservation
 		default:
 			if config.ActivationCapable && config.PrivateFunctionCapable && config.OperationCapable {

--- a/tesla_gen3_hsc_profile.go
+++ b/tesla_gen3_hsc_profile.go
@@ -1,6 +1,11 @@
 package modbusreg
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+const maxTeslaGen3HSCVersionEvidence = 252
 
 // TeslaGen3HSCVersionDisposition is the evidence state of a Gen3 version.
 type TeslaGen3HSCVersionDisposition string
@@ -13,8 +18,11 @@ const (
 
 // TeslaGen3HSCProfileConfig declares independently evaluated Gen3 predicates.
 type TeslaGen3HSCProfileConfig struct {
-	Enabled                bool
-	Version                string
+	Enabled bool
+	Version string
+	// VersionEvidence is the bounded native version payload associated with Version.
+	// It is retained byte-for-byte; callers may use an empty value when none exists.
+	VersionEvidence        []byte
 	ActivationCapable      bool
 	PrivateFunctionCapable bool
 	OperationCapable       bool
@@ -28,9 +36,14 @@ type TeslaGen3HSCProfile struct {
 
 // NewTeslaGen3HSCProfile creates a distinct Gen3 capability profile.
 func NewTeslaGen3HSCProfile(config TeslaGen3HSCProfileConfig) (TeslaGen3HSCProfile, error) {
+	if len(config.VersionEvidence) > maxTeslaGen3HSCVersionEvidence {
+		return TeslaGen3HSCProfile{}, fmt.Errorf("tesla Gen3 HSC version evidence exceeds %d bytes", maxTeslaGen3HSCVersionEvidence)
+	}
+	config.VersionEvidence = append([]byte(nil), config.VersionEvidence...)
 	disposition := TeslaGen3HSCVersionUnknown
-	if strings.TrimSpace(config.Version) != "" {
-		switch config.Version {
+	version := strings.TrimSpace(config.Version)
+	if version != "" {
+		switch version {
 		case "24.28.3", "24.44.3":
 			disposition = TeslaGen3HSCVersionKnownObservation
 		default:
@@ -38,6 +51,14 @@ func NewTeslaGen3HSCProfile(config TeslaGen3HSCProfileConfig) (TeslaGen3HSCProfi
 		}
 	}
 	return TeslaGen3HSCProfile{config: config, disposition: disposition}, nil
+}
+
+// Version returns the supplied version label without discarding native context.
+func (profile TeslaGen3HSCProfile) Version() string { return profile.config.Version }
+
+// VersionEvidence returns a defensive copy of the bounded native version payload.
+func (profile TeslaGen3HSCProfile) VersionEvidence() []byte {
+	return append([]byte(nil), profile.config.VersionEvidence...)
 }
 
 // VersionDisposition returns the separate version-evidence state.

--- a/tesla_gen3_hsc_profile.go
+++ b/tesla_gen3_hsc_profile.go
@@ -47,7 +47,9 @@ func NewTeslaGen3HSCProfile(config TeslaGen3HSCProfileConfig) (TeslaGen3HSCProfi
 		case "24.28.3", "24.44.3":
 			disposition = TeslaGen3HSCVersionKnownObservation
 		default:
-			disposition = TeslaGen3HSCVersionCompatibleCandidate
+			if config.ActivationCapable && config.PrivateFunctionCapable && config.OperationCapable {
+				disposition = TeslaGen3HSCVersionCompatibleCandidate
+			}
 		}
 	}
 	return TeslaGen3HSCProfile{config: config, disposition: disposition}, nil

--- a/tesla_gen3_hsc_profile_test.go
+++ b/tesla_gen3_hsc_profile_test.go
@@ -1,0 +1,35 @@
+package modbusreg
+
+import "testing"
+
+func TestTeslaGen3HSCProfileSeparatesKnownCandidateAndUnknownVersions(t *testing.T) {
+	known, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{
+		Enabled: true, Version: "24.28.3", ActivationCapable: true,
+		PrivateFunctionCapable: true, OperationCapable: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if known.VersionDisposition() != TeslaGen3HSCVersionKnownObservation || !known.ExchangeEligible() {
+		t.Fatalf("known=%#v", known)
+	}
+
+	candidate, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{
+		Enabled: true, Version: "25.1.0", ActivationCapable: true,
+		PrivateFunctionCapable: true, OperationCapable: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate.VersionDisposition() != TeslaGen3HSCVersionCompatibleCandidate || !candidate.ExchangeEligible() {
+		t.Fatalf("candidate=%#v", candidate)
+	}
+
+	unknown, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{Enabled: true, Version: "", ActivationCapable: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if unknown.VersionDisposition() != TeslaGen3HSCVersionUnknown || unknown.ExchangeEligible() {
+		t.Fatalf("unknown=%#v", unknown)
+	}
+}

--- a/tesla_gen3_hsc_profile_test.go
+++ b/tesla_gen3_hsc_profile_test.go
@@ -1,35 +1,76 @@
 package modbusreg
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestTeslaGen3HSCProfileSeparatesKnownCandidateAndUnknownVersions(t *testing.T) {
-	known, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{
-		Enabled: true, Version: "24.28.3", ActivationCapable: true,
-		PrivateFunctionCapable: true, OperationCapable: true,
-	})
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name        string
+		version     string
+		disposition TeslaGen3HSCVersionDisposition
+		eligible    bool
+	}{
+		{name: "first known observation", version: "24.28.3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
+		{name: "second known observation", version: "24.44.3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
+		{name: "candidate", version: "25.1.0", disposition: TeslaGen3HSCVersionCompatibleCandidate, eligible: true},
+		{name: "whitespace unknown", version: " \t", disposition: TeslaGen3HSCVersionUnknown},
 	}
-	if known.VersionDisposition() != TeslaGen3HSCVersionKnownObservation || !known.ExchangeEligible() {
-		t.Fatalf("known=%#v", known)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			profile, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{
+				Enabled: true, Version: test.version, ActivationCapable: true,
+				PrivateFunctionCapable: true, OperationCapable: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if profile.VersionDisposition() != test.disposition || profile.ExchangeEligible() != test.eligible {
+				t.Fatalf("profile=%#v", profile)
+			}
+		})
+	}
+}
+
+func TestTeslaGen3HSCProfileRetainsBoundedVersionEvidence(t *testing.T) {
+	evidence := []byte{0x76, 0x32, 0x35, 0x2e, 0x31, 0x2e, 0x30}
+	profile, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{
+		Enabled: true, Version: "25.1.0", VersionEvidence: evidence,
+		ActivationCapable: true, PrivateFunctionCapable: true, OperationCapable: true,
+	})
+	if err != nil || profile.Version() != "25.1.0" || !bytes.Equal(profile.VersionEvidence(), evidence) {
+		t.Fatalf("profile=%#v err=%v", profile, err)
+	}
+	evidence[0] = 0
+	if got := profile.VersionEvidence(); !bytes.Equal(got, []byte{0x76, 0x32, 0x35, 0x2e, 0x31, 0x2e, 0x30}) {
+		t.Fatalf("evidence mutated: %x", got)
 	}
 
-	candidate, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{
-		Enabled: true, Version: "25.1.0", ActivationCapable: true,
-		PrivateFunctionCapable: true, OperationCapable: true,
-	})
-	if err != nil {
-		t.Fatal(err)
+	unknown, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{VersionEvidence: []byte{0xff}})
+	if err != nil || unknown.VersionDisposition() != TeslaGen3HSCVersionUnknown || !bytes.Equal(unknown.VersionEvidence(), []byte{0xff}) {
+		t.Fatalf("unknown=%#v err=%v", unknown, err)
 	}
-	if candidate.VersionDisposition() != TeslaGen3HSCVersionCompatibleCandidate || !candidate.ExchangeEligible() {
-		t.Fatalf("candidate=%#v", candidate)
-	}
+}
 
-	unknown, err := NewTeslaGen3HSCProfile(TeslaGen3HSCProfileConfig{Enabled: true, Version: "", ActivationCapable: true})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if unknown.VersionDisposition() != TeslaGen3HSCVersionUnknown || unknown.ExchangeEligible() {
-		t.Fatalf("unknown=%#v", unknown)
+func TestTeslaGen3HSCProfileRequiresEveryCapability(t *testing.T) {
+	for _, denied := range []string{"enabled", "activation", "private function", "operation"} {
+		t.Run(denied, func(t *testing.T) {
+			config := TeslaGen3HSCProfileConfig{Enabled: true, Version: "24.44.3", ActivationCapable: true, PrivateFunctionCapable: true, OperationCapable: true}
+			switch denied {
+			case "enabled":
+				config.Enabled = false
+			case "activation":
+				config.ActivationCapable = false
+			case "private function":
+				config.PrivateFunctionCapable = false
+			case "operation":
+				config.OperationCapable = false
+			}
+			profile, err := NewTeslaGen3HSCProfile(config)
+			if err != nil || profile.ExchangeEligible() {
+				t.Fatalf("profile=%#v err=%v", profile, err)
+			}
+		})
 	}
 }

--- a/tesla_gen3_hsc_profile_test.go
+++ b/tesla_gen3_hsc_profile_test.go
@@ -71,6 +71,16 @@ func TestTeslaGen3HSCProfileRequiresEveryCapability(t *testing.T) {
 			if err != nil || profile.ExchangeEligible() {
 				t.Fatalf("profile=%#v err=%v", profile, err)
 			}
+			candidateConfig := config
+			candidateConfig.Version = "25.1.0"
+			candidate, err := NewTeslaGen3HSCProfile(candidateConfig)
+			wantDisposition := TeslaGen3HSCVersionUnknown
+			if denied == "enabled" {
+				wantDisposition = TeslaGen3HSCVersionCompatibleCandidate
+			}
+			if err != nil || candidate.VersionDisposition() != wantDisposition || candidate.ExchangeEligible() {
+				t.Fatalf("candidate=%#v err=%v", candidate, err)
+			}
 		})
 	}
 }

--- a/tesla_gen3_hsc_profile_test.go
+++ b/tesla_gen3_hsc_profile_test.go
@@ -12,8 +12,10 @@ func TestTeslaGen3HSCProfileSeparatesKnownCandidateAndUnknownVersions(t *testing
 		disposition TeslaGen3HSCVersionDisposition
 		eligible    bool
 	}{
-		{name: "first known observation", version: "24.28.3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
-		{name: "second known observation", version: "24.44.3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
+		{name: "first raw known observation", version: "24.28.3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
+		{name: "second raw known observation", version: "24.44.3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
+		{name: "first documented profile", version: "wc3_24_28_3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
+		{name: "second documented profile", version: "wc3_24_44_3", disposition: TeslaGen3HSCVersionKnownObservation, eligible: true},
 		{name: "candidate", version: "25.1.0", disposition: TeslaGen3HSCVersionCompatibleCandidate, eligible: true},
 		{name: "whitespace unknown", version: " \t", disposition: TeslaGen3HSCVersionUnknown},
 	}


### PR DESCRIPTION
Closes #176.

## RED checkpoint
`go test ./...` fails because the distinct Gen3 HSC profile resolver does not exist.

GREEN will model known observations, compatible candidates, and unknown versions as separate capability states. It will not infer a numeric minimum, reuse Gen2, open serial I/O, or dispatch hardware requests.