### PR TITLE
Retain Gen3 EVSE persistent and provisional current limits

### DIFF
--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -45,6 +45,9 @@ type TeslaGen3ProvisionalCurrentLimit struct {
 	operationVersion                         string
 	limitCurrentMaxAmps, limitTimeoutSeconds uint32
 	inhibitCharging                          bool
+	setRequestPayload                        []byte
+	ackPayload                               []byte
+	readbackRequestPayload                   []byte
 	readbackTerminalPayload                  []byte
 }
 
@@ -54,12 +57,30 @@ func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec)
 	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || e != nil || f != nil || len(a) != 1 || len(b) != 1 || a[0].Kind != TeslaFC100OperationTerminal || b[0].Kind != TeslaFC100OperationTerminal {
 		return TeslaGen3ProvisionalCurrentLimit{}, fmt.Errorf("Gen3 provisional current limit context is invalid")
 	}
-	return TeslaGen3ProvisionalCurrentLimit{s.OperationVersion, s.LimitCurrentMaxAmps, s.LimitTimeoutSeconds, s.InhibitCharging, append([]byte(nil), s.ReadbackTerminalPayload...)}, nil
+	return TeslaGen3ProvisionalCurrentLimit{
+		operationVersion:        s.OperationVersion,
+		limitCurrentMaxAmps:     s.LimitCurrentMaxAmps,
+		limitTimeoutSeconds:     s.LimitTimeoutSeconds,
+		inhibitCharging:         s.InhibitCharging,
+		setRequestPayload:       append([]byte(nil), s.SetRequestPayload...),
+		ackPayload:              append([]byte(nil), s.AckPayload...),
+		readbackRequestPayload:  append([]byte(nil), s.ReadbackRequestPayload...),
+		readbackTerminalPayload: append([]byte(nil), s.ReadbackTerminalPayload...),
+	}, nil
 }
 func (v TeslaGen3ProvisionalCurrentLimit) OperationVersion() string    { return v.operationVersion }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitCurrentMaxAmps() uint32 { return v.limitCurrentMaxAmps }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitTimeoutSeconds() uint32 { return v.limitTimeoutSeconds }
 func (v TeslaGen3ProvisionalCurrentLimit) InhibitCharging() bool       { return v.inhibitCharging }
+func (v TeslaGen3ProvisionalCurrentLimit) SetRequestPayload() []byte {
+	return append([]byte(nil), v.setRequestPayload...)
+}
+func (v TeslaGen3ProvisionalCurrentLimit) AckPayload() []byte {
+	return append([]byte(nil), v.ackPayload...)
+}
+func (v TeslaGen3ProvisionalCurrentLimit) ReadbackRequestPayload() []byte {
+	return append([]byte(nil), v.readbackRequestPayload...)
+}
 func (v TeslaGen3ProvisionalCurrentLimit) ReadbackTerminalPayload() []byte {
 	return append([]byte(nil), v.readbackTerminalPayload...)
 }

--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -54,7 +54,11 @@ type TeslaGen3ProvisionalCurrentLimit struct {
 func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec) (TeslaGen3ProvisionalCurrentLimit, error) {
 	a, e := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCSetProvisional, s.SetRequestPayload, [][]byte{s.AckPayload})
 	b, f := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCGetProvisional, s.ReadbackRequestPayload, [][]byte{s.ReadbackTerminalPayload})
-	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || e != nil || f != nil || len(a) != 1 || len(b) != 1 || a[0].Kind != TeslaFC100OperationTerminal || b[0].Kind != TeslaFC100OperationTerminal {
+	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 ||
+		!teslaGen3ExactFC100Request(TeslaFC100OperationWCSetProvisional, s.SetRequestPayload) ||
+		!teslaGen3ExactFC100Request(TeslaFC100OperationWCGetProvisional, s.ReadbackRequestPayload) ||
+		e != nil || f != nil || len(a) != 1 || len(b) != 1 ||
+		a[0].Kind != TeslaFC100OperationTerminal || b[0].Kind != TeslaFC100OperationTerminal {
 		return TeslaGen3ProvisionalCurrentLimit{}, fmt.Errorf("Gen3 provisional current limit context is invalid")
 	}
 	return TeslaGen3ProvisionalCurrentLimit{
@@ -68,6 +72,24 @@ func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec)
 		readbackTerminalPayload: append([]byte(nil), s.ReadbackTerminalPayload...),
 	}, nil
 }
