### PR TITLE
[0.7] Add Huawei per-class qualification cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ standard family. Vendor names alone do not justify an overlay.
 
 SmartLogger, EMMA, S-Dongle, model, and firmware distinctions are profile
 applicability and qualification dimensions, not separate repositories.
+The Huawei qualification package now exposes separate inert cards for bounded
+SmartLogger and EMMA evidence plus the retained S-Dongle non-response hard
+stop. Identity results carry no telemetry, automatic request, catalog, support,
+live-qualification, or write authority.
 
 ## Ownership
 

--- a/huawei_qualification_cards.go
+++ b/huawei_qualification_cards.go
@@ -1,0 +1,366 @@
+package modbusreg
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+const (
+	HuaweiSmartLoggerCanonicalClass = "SmartLogger"
+
+	HuaweiSmartLoggerQualificationCardID = "huawei.qualification.smartlogger.readonly@1.0.0"
+	HuaweiEMMAQualificationCardID        = "huawei.qualification.emma.readonly@1.0.0"
+	HuaweiSDongleQualificationCardID     = "huawei.qualification.sdongle.evidence-blocked@1.0.0"
+
+	huaweiQualificationExpectedResultSchema = "helianthus-huawei-qualification-readiness/v1"
+)
+
+type HuaweiQualificationReadiness string
+
+const (
+	HuaweiQualificationInsufficientEvidence HuaweiQualificationReadiness = "INSUFFICIENT_EVIDENCE"
+	HuaweiQualificationTestReady            HuaweiQualificationReadiness = "QUALIFICATION_TEST_READY"
+	HuaweiQualificationEvidenceBlocked      HuaweiQualificationReadiness = "QUALIFICATION_EVIDENCE_BLOCKED"
+	HuaweiQualificationAmbiguous            HuaweiQualificationReadiness = "AMBIGUOUS"
+)
+
+type HuaweiQualificationReason string
+
+const (
+	HuaweiQualificationIdentityInvalid                    HuaweiQualificationReason = "IDENTITY_INVALID"
+	HuaweiQualificationInventoryInvalid                   HuaweiQualificationReason = "INVENTORY_INVALID"
+	HuaweiQualificationMatchedIdentityInventory           HuaweiQualificationReason = "IDENTITY_INVENTORY_MATCHED"
+	HuaweiQualificationIdentityMatchedCapabilitiesMissing HuaweiQualificationReason = "IDENTITY_MATCHED_CAPABILITIES_MISSING"
+	HuaweiQualificationPersistentNonResponse              HuaweiQualificationReason = "LIVE_STOPPED_PERSISTENT_NON_RESPONSE"
+	HuaweiQualificationMultipleClasses                    HuaweiQualificationReason = "MULTIPLE_CLASSES"
+)
+
+type HuaweiQualificationInventoryLimits struct {
+	DeadlineMilliseconds uint32
+	MaxPages             uint32
+	MaxObjects           uint32
+	MaxBytes             uint32
+	MaxChildren          uint32
+}
+
+// HuaweiQualificationStep describes one caller-controlled read-only evidence
+// input. It is inert metadata and carries no transport or dispatch method.
+type HuaweiQualificationStep struct {
+	operation        string
+	unitID           uint8
+	offset, quantity uint16
+	objectID         uint8
+}
+
+func (step HuaweiQualificationStep) Operation() string { return step.operation }
+func (step HuaweiQualificationStep) UnitID() uint8     { return step.unitID }
+func (step HuaweiQualificationStep) Offset() uint16    { return step.offset }
+func (step HuaweiQualificationStep) Quantity() uint16  { return step.quantity }
+func (step HuaweiQualificationStep) ObjectID() uint8   { return step.objectID }
+
+type HuaweiQualificationResult struct {
+	candidateClass   string
+	selectedClass    string
+	modelVariant     string
+	readiness        HuaweiQualificationReadiness
+	reason           HuaweiQualificationReason
+	identityMatched  bool
+	inventory        *HuaweiGatewayInventory
+	missingEvidence  []string
+	candidateClasses []string
+}
+
+func (result HuaweiQualificationResult) CandidateClass() string { return result.candidateClass }
+func (result HuaweiQualificationResult) SelectedClass() string  { return result.selectedClass }
+func (result HuaweiQualificationResult) ModelVariant() string   { return result.modelVariant }
+func (result HuaweiQualificationResult) Readiness() HuaweiQualificationReadiness {
+	if result.readiness == "" {
+		return HuaweiQualificationInsufficientEvidence
+	}
+	return result.readiness
+}
+func (result HuaweiQualificationResult) Reason() HuaweiQualificationReason {
+	if result.reason == "" {
+		return HuaweiQualificationIdentityInvalid
+	}
+	return result.reason
+}
+func (result HuaweiQualificationResult) IdentityMatched() bool { return result.identityMatched }
+func (result HuaweiQualificationResult) QualificationTestReady() bool {
+	return result.Readiness() == HuaweiQualificationTestReady
+}
+func (HuaweiQualificationResult) HardwareTestReady() bool         { return false }
+func (HuaweiQualificationResult) DefaultDenied() bool             { return true }
+func (HuaweiQualificationResult) CatalogRegistered() bool         { return false }
+func (HuaweiQualificationResult) AutomaticRuntimeAdmission() bool { return false }
+func (HuaweiQualificationResult) LiveQualified() bool             { return false }
+func (HuaweiQualificationResult) SupportClaim() bool              { return false }
+func (HuaweiQualificationResult) WriteAuthority() bool            { return false }
+func (HuaweiQualificationResult) NativeFactCount() int            { return 0 }
+func (HuaweiQualificationResult) AutomaticRequestCount() int      { return 0 }
+func (HuaweiQualificationResult) FallbackAttempted() bool         { return false }
+func (result HuaweiQualificationResult) MissingEvidence() []string {
+	return append([]string(nil), result.missingEvidence...)
+}
+func (result HuaweiQualificationResult) CandidateClasses() []string {
+	return append([]string(nil), result.candidateClasses...)
+}
+func (result HuaweiQualificationResult) Inventory() (HuaweiGatewayInventory, bool) {
+	if result.inventory == nil {
+		return HuaweiGatewayInventory{}, false
+	}
+	inventory := *result.inventory
+	inventory.children = append([]HuaweiSmartLoggerInventoryChild(nil), result.inventory.children...)
+	return inventory, true
+}
+
+type HuaweiSmartLoggerQualificationCard struct{}
+
+type HuaweiSmartLoggerQualificationInput struct {
+	UnitID    uint8
+	Inventory HuaweiSmartLoggerOfflineInventoryInput
+}
+
+func NewHuaweiSmartLoggerQualificationCard() HuaweiSmartLoggerQualificationCard {
+	return HuaweiSmartLoggerQualificationCard{}
+}
+
+func (HuaweiSmartLoggerQualificationCard) ID() string { return HuaweiSmartLoggerQualificationCardID }
+func (HuaweiSmartLoggerQualificationCard) CandidateClass() string {
+	return HuaweiSmartLoggerCanonicalClass
+}
+func (HuaweiSmartLoggerQualificationCard) UnitID() uint8 { return 0 }
+func (HuaweiSmartLoggerQualificationCard) FirmwareTuples() []string {
+	return []string{"V300R024C10SPC191", "V300R024C10SPC210"}
+}
+func (HuaweiSmartLoggerQualificationCard) Steps() []HuaweiQualificationStep {
+	return []HuaweiQualificationStep{
+		{operation: "FC03_COUNTER_BEFORE", unitID: 0, offset: 65521, quantity: 1},
+		{operation: "FC2B_MEI_0E_READDEV03_INVENTORY", unitID: 0, objectID: huaweiSmartLoggerInventoryStartObject},
+		{operation: "FC03_COUNTER_AFTER", unitID: 0, offset: 65521, quantity: 1},
+	}
+}
+func (HuaweiSmartLoggerQualificationCard) Limits() HuaweiQualificationInventoryLimits {
+	return HuaweiQualificationInventoryLimits{
+		DeadlineMilliseconds: 15000,
+		MaxPages:             huaweiSmartLoggerInventoryMaxPages,
+		MaxObjects:           huaweiSmartLoggerInventoryMaxObjects,
+		MaxBytes:             huaweiSmartLoggerInventoryMaxBytes,
+		MaxChildren:          huaweiSmartLoggerInventoryMaxChildren,
+	}
+}
+func (card HuaweiSmartLoggerQualificationCard) EmptyResult() HuaweiQualificationResult {
+	return HuaweiQualificationResult{candidateClass: card.CandidateClass(), readiness: HuaweiQualificationInsufficientEvidence, reason: HuaweiQualificationIdentityInvalid}
+}
+func (card HuaweiSmartLoggerQualificationCard) Evaluate(input HuaweiSmartLoggerQualificationInput) HuaweiQualificationResult {
+	rejected := card.EmptyResult()
+	if input.UnitID != card.UnitID() {
+		return rejected
+	}
+	inventory, err := ParseHuaweiSmartLoggerOfflineInventory(input.Inventory)
+	if err != nil {
+		rejected.reason = HuaweiQualificationInventoryInvalid
+		return rejected
+	}
+	var self *HuaweiSmartLoggerInventoryChild
+	for _, page := range input.Inventory.Pages {
+		for _, object := range page.Objects {
+			if object.ObjectID != huaweiSmartLoggerInventoryStartObject+1 {
+				continue
+			}
+			decoded, err := parseHuaweiSmartLoggerInventoryChild(object)
+			if err != nil {
+				rejected.reason = HuaweiQualificationInventoryInvalid
+				return rejected
+			}
+			self = &decoded
+		}
+	}
+	if self == nil || self.Attribute("model") != card.CandidateClass() || !containsHuaweiQualificationString(card.FirmwareTuples(), self.Attribute("software_version")) {
+		return rejected
+	}
+	retained := inventory
+	return HuaweiQualificationResult{
+		candidateClass:  card.CandidateClass(),
+		selectedClass:   card.CandidateClass(),
+		readiness:       HuaweiQualificationTestReady,
+		reason:          HuaweiQualificationMatchedIdentityInventory,
+		identityMatched: true,
+		inventory:       &retained,
+		missingEvidence: []string{"connected_smartlogger_identity_inventory_capture"},
+	}
+}
+
+type HuaweiEMMAQualificationCard struct{}
+
+type HuaweiEMMAQualificationInput struct {
+	UnitID   uint8
+	Offering string
+	Model    string
+	Firmware string
+}
+
+func NewHuaweiEMMAQualificationCard() HuaweiEMMAQualificationCard {
+	return HuaweiEMMAQualificationCard{}
+}
+func (HuaweiEMMAQualificationCard) ID() string              { return HuaweiEMMAQualificationCardID }
+func (HuaweiEMMAQualificationCard) CandidateClass() string  { return HuaweiEMMACanonicalClass }
+func (HuaweiEMMAQualificationCard) UnitID() uint8           { return 0 }
+func (HuaweiEMMAQualificationCard) ModelVariants() []string { return []string{"EMMA-A01", "EMMA-A02"} }
+func (HuaweiEMMAQualificationCard) Steps() []HuaweiQualificationStep {
+	return []HuaweiQualificationStep{
+		{operation: "FC03_OFFERING", unitID: 0, offset: 30000, quantity: 15},
+		{operation: "FC03_MODEL", unitID: 0, offset: 30222, quantity: 20},
+		{operation: "FC03_FIRMWARE", unitID: 0, offset: 30035, quantity: 15},
+	}
+}
+func (HuaweiEMMAQualificationCard) MissingCapabilityEvidence() []string {
+	return []string{"sanitized_readonly_capability_fixture", "negative_overlap_with_smartlogger", "model_specific_capability_fixture"}
+}
+func (card HuaweiEMMAQualificationCard) EmptyResult() HuaweiQualificationResult {
+	return HuaweiQualificationResult{candidateClass: card.CandidateClass(), readiness: HuaweiQualificationInsufficientEvidence, reason: HuaweiQualificationIdentityInvalid}
+}
+func (card HuaweiEMMAQualificationCard) Evaluate(input HuaweiEMMAQualificationInput) HuaweiQualificationResult {
+	rejected := card.EmptyResult()
+	if input.UnitID != card.UnitID() {
+		return rejected
+	}
+	identity := EvaluateHuaweiEMMAOfflineIdentity(input.Offering, input.Model, input.Firmware)
+	if !identity.Matched() {
+		return rejected
+	}
+	return HuaweiQualificationResult{
+		candidateClass:  card.CandidateClass(),
+		selectedClass:   card.CandidateClass(),
+		modelVariant:    identity.ModelVariant(),
+		readiness:       HuaweiQualificationEvidenceBlocked,
+		reason:          HuaweiQualificationIdentityMatchedCapabilitiesMissing,
+		identityMatched: true,
+		missingEvidence: card.MissingCapabilityEvidence(),
+	}
+}
+
+type HuaweiSDongleQualificationCard struct{}
+
+func NewHuaweiSDongleQualificationCard() HuaweiSDongleQualificationCard {
+	return HuaweiSDongleQualificationCard{}
+}
+func (HuaweiSDongleQualificationCard) ID() string             { return HuaweiSDongleQualificationCardID }
+func (HuaweiSDongleQualificationCard) CandidateClass() string { return HuaweiSDongleCanonicalClass }
+func (HuaweiSDongleQualificationCard) UnitID() uint8          { return 100 }
+func (HuaweiSDongleQualificationCard) HardStop() bool         { return true }
+func (HuaweiSDongleQualificationCard) Steps() []HuaweiQualificationStep {
+	return nil
+}
+func (HuaweiSDongleQualificationCard) Status() HuaweiQualificationReadiness {
+	return HuaweiQualificationEvidenceBlocked
+}
+func (HuaweiSDongleQualificationCard) RequiredConnectionContext() []string {
+	return []string{"endpoint", "port", "unit_id_100", "gateway_child_topology"}
+}
+func (card HuaweiSDongleQualificationCard) Result() HuaweiQualificationResult {
+	return HuaweiQualificationResult{
+		candidateClass: card.CandidateClass(),
+		readiness:      HuaweiQualificationEvidenceBlocked,
+		reason:         HuaweiQualificationPersistentNonResponse,
+		missingEvidence: []string{
+			"confirmed_gateway_connection_context",
+			"gateway_unit_100_topology",
+			"sanitized_basic_mei_product_model_fixture",
+			"exact_protocol_version_encoding_fixture",
+			"completed_search_stable_sequence_capacity_fixture",
+			"separately_qualified_child_unit_inventory_fixture",
+		},
+	}
+}
+
+func ResolveHuaweiQualification(results ...HuaweiQualificationResult) HuaweiQualificationResult {
+	matches := make([]HuaweiQualificationResult, 0, len(results))
+	classes := make([]string, 0, len(results))
+	var persistentBlock *HuaweiQualificationResult
+	for _, result := range results {
+		if result.Readiness() == HuaweiQualificationEvidenceBlocked && result.Reason() == HuaweiQualificationPersistentNonResponse {
+			copy := result
+			persistentBlock = &copy
+		}
+		if !result.IdentityMatched() || result.SelectedClass() == "" {
+			continue
+		}
+		matches = append(matches, result)
+		classes = append(classes, result.SelectedClass())
+	}
+	sort.Strings(classes)
+	if len(matches) == 1 && len(results) == 1 {
+		selected := matches[0]
+		selected.candidateClasses = classes
+		return selected
+	}
+	if len(matches) > 1 {
+		return HuaweiQualificationResult{
+			readiness:        HuaweiQualificationAmbiguous,
+			reason:           HuaweiQualificationMultipleClasses,
+			candidateClasses: classes,
+		}
+	}
+	if persistentBlock != nil {
+		return *persistentBlock
+	}
+	if len(matches) == 1 {
+		return HuaweiQualificationResult{
+			readiness:        HuaweiQualificationInsufficientEvidence,
+			reason:           HuaweiQualificationIdentityInvalid,
+			candidateClasses: classes,
+		}
+	}
+	return HuaweiQualificationResult{readiness: HuaweiQualificationInsufficientEvidence, reason: HuaweiQualificationIdentityInvalid}
+}
+
+func containsHuaweiQualificationString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+type HuaweiQualificationPackage struct{}
+
+func NewHuaweiQualificationPackage() HuaweiQualificationPackage { return HuaweiQualificationPackage{} }
+func (HuaweiQualificationPackage) ExpectedResult() HuaweiQualificationExpectedResult {
+	return HuaweiQualificationExpectedResult{}
+}
+
+type HuaweiQualificationExpectedResult struct{}
+
+func (HuaweiQualificationExpectedResult) MarshalJSON() ([]byte, error) {
+	smartLogger := NewHuaweiSmartLoggerQualificationCard()
+	emma := NewHuaweiEMMAQualificationCard()
+	sdongle := NewHuaweiSDongleQualificationCard()
+	classes := []map[string]any{
+		{
+			"class": smartLogger.CandidateClass(), "card_id": smartLogger.ID(), "status": HuaweiQualificationTestReady,
+			"missing_evidence":    []string{"connected_smartlogger_identity_inventory_capture"},
+			"hardware_test_ready": false, "live_qualified": false, "automatic_request_count": 0, "native_fact_count": 0,
+		},
+		{
+			"class": emma.CandidateClass(), "card_id": emma.ID(), "status": HuaweiQualificationEvidenceBlocked,
+			"missing_evidence":    emma.MissingCapabilityEvidence(),
+			"hardware_test_ready": false, "live_qualified": false, "automatic_request_count": 0, "native_fact_count": 0,
+		},
+		{
+			"class": sdongle.CandidateClass(), "card_id": sdongle.ID(), "status": HuaweiQualificationEvidenceBlocked,
+			"missing_evidence":    sdongle.Result().MissingEvidence(),
+			"hardware_test_ready": false, "live_qualified": false, "automatic_request_count": 0, "native_fact_count": 0,
+		},
+	}
+	return json.Marshal(map[string]any{
+		"schema":                      huaweiQualificationExpectedResultSchema,
+		"classes":                     classes,
+		"default_denied":              true,
+		"catalog_registered":          false,
+		"automatic_runtime_admission": false,
+		"support_claim":               false,
+		"write_authority":             false,
+	})
+}

