### PR TITLE
REG-TESLA: retain Gen3 native operation records

### DIFF
--- a/tesla_gen3_hsc_native_operation_record.go
+++ b/tesla_gen3_hsc_native_operation_record.go
@@ -61,6 +61,9 @@ func NewTeslaGen3HSCNativeOperationRecord(config TeslaGen3HSCNativeOperationReco
 	if config.Outcome != TeslaGen3HSCNormalOutcome && config.Outcome != TeslaGen3HSCExceptionOutcome {
 		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC outcome is invalid")
 	}
+	if config.Direction == TeslaGen3HSCRequestDirection && config.Outcome == TeslaGen3HSCExceptionOutcome {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC exception must be a response")
+	}
 	if len(config.Payload) > maxTeslaHSCPayload {
 		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC native payload exceeds bound")
 	}

--- a/tesla_gen3_hsc_native_operation_record.go
+++ b/tesla_gen3_hsc_native_operation_record.go
@@ -1,0 +1,113 @@
+package modbusreg
+
+import (
+	"fmt"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+// TeslaGen3HSCNativeOperationDirection identifies the retained PDU direction.
+type TeslaGen3HSCNativeOperationDirection string
+
+const (
+	TeslaGen3HSCRequestDirection  TeslaGen3HSCNativeOperationDirection = "request"
+	TeslaGen3HSCResponseDirection TeslaGen3HSCNativeOperationDirection = "response"
+)
+
+// TeslaGen3HSCNativeOperationOutcome identifies the normal or exception path.
+type TeslaGen3HSCNativeOperationOutcome string
+
+const (
+	TeslaGen3HSCNormalOutcome    TeslaGen3HSCNativeOperationOutcome = "normal"
+	TeslaGen3HSCExceptionOutcome TeslaGen3HSCNativeOperationOutcome = "exception"
+)
+
+// TeslaGen3HSCNativeOperationRecordConfig supplies one bounded Gen3 native record.
+type TeslaGen3HSCNativeOperationRecordConfig struct {
+	Profile          string
+	ProfileVersion   string
+	OperationVersion string
+	Operation        TeslaFC100Operation
+	Function         modbus.PrivateFunctionCode
+	Direction        TeslaGen3HSCNativeOperationDirection
+	Outcome          TeslaGen3HSCNativeOperationOutcome
+	Payload          []byte
+}
+
+// TeslaGen3HSCNativeOperationRecord retains a profile-scoped native operation PDU.
+type TeslaGen3HSCNativeOperationRecord struct {
+	profile          string
+	profileVersion   string
+	operationVersion string
+	operation        TeslaFC100Operation
+	function         modbus.PrivateFunctionCode
+	direction        TeslaGen3HSCNativeOperationDirection
+	outcome          TeslaGen3HSCNativeOperationOutcome
+	payload          []byte
+}
+
+// NewTeslaGen3HSCNativeOperationRecord validates and defensively retains one
+// bounded Gen3 request, normal response, or transport-correlated exception.
+func NewTeslaGen3HSCNativeOperationRecord(config TeslaGen3HSCNativeOperationRecordConfig) (TeslaGen3HSCNativeOperationRecord, error) {
+	if config.Profile != TeslaHSCProfileName || config.ProfileVersion != TeslaHSCCompatibilityV1 {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC profile is unsupported")
+	}
+	if !isTeslaHSCFunction(config.Function) {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC function is unsupported")
+	}
+	if config.Direction != TeslaGen3HSCRequestDirection && config.Direction != TeslaGen3HSCResponseDirection {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC direction is invalid")
+	}
+	if config.Outcome != TeslaGen3HSCNormalOutcome && config.Outcome != TeslaGen3HSCExceptionOutcome {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC outcome is invalid")
+	}
+	if len(config.Payload) > maxTeslaHSCPayload {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 HSC native payload exceeds bound")
+	}
+	if config.Function == teslaHSCFunction100 {
+		if _, ok := teslaFC100OperationSpecs[config.Operation]; !ok || config.OperationVersion != TeslaHSCFC100OperationCompatibilityV1 {
+			return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 FC100 operation context is invalid")
+		}
+	} else if config.Operation != "" || config.OperationVersion != "" {
+		return TeslaGen3HSCNativeOperationRecord{}, fmt.Errorf("tesla Gen3 FC101 or FC102 operation is opaque")
+	}
+	return TeslaGen3HSCNativeOperationRecord{
+		profile:          config.Profile,
+		profileVersion:   config.ProfileVersion,
+		operationVersion: config.OperationVersion,
+		operation:        config.Operation,
+		function:         config.Function,
+		direction:        config.Direction,
+		outcome:          config.Outcome,
+		payload:          append([]byte(nil), config.Payload...),
+	}, nil
+}
+
+func (record TeslaGen3HSCNativeOperationRecord) Profile() string { return record.profile }
+
+func (record TeslaGen3HSCNativeOperationRecord) ProfileVersion() string { return record.profileVersion }
+
+func (record TeslaGen3HSCNativeOperationRecord) OperationVersion() string {
+	return record.operationVersion
+}
+
+func (record TeslaGen3HSCNativeOperationRecord) Operation() TeslaFC100Operation {
+	return record.operation
+}
+
+func (record TeslaGen3HSCNativeOperationRecord) Function() modbus.PrivateFunctionCode {
+	return record.function
+}
+
+func (record TeslaGen3HSCNativeOperationRecord) Direction() TeslaGen3HSCNativeOperationDirection {
+	return record.direction
+}
+
+func (record TeslaGen3HSCNativeOperationRecord) Outcome() TeslaGen3HSCNativeOperationOutcome {
+	return record.outcome
+}
+
+// Payload returns a defensive copy of the retained bounded native PDU payload.
+func (record TeslaGen3HSCNativeOperationRecord) Payload() []byte {
+	return append([]byte(nil), record.payload...)
+}

--- a/tesla_gen3_hsc_native_operation_record_test.go
+++ b/tesla_gen3_hsc_native_operation_record_test.go
@@ -59,6 +59,12 @@ func TestTeslaGen3HSCNativeOperationRecordAllowsOpaqueFC101AndFC102(t *testing.T
 func TestTeslaGen3HSCNativeOperationRecordRejectsInvalidPayloadAndContext(t *testing.T) {
 	if _, err := NewTeslaGen3HSCNativeOperationRecord(TeslaGen3HSCNativeOperationRecordConfig{
 		Profile: TeslaHSCProfileName, ProfileVersion: TeslaHSCCompatibilityV1,
+		Function: 101, Direction: TeslaGen3HSCRequestDirection, Outcome: TeslaGen3HSCExceptionOutcome,
+	}); err == nil {
+		t.Fatal("accepted exception request")
+	}
+	if _, err := NewTeslaGen3HSCNativeOperationRecord(TeslaGen3HSCNativeOperationRecordConfig{
+		Profile: TeslaHSCProfileName, ProfileVersion: TeslaHSCCompatibilityV1,
 		Function: 100, Direction: TeslaGen3HSCResponseDirection, Outcome: TeslaGen3HSCNormalOutcome,
 	}); err == nil {
 		t.Fatal("accepted unqualified FC100 context")

--- a/tesla_gen3_hsc_native_operation_record_test.go
+++ b/tesla_gen3_hsc_native_operation_record_test.go
@@ -1,0 +1,73 @@
+package modbusreg
+
+import (
+	"bytes"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+func TestTeslaGen3HSCNativeOperationRecordRetainsFC100TerminalContext(t *testing.T) {
+	payload := []byte{0x0a, 0x01, 0xff}
+	record, err := NewTeslaGen3HSCNativeOperationRecord(TeslaGen3HSCNativeOperationRecordConfig{
+		Profile:          TeslaHSCProfileName,
+		ProfileVersion:   TeslaHSCCompatibilityV1,
+		OperationVersion: TeslaHSCFC100OperationCompatibilityV1,
+		Operation:        TeslaFC100OperationWCGetConfig,
+		Function:         modbus.PrivateFunctionCode(100),
+		Direction:        TeslaGen3HSCResponseDirection,
+		Outcome:          TeslaGen3HSCNormalOutcome,
+		Payload:          payload,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Profile() != TeslaHSCProfileName ||
+		record.ProfileVersion() != TeslaHSCCompatibilityV1 ||
+		record.OperationVersion() != TeslaHSCFC100OperationCompatibilityV1 ||
+		record.Operation() != TeslaFC100OperationWCGetConfig ||
+		record.Function() != modbus.PrivateFunctionCode(100) ||
+		record.Direction() != TeslaGen3HSCResponseDirection ||
+		record.Outcome() != TeslaGen3HSCNormalOutcome ||
+		!bytes.Equal(record.Payload(), payload) {
+		t.Fatalf("record=%#v", record)
+	}
+	payload[0] = 0
+	if got := record.Payload(); !bytes.Equal(got, []byte{0x0a, 0x01, 0xff}) {
+		t.Fatalf("payload was not copied: %x", got)
+	}
+}
+
+func TestTeslaGen3HSCNativeOperationRecordAllowsOpaqueFC101AndFC102(t *testing.T) {
+	for _, function := range []modbus.PrivateFunctionCode{101, 102} {
+		t.Run(string(rune(function)), func(t *testing.T) {
+			record, err := NewTeslaGen3HSCNativeOperationRecord(TeslaGen3HSCNativeOperationRecordConfig{
+				Profile:        TeslaHSCProfileName,
+				ProfileVersion: TeslaHSCCompatibilityV1,
+				Function:       function,
+				Direction:      TeslaGen3HSCResponseDirection,
+				Outcome:        TeslaGen3HSCNormalOutcome,
+				Payload:        []byte{byte(function), 0x00},
+			})
+			if err != nil || record.Operation() != "" || !bytes.Equal(record.Payload(), []byte{byte(function), 0x00}) {
+				t.Fatalf("record=%#v err=%v", record, err)
+			}
+		})
+	}
+}
+
+func TestTeslaGen3HSCNativeOperationRecordRejectsInvalidPayloadAndContext(t *testing.T) {
+	if _, err := NewTeslaGen3HSCNativeOperationRecord(TeslaGen3HSCNativeOperationRecordConfig{
+		Profile: TeslaHSCProfileName, ProfileVersion: TeslaHSCCompatibilityV1,
+		Function: 100, Direction: TeslaGen3HSCResponseDirection, Outcome: TeslaGen3HSCNormalOutcome,
+	}); err == nil {
+		t.Fatal("accepted unqualified FC100 context")
+	}
+	if _, err := NewTeslaGen3HSCNativeOperationRecord(TeslaGen3HSCNativeOperationRecordConfig{
+		Profile: TeslaHSCProfileName, ProfileVersion: TeslaHSCCompatibilityV1,
+		Function: 101, Direction: TeslaGen3HSCResponseDirection, Outcome: TeslaGen3HSCNormalOutcome,
+		Payload: bytes.Repeat([]byte{0x01}, 253),
+	}); err == nil {
+		t.Fatal("accepted oversized native payload")
+	}
+}


### PR DESCRIPTION
Closes #178

RED-first checkpoint for docs-modbus #122. The test defines full native Gen3 operation-record context for FC100 terminal data and opaque FC101/FC102 records, including defensive retention and bounds.

RED evidence: `go test -race -count=1 ./...` fails only because the new record API is absent.

No serial I/O, transport, gateway, or legacy Gen2 changes.