+
+func teslaGen3ExactFC100Request(operation TeslaFC100Operation, payload []byte) bool {
+	spec, ok := teslaFC100OperationSpecs[operation]
+	if !ok {
+		return false
+	}
+	envelope, err := DecodeTeslaHSCEnvelope(teslaHSCFunction100, payload)
+	if err != nil {
+		return false
+	}
+	family, err := decodeExactLengthDelimitedField(envelope.Payload(), spec.family)
+	if err != nil {
+		return false
+	}
+	_, err = decodeExactLengthDelimitedField(family, spec.requestTag)
+	return err == nil
+}
+
 func (v TeslaGen3ProvisionalCurrentLimit) OperationVersion() string    { return v.operationVersion }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitCurrentMaxAmps() uint32 { return v.limitCurrentMaxAmps }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitTimeoutSeconds() uint32 { return v.limitTimeoutSeconds }

--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -2,71 +2,75 @@ package modbusreg
 
 import "fmt"
 
-// TeslaGen3CurrentLimitOperationVersion24443 identifies the only admitted
-// Gen3 current-limit operation version.
 const TeslaGen3CurrentLimitOperationVersion24443 = "wc3_24_44_3"
-
 const (
 	teslaGen3MinCurrentAmps uint32 = 6
 	teslaGen3MaxTimeoutS    uint32 = 86399
 )
 
 type TeslaGen3PersistentCurrentLimitSpec struct {
-	OperationVersion     string
-	MaxOutputCurrentAmps uint32
-	Raw                  []byte
+	OperationVersion                string
+	MaxOutputCurrentAmps            uint32
+	RequestPayload, TerminalPayload []byte
 }
-
 type TeslaGen3PersistentCurrentLimit struct {
-	operationVersion     string
-	maxOutputCurrentAmps uint32
-	raw                  []byte
+	operationVersion                string
+	maxOutputCurrentAmps            uint32
+	requestPayload, terminalPayload []byte
 }
 
-func NewTeslaGen3PersistentCurrentLimit(spec TeslaGen3PersistentCurrentLimitSpec) (TeslaGen3PersistentCurrentLimit, error) {
-	if spec.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || len(spec.Raw) == 0 || len(spec.Raw) > 252 {
-		return TeslaGen3PersistentCurrentLimit{}, fmt.Errorf("Gen3 persistent current limit is not qualified")
+func NewTeslaGen3PersistentCurrentLimit(s TeslaGen3PersistentCurrentLimitSpec) (TeslaGen3PersistentCurrentLimit, error) {
+	r, e := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCConfigureSettings, s.RequestPayload, [][]byte{s.TerminalPayload})
+	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || e != nil || len(r) != 1 || r[0].Kind != TeslaFC100OperationTerminal {
+		return TeslaGen3PersistentCurrentLimit{}, fmt.Errorf("Gen3 persistent current limit context is invalid")
 	}
-	return TeslaGen3PersistentCurrentLimit{operationVersion: spec.OperationVersion, maxOutputCurrentAmps: spec.MaxOutputCurrentAmps, raw: append([]byte(nil), spec.Raw...)}, nil
+	return TeslaGen3PersistentCurrentLimit{s.OperationVersion, s.MaxOutputCurrentAmps, append([]byte(nil), s.RequestPayload...), append([]byte(nil), s.TerminalPayload...)}, nil
 }
 func (v TeslaGen3PersistentCurrentLimit) OperationVersion() string     { return v.operationVersion }
 func (v TeslaGen3PersistentCurrentLimit) MaxOutputCurrentAmps() uint32 { return v.maxOutputCurrentAmps }
-func (v TeslaGen3PersistentCurrentLimit) Raw() []byte                  { return append([]byte(nil), v.raw...) }
+func (v TeslaGen3PersistentCurrentLimit) RequestPayload() []byte {
+	return append([]byte(nil), v.requestPayload...)
+}
+func (v TeslaGen3PersistentCurrentLimit) TerminalPayload() []byte {
+	return append([]byte(nil), v.terminalPayload...)
+}
 
 type TeslaGen3ProvisionalCurrentLimitSpec struct {
-	OperationVersion                         string
-	LimitCurrentMaxAmps, LimitTimeoutSeconds uint32
-	InhibitCharging                          bool
-	ReadbackRaw                              []byte
+	OperationVersion                                                               string
+	LimitCurrentMaxAmps, LimitTimeoutSeconds                                       uint32
+	InhibitCharging                                                                bool
+	SetRequestPayload, AckPayload, ReadbackRequestPayload, ReadbackTerminalPayload []byte
 }
 type TeslaGen3ProvisionalCurrentLimit struct {
 	operationVersion                         string
 	limitCurrentMaxAmps, limitTimeoutSeconds uint32
 	inhibitCharging                          bool
-	readbackRaw                              []byte
+	readbackTerminalPayload                  []byte
 }
 
-func NewTeslaGen3ProvisionalCurrentLimit(spec TeslaGen3ProvisionalCurrentLimitSpec) (TeslaGen3ProvisionalCurrentLimit, error) {
-	if spec.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || len(spec.ReadbackRaw) == 0 || len(spec.ReadbackRaw) > 252 {
-		return TeslaGen3ProvisionalCurrentLimit{}, fmt.Errorf("Gen3 provisional current limit is not qualified")
+func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec) (TeslaGen3ProvisionalCurrentLimit, error) {
+	a, e := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCSetProvisional, s.SetRequestPayload, [][]byte{s.AckPayload})
+	b, f := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCGetProvisional, s.ReadbackRequestPayload, [][]byte{s.ReadbackTerminalPayload})
+	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || e != nil || f != nil || len(a) != 1 || len(b) != 1 || a[0].Kind != TeslaFC100OperationTerminal || b[0].Kind != TeslaFC100OperationTerminal {
+		return TeslaGen3ProvisionalCurrentLimit{}, fmt.Errorf("Gen3 provisional current limit context is invalid")
 	}
-	return TeslaGen3ProvisionalCurrentLimit{spec.OperationVersion, spec.LimitCurrentMaxAmps, spec.LimitTimeoutSeconds, spec.InhibitCharging, append([]byte(nil), spec.ReadbackRaw...)}, nil
+	return TeslaGen3ProvisionalCurrentLimit{s.OperationVersion, s.LimitCurrentMaxAmps, s.LimitTimeoutSeconds, s.InhibitCharging, append([]byte(nil), s.ReadbackTerminalPayload...)}, nil
 }