--- a/huawei_qualification_cards.go
+++ b/huawei_qualification_cards.go
@@ -289,6 +289,9 @@ func ResolveHuaweiQualification(results ...HuaweiQualificationResult) HuaweiQual
 		matches = append(matches, result)
 		classes = append(classes, result.SelectedClass())
 	}
+	if persistentBlock != nil {
+		return *persistentBlock
+	}
 	sort.Strings(classes)
 	if len(matches) == 1 && len(results) == 1 {
 		selected := matches[0]
@@ -301,9 +304,6 @@ func ResolveHuaweiQualification(results ...HuaweiQualificationResult) HuaweiQual
 			reason:           HuaweiQualificationMultipleClasses,
 			candidateClasses: classes,
 		}
-	}
-	if persistentBlock != nil {
-		return *persistentBlock
 	}
 	if len(matches) == 1 {
 		return HuaweiQualificationResult{

--- a/huawei_qualification_cards_test.go
+++ b/huawei_qualification_cards_test.go
@@ -148,6 +148,32 @@ func TestHuaweiQualificationResolutionRejectsAmbiguityAndNeverFallsBack(t *testi
 	}
 }
 
+func TestHuaweiQualificationPersistentNonResponseDominatesEveryClassOrder(t *testing.T) {
+	smartLogger := NewHuaweiSmartLoggerQualificationCard().Evaluate(validHuaweiSmartLoggerQualificationInput())
+	emma := NewHuaweiEMMAQualificationCard().Evaluate(HuaweiEMMAQualificationInput{
+		UnitID: 0, Offering: "SmartHEMS", Model: "EMMA-A02", Firmware: "SmartHEMS V100R025C00SPC131",
+	})
+	blocked := NewHuaweiSDongleQualificationCard().Result()
+	permutations := [][]HuaweiQualificationResult{
+		{smartLogger, emma, blocked},
+		{smartLogger, blocked, emma},
+		{emma, smartLogger, blocked},
+		{emma, blocked, smartLogger},
+		{blocked, smartLogger, emma},
+		{blocked, emma, smartLogger},
+	}
+	for index, results := range permutations {
+		resolution := ResolveHuaweiQualification(results...)
+		if resolution.Readiness() != HuaweiQualificationEvidenceBlocked ||
+			resolution.Reason() != HuaweiQualificationPersistentNonResponse ||
+			!reflect.DeepEqual(resolution.MissingEvidence(), blocked.MissingEvidence()) ||
+			resolution.SelectedClass() != "" || len(resolution.CandidateClasses()) != 0 ||
+			resolution.NativeFactCount() != 0 || resolution.AutomaticRequestCount() != 0 || resolution.FallbackAttempted() {
+			t.Fatalf("permutation %d lost the complete S-Dongle hard stop: %#v", index, resolution)
+		}
+	}
+}
+
 func TestHuaweiSDongleQualificationCardPreservesPersistentNonResponseHardStop(t *testing.T) {
 	card := NewHuaweiSDongleQualificationCard()
 	result := card.Result()

--- a/huawei_qualification_cards_test.go
+++ b/huawei_qualification_cards_test.go
@@ -1,0 +1,235 @@
+package modbusreg
+
+import (
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestHuaweiQualificationCardsAreBoundedDefaultDeniedAndClassLocal(t *testing.T) {
+	smartLogger := NewHuaweiSmartLoggerQualificationCard()
+	if smartLogger.ID() != HuaweiSmartLoggerQualificationCardID || smartLogger.CandidateClass() != HuaweiSmartLoggerCanonicalClass ||
+		smartLogger.UnitID() != 0 || !reflect.DeepEqual(smartLogger.FirmwareTuples(), []string{"V300R024C10SPC191", "V300R024C10SPC210"}) ||
+		smartLogger.Limits() != (HuaweiQualificationInventoryLimits{DeadlineMilliseconds: 15000, MaxPages: 248, MaxObjects: 248, MaxBytes: 65536, MaxChildren: 247}) {
+		t.Fatalf("unexpected SmartLogger card: %#v", smartLogger)
+	}
+	assertHuaweiQualificationSteps(t, smartLogger.Steps(), []HuaweiQualificationStep{
+		{operation: "FC03_COUNTER_BEFORE", unitID: 0, offset: 65521, quantity: 1},
+		{operation: "FC2B_MEI_0E_READDEV03_INVENTORY", unitID: 0, objectID: 0x87},
+		{operation: "FC03_COUNTER_AFTER", unitID: 0, offset: 65521, quantity: 1},
+	})
+
+	emma := NewHuaweiEMMAQualificationCard()
+	if emma.ID() != HuaweiEMMAQualificationCardID || emma.CandidateClass() != HuaweiEMMACanonicalClass || emma.UnitID() != 0 ||
+		!reflect.DeepEqual(emma.ModelVariants(), []string{"EMMA-A01", "EMMA-A02"}) ||
+		!reflect.DeepEqual(emma.MissingCapabilityEvidence(), []string{"sanitized_readonly_capability_fixture", "negative_overlap_with_smartlogger", "model_specific_capability_fixture"}) {
+		t.Fatalf("unexpected EMMA card: %#v", emma)
+	}
+	assertHuaweiQualificationSteps(t, emma.Steps(), []HuaweiQualificationStep{
+		{operation: "FC03_OFFERING", unitID: 0, offset: 30000, quantity: 15},
+		{operation: "FC03_MODEL", unitID: 0, offset: 30222, quantity: 20},
+		{operation: "FC03_FIRMWARE", unitID: 0, offset: 30035, quantity: 15},
+	})
+
+	sdongle := NewHuaweiSDongleQualificationCard()
+	if sdongle.ID() != HuaweiSDongleQualificationCardID || sdongle.CandidateClass() != HuaweiSDongleCanonicalClass || sdongle.UnitID() != 100 ||
+		!sdongle.HardStop() || sdongle.Status() != HuaweiQualificationEvidenceBlocked || len(sdongle.Steps()) != 0 ||
+		!reflect.DeepEqual(sdongle.RequiredConnectionContext(), []string{"endpoint", "port", "unit_id_100", "gateway_child_topology"}) {
+		t.Fatalf("unexpected S-Dongle card: %#v", sdongle)
+	}
+
+	for _, result := range []HuaweiQualificationResult{smartLogger.EmptyResult(), emma.EmptyResult(), sdongle.Result()} {
+		if !result.DefaultDenied() || result.CatalogRegistered() || result.AutomaticRuntimeAdmission() || result.LiveQualified() ||
+			result.SupportClaim() || result.WriteAuthority() || result.NativeFactCount() != 0 || result.AutomaticRequestCount() != 0 || result.FallbackAttempted() || result.HardwareTestReady() {
+			t.Fatalf("qualification result created authority or telemetry: %#v", result)
+		}
+	}
+}
+
+func TestHuaweiSmartLoggerQualificationCardUsesStableSelfBackedInventory(t *testing.T) {
+	card := NewHuaweiSmartLoggerQualificationCard()
+	input := validHuaweiSmartLoggerQualificationInput()
+	result := card.Evaluate(input)
+	if !result.IdentityMatched() || result.SelectedClass() != HuaweiSmartLoggerCanonicalClass ||
+		result.Readiness() != HuaweiQualificationTestReady || !result.QualificationTestReady() || result.Reason() != HuaweiQualificationMatchedIdentityInventory {
+		t.Fatalf("unexpected SmartLogger result: %#v", result)
+	}
+	inventory, ok := result.Inventory()
+	if !ok || inventory.DeclaredChildren() != 1 || inventory.ChildCount() != 1 || inventory.Children()[0].Address() != "1" ||
+		inventory.Children()[0].Attribute("model") != "SUN2000" || inventory.Children()[0].Attribute("4") != "" {
+		t.Fatalf("unexpected retained inventory: %#v ok=%t", inventory, ok)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*HuaweiSmartLoggerQualificationInput)
+	}{
+		{"wrong unit", func(input *HuaweiSmartLoggerQualificationInput) { input.UnitID = 1 }},
+		{"wrong firmware", func(input *HuaweiSmartLoggerQualificationInput) {
+			input.Inventory.Pages[0].Objects[1].Value = []byte("1=SmartLogger;2=V300R024C10SPC999;5=0")
+		}},
+		{"EMMA self is not SmartLogger", func(input *HuaweiSmartLoggerQualificationInput) {
+			input.Inventory.Pages[0].Objects[1].Value = []byte("1=EMMA-A02;2=SmartHEMS V100R025C00SPC131;5=0")
+		}},
+		{"counter changed", func(input *HuaweiSmartLoggerQualificationInput) { input.Inventory.ChangeCounterAfter++ }},
+		{"malformed child", func(input *HuaweiSmartLoggerQualificationInput) {
+			input.Inventory.Pages[0].Objects[2].Value = []byte("1=SUN2000;5")
+		}},
+		{"unknown child attribute", func(input *HuaweiSmartLoggerQualificationInput) {
+			input.Inventory.Pages[0].Objects[2].Value = []byte("1=SUN2000;5=1;9=unknown")
+		}},
+		{"cursor loop", func(input *HuaweiSmartLoggerQualificationInput) {
+			input.Inventory.Pages[0].More = true
+			input.Inventory.Pages[0].NextObjectID = 0x87
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := validHuaweiSmartLoggerQualificationInput()
+			tc.mutate(&input)
+			result := card.Evaluate(input)
+			assertHuaweiQualificationFailureHasNoFallback(t, result)
+		})
+	}
+}
+
+func TestHuaweiEMMAQualificationCardPinsModelFirmwareAndMissingCapabilities(t *testing.T) {
+	card := NewHuaweiEMMAQualificationCard()
+	for _, input := range []HuaweiEMMAQualificationInput{
+		{UnitID: 0, Offering: "SmartHEMS", Model: "EMMA-A01", Firmware: "SmartHEMS V100R024C00SPC100"},
+		{UnitID: 0, Offering: "SmartHEMS", Model: "EMMA-A02", Firmware: "SmartHEMS V100R025C00SPC131"},
+	} {
+		result := card.Evaluate(input)
+		if !result.IdentityMatched() || result.SelectedClass() != HuaweiEMMACanonicalClass || result.ModelVariant() != input.Model ||
+			result.Readiness() != HuaweiQualificationEvidenceBlocked || result.QualificationTestReady() || result.Reason() != HuaweiQualificationIdentityMatchedCapabilitiesMissing ||
+			!reflect.DeepEqual(result.MissingEvidence(), card.MissingCapabilityEvidence()) || result.NativeFactCount() != 0 {
+			t.Fatalf("unexpected EMMA result for %#v: %#v", input, result)
+		}
+	}
+
+	for _, input := range []HuaweiEMMAQualificationInput{
+		{UnitID: 1, Offering: "SmartHEMS", Model: "EMMA-A02", Firmware: "SmartHEMS V100R025C00SPC131"},
+		{UnitID: 0, Offering: "SmartHEMS", Model: "SmartLogger", Firmware: "SmartHEMS V100R025C00SPC131"},
+		{UnitID: 0, Offering: "SmartHEMS", Model: "EMMA-A02", Firmware: "SmartHEMS V100R025C00SPC101"},
+	} {
+		assertHuaweiQualificationFailureHasNoFallback(t, card.Evaluate(input))
+	}
+}
+
+func TestHuaweiQualificationResolutionRejectsAmbiguityAndNeverFallsBack(t *testing.T) {
+	smartLogger := NewHuaweiSmartLoggerQualificationCard().Evaluate(validHuaweiSmartLoggerQualificationInput())
+	emma := NewHuaweiEMMAQualificationCard().Evaluate(HuaweiEMMAQualificationInput{
+		UnitID: 0, Offering: "SmartHEMS", Model: "EMMA-A02", Firmware: "SmartHEMS V100R025C00SPC131",
+	})
+	resolution := ResolveHuaweiQualification(smartLogger, emma)
+	if resolution.Readiness() != HuaweiQualificationAmbiguous || resolution.SelectedClass() != "" ||
+		!reflect.DeepEqual(resolution.CandidateClasses(), []string{HuaweiEMMACanonicalClass, HuaweiSmartLoggerCanonicalClass}) ||
+		resolution.NativeFactCount() != 0 || resolution.AutomaticRequestCount() != 0 || resolution.FallbackAttempted() {
+		t.Fatalf("ambiguous resolution leaked a selection: %#v", resolution)
+	}
+
+	failed := NewHuaweiSmartLoggerQualificationCard().Evaluate(HuaweiSmartLoggerQualificationInput{})
+	resolution = ResolveHuaweiQualification(failed)
+	if resolution.Readiness() != HuaweiQualificationInsufficientEvidence || resolution.SelectedClass() != "" ||
+		len(resolution.CandidateClasses()) != 0 || resolution.NativeFactCount() != 0 || resolution.AutomaticRequestCount() != 0 || resolution.FallbackAttempted() {
+		t.Fatalf("failed resolution created fallback: %#v", resolution)
+	}
+
+	resolution = ResolveHuaweiQualification(failed, emma)
+	if resolution.Readiness() != HuaweiQualificationInsufficientEvidence || resolution.SelectedClass() != "" || resolution.FallbackAttempted() {
+		t.Fatalf("mixed failed/positive classifications created cross-class fallback: %#v", resolution)
+	}
+
+	blocked := NewHuaweiSDongleQualificationCard().Result()
+	resolution = ResolveHuaweiQualification(blocked)
+	if resolution.Readiness() != HuaweiQualificationEvidenceBlocked || resolution.Reason() != HuaweiQualificationPersistentNonResponse || resolution.SelectedClass() != "" {
+		t.Fatalf("S-Dongle hard stop was downgraded by shared resolution: %#v", resolution)
+	}
+}
+
+func TestHuaweiSDongleQualificationCardPreservesPersistentNonResponseHardStop(t *testing.T) {
+	card := NewHuaweiSDongleQualificationCard()
+	result := card.Result()
+	wantMissing := []string{
+		"confirmed_gateway_connection_context",
+		"gateway_unit_100_topology",
+		"sanitized_basic_mei_product_model_fixture",
+		"exact_protocol_version_encoding_fixture",
+		"completed_search_stable_sequence_capacity_fixture",
+		"separately_qualified_child_unit_inventory_fixture",
+	}
+	if result.Readiness() != HuaweiQualificationEvidenceBlocked || result.Reason() != HuaweiQualificationPersistentNonResponse ||
+		result.IdentityMatched() || result.SelectedClass() != "" || !reflect.DeepEqual(result.MissingEvidence(), wantMissing) ||
+		result.QualificationTestReady() || result.AutomaticRequestCount() != 0 || result.FallbackAttempted() {
+		t.Fatalf("unexpected S-Dongle hard-stop result: %#v", result)
+	}
+
+	// A synthetic candidate tuple exercises only the existing offline decoder;
+	// it cannot overwrite the retained live evidence outcome of this card.
+	candidate := EvaluateHuaweiSDongleOfflineObservation(HuaweiSDongleOfflineObservation{
+		UnitID: 100, Model: "S-DongleA-05", Firmware: "V200R025C00SPC120", ProtocolMajor: 5, ProtocolMinor: 0,
+		SearchState: 0, ChangeSequenceBefore: 7, ChangeSequenceAfter: 7, Capacity: 2, ChildCount: 1,
+	})
+	if !candidate.Matched() || card.Result().Readiness() != HuaweiQualificationEvidenceBlocked || card.Result().IdentityMatched() {
+		t.Fatal("synthetic offline candidate overrode the persistent non-response hard stop")
+	}
+}
+
+func TestHuaweiQualificationPackageSanitizedExpectedResult(t *testing.T) {
+	encoded, err := json.Marshal(NewHuaweiQualificationPackage().ExpectedResult())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.ReadFile("testdata/huawei/qualification/readiness_expected.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotValue, wantValue any
+	if err := json.Unmarshal(encoded, &gotValue); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(want, &wantValue); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("expected result=%s want=%s", encoded, want)
+	}
+}
+
+func validHuaweiSmartLoggerQualificationInput() HuaweiSmartLoggerQualificationInput {
+	return HuaweiSmartLoggerQualificationInput{
+		UnitID: 0,
+		Inventory: HuaweiSmartLoggerOfflineInventoryInput{
+			ChangeCounterBefore: 7,
+			ChangeCounterAfter:  7,
+			Pages: []HuaweiSmartLoggerInventoryPage{{
+				Objects: []HuaweiSmartLoggerInventoryObject{
+					{ObjectID: 0x87, Value: []byte{1}},
+					{ObjectID: 0x88, Value: []byte("1=SmartLogger;2=V300R024C10SPC191;5=0")},
+					{ObjectID: 0x89, Value: []byte("1=SUN2000;2=V300R024C10SPC191;3=V1;4=synthetic-private-input;5=1;6=F1;8=PV")},
+				},
+			}},
+		},
+	}
+}
+
+func assertHuaweiQualificationFailureHasNoFallback(t *testing.T, result HuaweiQualificationResult) {
+	t.Helper()
+	if result.IdentityMatched() || result.SelectedClass() != "" || result.Readiness() != HuaweiQualificationInsufficientEvidence ||
+		result.NativeFactCount() != 0 || result.AutomaticRequestCount() != 0 || result.FallbackAttempted() || !result.DefaultDenied() {
+		t.Fatalf("failed classification created fallback, telemetry, or request: %#v", result)
+	}
+}
+
+func assertHuaweiQualificationSteps(t *testing.T, got, want []HuaweiQualificationStep) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("qualification steps=%#v want=%#v", got, want)
+	}
+	for _, step := range got {
+		if step.Operation() == "" || step.UnitID() != step.unitID || step.Offset() != step.offset || step.Quantity() != step.quantity || step.ObjectID() != step.objectID {
+			t.Fatalf("qualification step accessors disagree: %#v", step)
+		}
+	}
+}

