### PR TITLE
Retain Gen2 FBE0/FDE0 EVSE dynamic-current observations

### DIFF
--- a/tesla_legacy_fbe0_fde0.go
+++ b/tesla_legacy_fbe0_fde0.go
@@ -1,0 +1,70 @@
+package modbusreg
+
+import "fmt"
+
+// TeslaLegacyQualification states the evidence tier for a legacy Tesla record.
+type TeslaLegacyQualification string
+
+const (
+	TeslaLegacyFamilyCompatible TeslaLegacyQualification = "family_compatible"
+	TeslaLegacyBuildConfirmed   TeslaLegacyQualification = "build_confirmed"
+)
+
+// TeslaLegacyFDE0State is the native legacy dynamic-current state byte.
+type TeslaLegacyFDE0State byte
+
+const (
+	TeslaLegacyFDE0StatePreCharge TeslaLegacyFDE0State = 0x05
+	TeslaLegacyFDE0StateCharging  TeslaLegacyFDE0State = 0x09
+)
+
+// IsAbsoluteOffer distinguishes the two documented absolute-offer states from
+// native-only relative and unknown state values.
+func (state TeslaLegacyFDE0State) IsAbsoluteOffer() bool {
+	return state == TeslaLegacyFDE0StatePreCharge || state == TeslaLegacyFDE0StateCharging
+}
+
+// TeslaLegacyFDE0ObservationSpec contains a bounded legacy FDE0 observation.
+type TeslaLegacyFDE0ObservationSpec struct {
+	Qualification   TeslaLegacyQualification
+	State           TeslaLegacyFDE0State
+	AllocatedMaxCA  uint16
+	ActualCurrentCA uint16
+	Raw             []byte
+}
+
+// TeslaLegacyFDE0Observation retains candidate native current roles without
+// inferring device limits, EVSE control, or a protocol-neutral fact.
+type TeslaLegacyFDE0Observation struct {
+	qualification   TeslaLegacyQualification
+	state           TeslaLegacyFDE0State
+	allocatedMaxCA  uint16
+	actualCurrentCA uint16
+	raw             []byte
+}
+
+// NewTeslaLegacyFDE0Observation validates and defensively retains a bounded
+// native FDE0 observation.
+func NewTeslaLegacyFDE0Observation(spec TeslaLegacyFDE0ObservationSpec) (TeslaLegacyFDE0Observation, error) {
+	if spec.Qualification != TeslaLegacyFamilyCompatible && spec.Qualification != TeslaLegacyBuildConfirmed {
+		return TeslaLegacyFDE0Observation{}, fmt.Errorf("legacy Tesla qualification is unsupported")
+	}
+	if len(spec.Raw) == 0 || len(spec.Raw) > 256 {
+		return TeslaLegacyFDE0Observation{}, fmt.Errorf("legacy Tesla FDE0 raw observation is out of bounds")
+	}
+	return TeslaLegacyFDE0Observation{qualification: spec.Qualification, state: spec.State, allocatedMaxCA: spec.AllocatedMaxCA, actualCurrentCA: spec.ActualCurrentCA, raw: append([]byte(nil), spec.Raw...)}, nil
+}
+
+func (observation TeslaLegacyFDE0Observation) Qualification() TeslaLegacyQualification {
+	return observation.qualification
+}
+func (observation TeslaLegacyFDE0Observation) State() TeslaLegacyFDE0State { return observation.state }
+func (observation TeslaLegacyFDE0Observation) AllocatedMaxCA() uint16 {
+	return observation.allocatedMaxCA
+}
+func (observation TeslaLegacyFDE0Observation) ActualCurrentCA() uint16 {
+	return observation.actualCurrentCA
+}
+func (observation TeslaLegacyFDE0Observation) Raw() []byte {
+	return append([]byte(nil), observation.raw...)
+}

--- a/tesla_legacy_fbe0_fde0_test.go
+++ b/tesla_legacy_fbe0_fde0_test.go
@@ -5,11 +5,11 @@ import "testing"
 func TestTeslaLegacyFDE0CandidateObservationRetainsCurrentRoles(t *testing.T) {
 	raw := []byte{0xfd, 0xe0, 0x09, 0x07, 0xd0, 0x03, 0xe8}
 	observation, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
-		Qualification: TeslaLegacyFamilyCompatible,
-		State:         TeslaLegacyFDE0StateCharging,
-		AllocatedMaxCA: 2000,
+		Qualification:   TeslaLegacyFamilyCompatible,
+		State:           TeslaLegacyFDE0StateCharging,
+		AllocatedMaxCA:  2000,
 		ActualCurrentCA: 1000,
-		Raw:           raw,
+		Raw:             raw,
 	})
 	if err != nil {
 		t.Fatalf("NewTeslaLegacyFDE0Observation() error = %v", err)

--- a/tesla_legacy_fbe0_fde0_test.go
+++ b/tesla_legacy_fbe0_fde0_test.go
@@ -1,0 +1,38 @@
+package modbusreg
+
+import "testing"
+
+func TestTeslaLegacyFDE0CandidateObservationRetainsCurrentRoles(t *testing.T) {
+	raw := []byte{0xfd, 0xe0, 0x09, 0x07, 0xd0, 0x03, 0xe8}
+	observation, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
+		Qualification: TeslaLegacyFamilyCompatible,
+		State:         TeslaLegacyFDE0StateCharging,
+		AllocatedMaxCA: 2000,
+		ActualCurrentCA: 1000,
+		Raw:           raw,
+	})
+	if err != nil {
+		t.Fatalf("NewTeslaLegacyFDE0Observation() error = %v", err)
+	}
+	if observation.Qualification() != TeslaLegacyFamilyCompatible || observation.State() != TeslaLegacyFDE0StateCharging || observation.AllocatedMaxCA() != 2000 || observation.ActualCurrentCA() != 1000 {
+		t.Fatalf("observation did not retain the candidate FDE0 roles: %#v", observation)
+	}
+	copy := observation.Raw()
+	copy[0] = 0
+	if observation.Raw()[0] != 0xfd {
+		t.Fatal("Raw() did not defensively copy native evidence")
+	}
+}
+
+func TestTeslaLegacyFDE0OnlyMapsAbsoluteOfferStates(t *testing.T) {
+	for _, state := range []TeslaLegacyFDE0State{TeslaLegacyFDE0StatePreCharge, TeslaLegacyFDE0StateCharging} {
+		if !state.IsAbsoluteOffer() {
+			t.Fatalf("state %x must be an absolute offer", state)
+		}
+	}
+	for _, state := range []TeslaLegacyFDE0State{0x06, 0x07, 0x08} {
+		if state.IsAbsoluteOffer() {
+			t.Fatalf("state %x must remain native-only or unknown", state)
+		}
+	}
+}


### PR DESCRIPTION
Closes #182

Docs gate: helianthus-docs-modbus #126 merged at c85b59a34a78ae577922389b0d6c6f0624d7157b.

RED: `9923f45c869e1ebe351eff602647f3a600576de8`; `go test -race -count=1 ./...` fails because the legacy FDE0 retention API is absent.

Scope is candidate-only FBE0/FDE0 native observation retention and state-role projection; no transport, control, Gen3, gateway, Matter/eeBUS, or live I/O.