+func (v TeslaGen3ProvisionalCurrentLimit) OperationVersion() string    { return v.operationVersion }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitCurrentMaxAmps() uint32 { return v.limitCurrentMaxAmps }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitTimeoutSeconds() uint32 { return v.limitTimeoutSeconds }
 func (v TeslaGen3ProvisionalCurrentLimit) InhibitCharging() bool       { return v.inhibitCharging }
-func (v TeslaGen3ProvisionalCurrentLimit) OperationVersion() string    { return v.operationVersion }
-func (v TeslaGen3ProvisionalCurrentLimit) ReadbackRaw() []byte {
-	return append([]byte(nil), v.readbackRaw...)
+func (v TeslaGen3ProvisionalCurrentLimit) ReadbackTerminalPayload() []byte {
+	return append([]byte(nil), v.readbackTerminalPayload...)
 }
 
 type TeslaGen3InteroperableCurrentLimit struct{ maxAmps, timeoutSeconds uint32 }
 
-func NewTeslaGen3InteroperableCurrentLimit(amps, timeout uint32) (TeslaGen3InteroperableCurrentLimit, error) {
-	if amps < teslaGen3MinCurrentAmps || timeout == 0 || timeout > teslaGen3MaxTimeoutS {
+func NewTeslaGen3InteroperableCurrentLimit(a, t uint32) (TeslaGen3InteroperableCurrentLimit, error) {
+	if a < teslaGen3MinCurrentAmps || t == 0 || t > teslaGen3MaxTimeoutS {
 		return TeslaGen3InteroperableCurrentLimit{}, fmt.Errorf("Gen3 interoperable current limit is out of bounds")
 	}
-	return TeslaGen3InteroperableCurrentLimit{maxAmps: amps, timeoutSeconds: timeout}, nil
+	return TeslaGen3InteroperableCurrentLimit{a, t}, nil
 }
 func (v TeslaGen3InteroperableCurrentLimit) MaxAmps() uint32        { return v.maxAmps }
 func (v TeslaGen3InteroperableCurrentLimit) TimeoutSeconds() uint32 { return v.timeoutSeconds }

--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -1,0 +1,66 @@
+package modbusreg
+
+import "fmt"
+
+// TeslaGen3CurrentLimitOperationVersion24443 identifies the only admitted
+// Gen3 current-limit operation version.
+const TeslaGen3CurrentLimitOperationVersion24443 = "wc3_24_44_3"
+
+const (
+	teslaGen3MinCurrentAmps uint32 = 6
+	teslaGen3MaxTimeoutS    uint32 = 86399
+)
+
+type TeslaGen3PersistentCurrentLimitSpec struct {
+	OperationVersion     string
+	MaxOutputCurrentAmps uint32
+	Raw                  []byte
+}
+
+type TeslaGen3PersistentCurrentLimit struct {
+	operationVersion     string
+	maxOutputCurrentAmps uint32
+	raw                  []byte
+}
+
+func NewTeslaGen3PersistentCurrentLimit(spec TeslaGen3PersistentCurrentLimitSpec) (TeslaGen3PersistentCurrentLimit, error) {
+	if spec.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || len(spec.Raw) == 0 || len(spec.Raw) > 252 {
+		return TeslaGen3PersistentCurrentLimit{}, fmt.Errorf("Gen3 persistent current limit is not qualified")
+	}
+	return TeslaGen3PersistentCurrentLimit{operationVersion: spec.OperationVersion, maxOutputCurrentAmps: spec.MaxOutputCurrentAmps, raw: append([]byte(nil), spec.Raw...)}, nil
+}
+func (v TeslaGen3PersistentCurrentLimit) OperationVersion() string     { return v.operationVersion }
+func (v TeslaGen3PersistentCurrentLimit) MaxOutputCurrentAmps() uint32 { return v.maxOutputCurrentAmps }
+func (v TeslaGen3PersistentCurrentLimit) Raw() []byte                  { return append([]byte(nil), v.raw...) }
+
+type TeslaGen3ProvisionalCurrentLimitSpec struct {
+	OperationVersion                         string
+	LimitCurrentMaxAmps, LimitTimeoutSeconds uint32
+	InhibitCharging                          bool
+	ReadbackRaw                              []byte
+}
+type TeslaGen3ProvisionalCurrentLimit struct {
+	operationVersion                         string
+	limitCurrentMaxAmps, limitTimeoutSeconds uint32
+	inhibitCharging                          bool
+	readbackRaw                              []byte
+}
+
+func NewTeslaGen3ProvisionalCurrentLimit(spec TeslaGen3ProvisionalCurrentLimitSpec) (TeslaGen3ProvisionalCurrentLimit, error) {
+	if spec.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || len(spec.ReadbackRaw) == 0 || len(spec.ReadbackRaw) > 252 {
+		return TeslaGen3ProvisionalCurrentLimit{}, fmt.Errorf("Gen3 provisional current limit is not qualified")
+	}
+	return TeslaGen3ProvisionalCurrentLimit{spec.OperationVersion, spec.LimitCurrentMaxAmps, spec.LimitTimeoutSeconds, spec.InhibitCharging, append([]byte(nil), spec.ReadbackRaw...)}, nil
+}
+func (v TeslaGen3ProvisionalCurrentLimit) LimitCurrentMaxAmps() uint32 { return v.limitCurrentMaxAmps }
+func (v TeslaGen3ProvisionalCurrentLimit) LimitTimeoutSeconds() uint32 { return v.limitTimeoutSeconds }
+func (v TeslaGen3ProvisionalCurrentLimit) InhibitCharging() bool       { return v.inhibitCharging }
+
+type TeslaGen3InteroperableCurrentLimit struct{ MaxAmps, TimeoutSeconds uint32 }
+
+func NewTeslaGen3InteroperableCurrentLimit(amps, timeout uint32) (TeslaGen3InteroperableCurrentLimit, error) {
+	if amps < teslaGen3MinCurrentAmps || timeout == 0 || timeout > teslaGen3MaxTimeoutS {
+		return TeslaGen3InteroperableCurrentLimit{}, fmt.Errorf("Gen3 interoperable current limit is out of bounds")
+	}
+	return TeslaGen3InteroperableCurrentLimit{amps, timeout}, nil
+}

--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -55,12 +55,18 @@ func NewTeslaGen3ProvisionalCurrentLimit(spec TeslaGen3ProvisionalCurrentLimitSp
 func (v TeslaGen3ProvisionalCurrentLimit) LimitCurrentMaxAmps() uint32 { return v.limitCurrentMaxAmps }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitTimeoutSeconds() uint32 { return v.limitTimeoutSeconds }
 func (v TeslaGen3ProvisionalCurrentLimit) InhibitCharging() bool       { return v.inhibitCharging }
+func (v TeslaGen3ProvisionalCurrentLimit) OperationVersion() string    { return v.operationVersion }
+func (v TeslaGen3ProvisionalCurrentLimit) ReadbackRaw() []byte {
+	return append([]byte(nil), v.readbackRaw...)
+}
 
-type TeslaGen3InteroperableCurrentLimit struct{ MaxAmps, TimeoutSeconds uint32 }
+type TeslaGen3InteroperableCurrentLimit struct{ maxAmps, timeoutSeconds uint32 }
 
 func NewTeslaGen3InteroperableCurrentLimit(amps, timeout uint32) (TeslaGen3InteroperableCurrentLimit, error) {
 	if amps < teslaGen3MinCurrentAmps || timeout == 0 || timeout > teslaGen3MaxTimeoutS {
 		return TeslaGen3InteroperableCurrentLimit{}, fmt.Errorf("Gen3 interoperable current limit is out of bounds")
 	}
-	return TeslaGen3InteroperableCurrentLimit{amps, timeout}, nil
+	return TeslaGen3InteroperableCurrentLimit{maxAmps: amps, timeoutSeconds: timeout}, nil
 }
+func (v TeslaGen3InteroperableCurrentLimit) MaxAmps() uint32        { return v.maxAmps }
+func (v TeslaGen3InteroperableCurrentLimit) TimeoutSeconds() uint32 { return v.timeoutSeconds }

--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -21,7 +21,9 @@ type TeslaGen3PersistentCurrentLimit struct {
 
 func NewTeslaGen3PersistentCurrentLimit(s TeslaGen3PersistentCurrentLimitSpec) (TeslaGen3PersistentCurrentLimit, error) {
 	r, e := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCConfigureSettings, s.RequestPayload, [][]byte{s.TerminalPayload})
-	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 || e != nil || len(r) != 1 || r[0].Kind != TeslaFC100OperationTerminal {
+	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 ||
+		!teslaGen3ExactFC100Request(TeslaFC100OperationWCConfigureSettings, s.RequestPayload) ||
+		e != nil || len(r) != 1 || r[0].Kind != TeslaFC100OperationTerminal {
 		return TeslaGen3PersistentCurrentLimit{}, fmt.Errorf("Gen3 persistent current limit context is invalid")
 	}
 	return TeslaGen3PersistentCurrentLimit{s.OperationVersion, s.MaxOutputCurrentAmps, append([]byte(nil), s.RequestPayload...), append([]byte(nil), s.TerminalPayload...)}, nil

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -124,3 +124,25 @@ func TestTeslaGen3ProvisionalCurrentLimitRejectsMismatchedRequestOperations(t *t
 		})
 	}
 }
+
+func TestTeslaGen3PersistentCurrentLimitRejectsMismatchedRequestOperations(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		request []byte
+	}{
+		{"provisional set", currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10})},
+		{"provisional get", currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewTeslaGen3PersistentCurrentLimit(TeslaGen3PersistentCurrentLimitSpec{
+				OperationVersion:     TeslaGen3CurrentLimitOperationVersion24443,
+				MaxOutputCurrentAmps: 16,
+				RequestPayload:       tc.request,
+				TerminalPayload:      currentLimitTerminal(TeslaFC100OperationWCConfigureSettings, []byte{0x08, 0x10}),
+			})
+			if err == nil {
+				t.Fatal("mismatched request operation was accepted")
+			}
+		})
+	}
+}

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -1,0 +1,32 @@
+package modbusreg
+
+import "testing"
+
+func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *testing.T) {
+	persistent, err := NewTeslaGen3PersistentCurrentLimit(TeslaGen3PersistentCurrentLimitSpec{
+		OperationVersion: TeslaGen3CurrentLimitOperationVersion24443,
+		MaxOutputCurrentAmps: 16,
+		Raw:               []byte{0x32, 0x02, 0x3a, 0x00},
+	})
+	if err != nil || persistent.MaxOutputCurrentAmps() != 16 || persistent.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 {
+		t.Fatalf("persistent record = %#v, %v", persistent, err)
+	}
+
+	provisional, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
+		OperationVersion: TeslaGen3CurrentLimitOperationVersion24443,
+		LimitCurrentMaxAmps: 16,
+		LimitTimeoutSeconds: 600,
+		InhibitCharging:     false,
+		ReadbackRaw:         []byte{0x32, 0x03, 0xda, 0x01, 0x00},
+	})
+	if err != nil || provisional.LimitCurrentMaxAmps() != 16 || provisional.LimitTimeoutSeconds() != 600 || provisional.InhibitCharging() {
+		t.Fatalf("provisional record = %#v, %v", provisional, err)
+	}
+}
+
+func TestTeslaGen3EVSECurrentLimitInteroperableProjectionIsBounded(t *testing.T) {
+	for _, tc := range []struct{ amps, timeout uint32; valid bool }{{6, 1, true}, {5, 1, false}, {6, 0, false}, {6, 86400, false}} {
+		_, err := NewTeslaGen3InteroperableCurrentLimit(tc.amps, tc.timeout)
+		if (err == nil) != tc.valid { t.Fatalf("amps=%d timeout=%d err=%v", tc.amps, tc.timeout, err) }
+	}
+}

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *testing.T) {
 	persistent, err := NewTeslaGen3PersistentCurrentLimit(TeslaGen3PersistentCurrentLimitSpec{
-		OperationVersion: TeslaGen3CurrentLimitOperationVersion24443,
+		OperationVersion:     TeslaGen3CurrentLimitOperationVersion24443,
 		MaxOutputCurrentAmps: 16,
-		Raw:               []byte{0x32, 0x02, 0x3a, 0x00},
+		Raw:                  []byte{0x32, 0x02, 0x3a, 0x00},
 	})
 	if err != nil || persistent.MaxOutputCurrentAmps() != 16 || persistent.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 {
 		t.Fatalf("persistent record = %#v, %v", persistent, err)
 	}
 
 	provisional, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
-		OperationVersion: TeslaGen3CurrentLimitOperationVersion24443,
+		OperationVersion:    TeslaGen3CurrentLimitOperationVersion24443,
 		LimitCurrentMaxAmps: 16,
 		LimitTimeoutSeconds: 600,
 		InhibitCharging:     false,
@@ -25,8 +25,13 @@ func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *test
 }
 
 func TestTeslaGen3EVSECurrentLimitInteroperableProjectionIsBounded(t *testing.T) {
-	for _, tc := range []struct{ amps, timeout uint32; valid bool }{{6, 1, true}, {5, 1, false}, {6, 0, false}, {6, 86400, false}} {
+	for _, tc := range []struct {
+		amps, timeout uint32
+		valid         bool
+	}{{6, 1, true}, {5, 1, false}, {6, 0, false}, {6, 86400, false}} {
 		_, err := NewTeslaGen3InteroperableCurrentLimit(tc.amps, tc.timeout)
-		if (err == nil) != tc.valid { t.Fatalf("amps=%d timeout=%d err=%v", tc.amps, tc.timeout, err) }
+		if (err == nil) != tc.valid {
+			t.Fatalf("amps=%d timeout=%d err=%v", tc.amps, tc.timeout, err)
+		}
 	}
 }

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -1,6 +1,9 @@
 package modbusreg
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func currentLimitRequest(t *testing.T, operation TeslaFC100Operation, body []byte) []byte {
 	t.Helper()
@@ -33,26 +36,48 @@ func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *test
 		t.Fatalf("persistent record = %#v, %v", persistent, err)
 	}
 
+	setRequest := currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10})
+	ack := currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil)
+	readbackRequest := currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil)
+	readbackTerminal := currentLimitTerminal(TeslaFC100OperationWCGetProvisional, []byte{0x08, 0x10})
+	setRequestWant := append([]byte(nil), setRequest...)
+	ackWant := append([]byte(nil), ack...)
+	readbackRequestWant := append([]byte(nil), readbackRequest...)
+	readbackTerminalWant := append([]byte(nil), readbackTerminal...)
 	provisional, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
 		OperationVersion:        TeslaGen3CurrentLimitOperationVersion24443,
 		LimitCurrentMaxAmps:     16,
 		LimitTimeoutSeconds:     600,
 		InhibitCharging:         false,