--- a/testdata/huawei/qualification/readiness_expected.json
+++ b/testdata/huawei/qualification/readiness_expected.json
@@ -1,0 +1,51 @@
+{
+  "schema": "helianthus-huawei-qualification-readiness/v1",
+  "classes": [
+    {
+      "class": "SmartLogger",
+      "card_id": "huawei.qualification.smartlogger.readonly@1.0.0",
+      "status": "QUALIFICATION_TEST_READY",
+      "missing_evidence": ["connected_smartlogger_identity_inventory_capture"],
+      "hardware_test_ready": false,
+      "live_qualified": false,
+      "automatic_request_count": 0,
+      "native_fact_count": 0
+    },
+    {
+      "class": "EMMA",
+      "card_id": "huawei.qualification.emma.readonly@1.0.0",
+      "status": "QUALIFICATION_EVIDENCE_BLOCKED",
+      "missing_evidence": [
+        "sanitized_readonly_capability_fixture",
+        "negative_overlap_with_smartlogger",
+        "model_specific_capability_fixture"
+      ],
+      "hardware_test_ready": false,
+      "live_qualified": false,
+      "automatic_request_count": 0,
+      "native_fact_count": 0
+    },
+    {
+      "class": "S-Dongle",
+      "card_id": "huawei.qualification.sdongle.evidence-blocked@1.0.0",
+      "status": "QUALIFICATION_EVIDENCE_BLOCKED",
+      "missing_evidence": [
+        "confirmed_gateway_connection_context",
+        "gateway_unit_100_topology",
+        "sanitized_basic_mei_product_model_fixture",
+        "exact_protocol_version_encoding_fixture",
+        "completed_search_stable_sequence_capacity_fixture",
+        "separately_qualified_child_unit_inventory_fixture"
+      ],
+      "hardware_test_ready": false,
+      "live_qualified": false,
+      "automatic_request_count": 0,
+      "native_fact_count": 0
+    }
+  ],
+  "default_denied": true,
+  "catalog_registered": false,
+  "automatic_runtime_admission": false,
+  "support_claim": false,
+  "write_authority": false
+}