-		SetRequestPayload:       currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10}),
-		AckPayload:              currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil),
-		ReadbackRequestPayload:  currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil),
-		ReadbackTerminalPayload: currentLimitTerminal(TeslaFC100OperationWCGetProvisional, []byte{0x08, 0x10}),
+		SetRequestPayload:       setRequest,
+		AckPayload:              ack,
+		ReadbackRequestPayload:  readbackRequest,
+		ReadbackTerminalPayload: readbackTerminal,
 	})
 	if err != nil || provisional.LimitCurrentMaxAmps() != 16 || provisional.LimitTimeoutSeconds() != 600 || provisional.InhibitCharging() {
 		t.Fatalf("provisional record = %#v, %v", provisional, err)
 	}
-	if provisional.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 || provisional.ReadbackTerminalPayload()[0] == 0 {
-		t.Fatalf("provisional evidence is not retrievable")
+	for _, source := range [][]byte{setRequest, ack, readbackRequest, readbackTerminal} {
+		source[0] ^= 0xff
 	}
-	readback := provisional.ReadbackTerminalPayload()
-	readback[0] = 0
-	if provisional.ReadbackTerminalPayload()[0] == 0 {
-		t.Fatal("ReadbackRaw() did not defensively copy")
+	for _, evidence := range []struct {
+		name string
+		want []byte
+		get  func() []byte
+	}{
+		{"set request", setRequestWant, provisional.SetRequestPayload},
+		{"ack", ackWant, provisional.AckPayload},
+		{"readback request", readbackRequestWant, provisional.ReadbackRequestPayload},
+		{"readback terminal", readbackTerminalWant, provisional.ReadbackTerminalPayload},
+	} {
+		got := evidence.get()
+		if !bytes.Equal(got, evidence.want) {
+			t.Fatalf("%s = %x, want %x", evidence.name, got, evidence.want)
+		}
+		got[0] ^= 0xff
+		if bytes.Equal(got, evidence.get()) {
+			t.Fatalf("%s getter did not defensively copy", evidence.name)
+		}
 	}
 }
 

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -2,32 +2,56 @@ package modbusreg
 
 import "testing"
 
+func currentLimitRequest(t *testing.T, operation TeslaFC100Operation, body []byte) []byte {
+	t.Helper()
+	request, err := BuildTeslaFC100OperationRequest(TeslaGen3CurrentLimitOperationVersion24443, operation, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return request.Payload()
+}
+
+func currentLimitTerminal(operation TeslaFC100Operation, body []byte) []byte {
+	spec := teslaFC100OperationSpecs[operation]
+	inner := appendTeslaFC100Varint(nil, spec.responseTag<<3|2)
+	inner = appendTeslaFC100Varint(inner, uint64(len(body)))
+	inner = append(inner, body...)
+	message := appendTeslaFC100Varint(nil, spec.family<<3|2)
+	message = appendTeslaFC100Varint(message, uint64(len(inner)))
+	message = append(message, inner...)
+	return append([]byte{byte(len(message))}, message...)
+}
+
 func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *testing.T) {
 	persistent, err := NewTeslaGen3PersistentCurrentLimit(TeslaGen3PersistentCurrentLimitSpec{
 		OperationVersion:     TeslaGen3CurrentLimitOperationVersion24443,
 		MaxOutputCurrentAmps: 16,
-		Raw:                  []byte{0x32, 0x02, 0x3a, 0x00},
+		RequestPayload:       currentLimitRequest(t, TeslaFC100OperationWCConfigureSettings, []byte{0x08, 0x10}),
+		TerminalPayload:      currentLimitTerminal(TeslaFC100OperationWCConfigureSettings, []byte{0x08, 0x10}),
 	})
 	if err != nil || persistent.MaxOutputCurrentAmps() != 16 || persistent.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 {
 		t.Fatalf("persistent record = %#v, %v", persistent, err)
 	}
 
 	provisional, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
-		OperationVersion:    TeslaGen3CurrentLimitOperationVersion24443,
-		LimitCurrentMaxAmps: 16,
-		LimitTimeoutSeconds: 600,
-		InhibitCharging:     false,
-		ReadbackRaw:         []byte{0x32, 0x03, 0xda, 0x01, 0x00},
+		OperationVersion:        TeslaGen3CurrentLimitOperationVersion24443,
+		LimitCurrentMaxAmps:     16,
+		LimitTimeoutSeconds:     600,
+		InhibitCharging:         false,
+		SetRequestPayload:       currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10}),
+		AckPayload:              currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil),
+		ReadbackRequestPayload:  currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil),
+		ReadbackTerminalPayload: currentLimitTerminal(TeslaFC100OperationWCGetProvisional, []byte{0x08, 0x10}),
 	})
 	if err != nil || provisional.LimitCurrentMaxAmps() != 16 || provisional.LimitTimeoutSeconds() != 600 || provisional.InhibitCharging() {
 		t.Fatalf("provisional record = %#v, %v", provisional, err)
 	}