### PR DESCRIPTION
Closes #188.

Huawei provider evidence previously exposed individual identity and inventory
helpers without one bounded, class-local qualification result. This change adds
inert offline cards for SmartLogger, EMMA, and S-Dongle and a shared resolver
that refuses ambiguity and mixed-class fallback.

The cards reuse the existing SmartLogger inventory parser, EMMA identity helper,
and S-Dongle observation evaluator. They add no transport dispatch, catalog
registration, runtime admission, live qualification, support claim, write
authority, automatic request, or telemetry fact.

Class outcomes:

- SmartLogger: `QUALIFICATION_TEST_READY`; exact unit 0, firmware tuple,
  self-entry, child encoding, counter stability, malformed inventory, and cursor
  loop controls pass offline. A connected read-only identity/inventory capture
  remains missing.
- EMMA: `QUALIFICATION_EVIDENCE_BLOCKED`; exact EMMA-A01/A02 and branch-local
  firmware floors are reproducible, while sanitized read-only capability,
  SmartLogger negative-overlap, and model-specific capability fixtures remain
  missing.
- S-Dongle: `QUALIFICATION_EVIDENCE_BLOCKED`; the retained persistent
  non-response at unit 100 is a hard stop. Confirmed connection context,
  gateway/child topology, exact identity/protocol encoding, stable
  search/capacity, and separately qualified child inventory remain missing.

RED evidence:

- `GOWORK=off go test -run 'TestHuaweiQualification' -count=1 ./...` initially
  failed because the qualification-card API did not exist.
- The mixed failed-SmartLogger plus positive-EMMA resolver test then failed by
  selecting EMMA; the resolver now returns insufficient evidence with no class,
  facts, requests, or fallback.
- Independent review of the first pushed head found that two positive classes
  were resolved as ambiguous before a retained S-Dongle persistent non-response
  was considered. The new three-result regression reproduced that loss. The
  hard stop now takes precedence, preserving its reason and complete missing-
  evidence list in all six input orders with no class, fact, request, or
  fallback.

Validation on the pushed head:

- `./scripts/ci_local.sh` — pass: terminology, scope, 14 scope-policy mutation
  tests, gofmt, vet, build, Go race tests, and golangci-lint with 0 issues
- `GOWORK=off go test -count=1 -json ./...` — 860 tests passed, 0 failed
- focused Huawei qualification suite — pass
- `git diff --check` — pass

Documentation gate: Project-Helianthus/helianthus-docs-modbus#136 merged first
as `5da1e9c47077c2d8aa39321c26770ed96333644a` after an independent
`NO_BLOCKING_FINDINGS` verdict on its exact head. The change remains
provider-local; acquisition, gateway integration, semantic publication, public
surfaces, physical qualification, and hardware acceptance remain with later
integration work.