-	if provisional.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 || provisional.ReadbackRaw()[0] != 0x32 {
+	if provisional.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 || provisional.ReadbackTerminalPayload()[0] == 0 {
 		t.Fatalf("provisional evidence is not retrievable")
 	}
-	readback := provisional.ReadbackRaw()
+	readback := provisional.ReadbackTerminalPayload()
 	readback[0] = 0
-	if provisional.ReadbackRaw()[0] != 0x32 {
+	if provisional.ReadbackTerminalPayload()[0] == 0 {
 		t.Fatal("ReadbackRaw() did not defensively copy")
 	}
 }

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -96,3 +96,31 @@ func TestTeslaGen3EVSECurrentLimitInteroperableProjectionIsBounded(t *testing.T)
 		t.Fatalf("bounded projection = %#v, %v", limit, err)
 	}
 }
+
+func TestTeslaGen3ProvisionalCurrentLimitRejectsMismatchedRequestOperations(t *testing.T) {
+	setRequest := currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10})
+	readbackRequest := currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil)
+	wrongRequest := currentLimitRequest(t, TeslaFC100OperationWCConfigureSettings, []byte{0x08, 0x10})
+	for _, tc := range []struct {
+		name                        string
+		setRequest, readbackRequest []byte
+	}{
+		{"set", wrongRequest, readbackRequest},
+		{"readback", setRequest, wrongRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
+				OperationVersion:        TeslaGen3CurrentLimitOperationVersion24443,
+				LimitCurrentMaxAmps:     16,
+				LimitTimeoutSeconds:     600,
+				SetRequestPayload:       tc.setRequest,
+				AckPayload:              currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil),
+				ReadbackRequestPayload:  tc.readbackRequest,
+				ReadbackTerminalPayload: currentLimitTerminal(TeslaFC100OperationWCGetProvisional, []byte{0x08, 0x10}),
+			})
+			if err == nil {
+				t.Fatal("mismatched request operation was accepted")
+			}
+		})
+	}
+}

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -22,6 +22,14 @@ func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *test
 	if err != nil || provisional.LimitCurrentMaxAmps() != 16 || provisional.LimitTimeoutSeconds() != 600 || provisional.InhibitCharging() {
 		t.Fatalf("provisional record = %#v, %v", provisional, err)
 	}
+	if provisional.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 || provisional.ReadbackRaw()[0] != 0x32 {
+		t.Fatalf("provisional evidence is not retrievable")
+	}
+	readback := provisional.ReadbackRaw()
+	readback[0] = 0
+	if provisional.ReadbackRaw()[0] != 0x32 {
+		t.Fatal("ReadbackRaw() did not defensively copy")
+	}
 }
 
 func TestTeslaGen3EVSECurrentLimitInteroperableProjectionIsBounded(t *testing.T) {
@@ -33,5 +41,9 @@ func TestTeslaGen3EVSECurrentLimitInteroperableProjectionIsBounded(t *testing.T)
 		if (err == nil) != tc.valid {
 			t.Fatalf("amps=%d timeout=%d err=%v", tc.amps, tc.timeout, err)
 		}
+	}
+	limit, err := NewTeslaGen3InteroperableCurrentLimit(6, 1)
+	if err != nil || limit.MaxAmps() != 6 || limit.TimeoutSeconds() != 1 {
+		t.Fatalf("bounded projection = %#v, %v", limit, err)
 	}
 }


### PR DESCRIPTION
Closes #184

Docs gate: docs-modbus #128 merged at 6611e20ac8b2c3e8b953934757346f8a847b30bf.

RED: `go test -race -count=1 ./...` fails because version-qualified Gen3 current-limit records/projection are absent.

Scope: only native 24.44.3 persistent/provisional retention and bounded projection; no transport, dispatch, gateway, or live I/O.