### PR TITLE
REG-TESLA: validate Gen3 FC100 current-limit provenance

### DIFF
--- a/tesla_gen3_evse_current_limit.go
+++ b/tesla_gen3_evse_current_limit.go
@@ -1,6 +1,9 @@
 package modbusreg
 
-import "fmt"
+import (
+	"fmt"
+	"math"
+)
 
 const TeslaGen3CurrentLimitOperationVersion24443 = "wc3_24_44_3"
 const (
@@ -21,9 +24,17 @@ type TeslaGen3PersistentCurrentLimit struct {
 
 func NewTeslaGen3PersistentCurrentLimit(s TeslaGen3PersistentCurrentLimitSpec) (TeslaGen3PersistentCurrentLimit, error) {
 	r, e := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCConfigureSettings, s.RequestPayload, [][]byte{s.TerminalPayload})
+	request, requestErr := teslaGen3ExactFC100RequestBody(TeslaFC100OperationWCConfigureSettings, s.RequestPayload)
+	requestAmps, requestDecodeErr := decodeTeslaGen3PersistentCurrentLimitBody(request)
+	var terminalAmps uint32
+	var terminalDecodeErr error
+	if len(r) == 1 {
+		terminalAmps, terminalDecodeErr = decodeTeslaGen3PersistentCurrentLimitBody(r[0].Body)
+	}
 	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 ||
-		!teslaGen3ExactFC100Request(TeslaFC100OperationWCConfigureSettings, s.RequestPayload) ||
-		e != nil || len(r) != 1 || r[0].Kind != TeslaFC100OperationTerminal {
+		requestErr != nil || requestDecodeErr != nil || terminalDecodeErr != nil ||
+		e != nil || len(r) != 1 || r[0].Kind != TeslaFC100OperationTerminal ||
+		s.MaxOutputCurrentAmps != requestAmps || requestAmps != terminalAmps {
 		return TeslaGen3PersistentCurrentLimit{}, fmt.Errorf("Gen3 persistent current limit context is invalid")
 	}
 	return TeslaGen3PersistentCurrentLimit{s.OperationVersion, s.MaxOutputCurrentAmps, append([]byte(nil), s.RequestPayload...), append([]byte(nil), s.TerminalPayload...)}, nil
@@ -47,6 +58,7 @@ type TeslaGen3ProvisionalCurrentLimit struct {
 	operationVersion                         string
 	limitCurrentMaxAmps, limitTimeoutSeconds uint32
 	inhibitCharging                          bool
+	configuredCurrentAmps                    uint32
 	setRequestPayload                        []byte
 	ackPayload                               []byte
 	readbackRequestPayload                   []byte
@@ -56,11 +68,21 @@ type TeslaGen3ProvisionalCurrentLimit struct {
 func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec) (TeslaGen3ProvisionalCurrentLimit, error) {
 	a, e := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCSetProvisional, s.SetRequestPayload, [][]byte{s.AckPayload})
 	b, f := DecodeTeslaFC100OperationSequence(s.OperationVersion, TeslaFC100OperationWCGetProvisional, s.ReadbackRequestPayload, [][]byte{s.ReadbackTerminalPayload})
+	setRequest, setRequestErr := teslaGen3ExactFC100RequestBody(TeslaFC100OperationWCSetProvisional, s.SetRequestPayload)
+	setValues, setDecodeErr := decodeTeslaGen3ProvisionalCurrentLimitBody(setRequest, false)
+	readbackRequest, readbackRequestErr := teslaGen3ExactFC100RequestBody(TeslaFC100OperationWCGetProvisional, s.ReadbackRequestPayload)
+	var readbackValues teslaGen3ProvisionalCurrentLimitWire
+	var readbackDecodeErr error
+	if len(b) == 1 {
+		readbackValues, readbackDecodeErr = decodeTeslaGen3ProvisionalCurrentLimitBody(b[0].Body, true)
+	}
 	if s.OperationVersion != TeslaGen3CurrentLimitOperationVersion24443 ||
-		!teslaGen3ExactFC100Request(TeslaFC100OperationWCSetProvisional, s.SetRequestPayload) ||
-		!teslaGen3ExactFC100Request(TeslaFC100OperationWCGetProvisional, s.ReadbackRequestPayload) ||
+		setRequestErr != nil || setDecodeErr != nil || readbackRequestErr != nil || len(readbackRequest) != 0 ||
+		readbackDecodeErr != nil ||
 		e != nil || f != nil || len(a) != 1 || len(b) != 1 ||
-		a[0].Kind != TeslaFC100OperationTerminal || b[0].Kind != TeslaFC100OperationTerminal {
+		a[0].Kind != TeslaFC100OperationTerminal || b[0].Kind != TeslaFC100OperationTerminal || len(a[0].Body) != 0 ||
+		s.LimitCurrentMaxAmps != setValues.amps || s.LimitTimeoutSeconds != setValues.timeout || s.InhibitCharging != setValues.inhibit ||
+		setValues.amps != readbackValues.amps || setValues.timeout != readbackValues.timeout || setValues.inhibit != readbackValues.inhibit {
 		return TeslaGen3ProvisionalCurrentLimit{}, fmt.Errorf("Gen3 provisional current limit context is invalid")
 	}
 	return TeslaGen3ProvisionalCurrentLimit{
@@ -68,6 +90,7 @@ func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec)
 		limitCurrentMaxAmps:     s.LimitCurrentMaxAmps,
 		limitTimeoutSeconds:     s.LimitTimeoutSeconds,
 		inhibitCharging:         s.InhibitCharging,
+		configuredCurrentAmps:   readbackValues.configured,
 		setRequestPayload:       append([]byte(nil), s.SetRequestPayload...),
 		ackPayload:              append([]byte(nil), s.AckPayload...),
 		readbackRequestPayload:  append([]byte(nil), s.ReadbackRequestPayload...),
@@ -75,27 +98,29 @@ func NewTeslaGen3ProvisionalCurrentLimit(s TeslaGen3ProvisionalCurrentLimitSpec)
 	}, nil
 }
 
-func teslaGen3ExactFC100Request(operation TeslaFC100Operation, payload []byte) bool {
+func teslaGen3ExactFC100RequestBody(operation TeslaFC100Operation, payload []byte) ([]byte, error) {
 	spec, ok := teslaFC100OperationSpecs[operation]
 	if !ok {
-		return false
+		return nil, fmt.Errorf("Gen3 FC100 operation is unsupported")
 	}
 	envelope, err := DecodeTeslaHSCEnvelope(teslaHSCFunction100, payload)
 	if err != nil {
-		return false
+		return nil, err
 	}
 	family, err := decodeExactLengthDelimitedField(envelope.Payload(), spec.family)
 	if err != nil {
-		return false
+		return nil, err
 	}
-	_, err = decodeExactLengthDelimitedField(family, spec.requestTag)
-	return err == nil
+	return decodeExactLengthDelimitedField(family, spec.requestTag)
 }
 
 func (v TeslaGen3ProvisionalCurrentLimit) OperationVersion() string    { return v.operationVersion }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitCurrentMaxAmps() uint32 { return v.limitCurrentMaxAmps }
 func (v TeslaGen3ProvisionalCurrentLimit) LimitTimeoutSeconds() uint32 { return v.limitTimeoutSeconds }
 func (v TeslaGen3ProvisionalCurrentLimit) InhibitCharging() bool       { return v.inhibitCharging }
+func (v TeslaGen3ProvisionalCurrentLimit) ConfiguredCurrentAmps() uint32 {
+	return v.configuredCurrentAmps
+}
 func (v TeslaGen3ProvisionalCurrentLimit) SetRequestPayload() []byte {
 	return append([]byte(nil), v.setRequestPayload...)
 }
@@ -119,3 +144,124 @@ func NewTeslaGen3InteroperableCurrentLimit(a, t uint32) (TeslaGen3InteroperableC
 }
 func (v TeslaGen3InteroperableCurrentLimit) MaxAmps() uint32        { return v.maxAmps }
 func (v TeslaGen3InteroperableCurrentLimit) TimeoutSeconds() uint32 { return v.timeoutSeconds }
+
+type teslaGen3CurrentLimitWireField struct {
+	varint uint64
+	bytes  []byte
+}
+
+func decodeTeslaGen3CurrentLimitFields(body []byte, known map[uint64]uint8) (map[uint64]teslaGen3CurrentLimitWireField, error) {
+	fields := make(map[uint64]teslaGen3CurrentLimitWireField, len(known))
+	for offset := 0; offset < len(body); {
+		key, keyWidth, err := decodeTeslaFC100Varint(body[offset:])
+		if err != nil || key>>3 == 0 || key&7 > 5 {
+			return nil, fmt.Errorf("Gen3 current-limit protobuf field is invalid")
+		}
+		number, wireType := key>>3, uint8(key&7)
+		expectedWireType, isKnown := known[number]
+		if !isKnown {
+			_, consumed, err := decodeTeslaFC100RequestField(body[offset:])
+			if err != nil {
+				return nil, fmt.Errorf("Gen3 current-limit unknown protobuf field is malformed")
+			}
+			offset += consumed
+			continue
+		}
+		if wireType != expectedWireType {
+			return nil, fmt.Errorf("Gen3 current-limit protobuf field has wrong wire type")
+		}
+		if _, exists := fields[number]; exists {
+			return nil, fmt.Errorf("Gen3 current-limit protobuf field is duplicated")
+		}
+		offset += keyWidth
+		field := teslaGen3CurrentLimitWireField{}
+		switch wireType {
+		case 0:
+			value, width, err := decodeTeslaFC100Varint(body[offset:])
+			if err != nil {
+				return nil, fmt.Errorf("Gen3 current-limit protobuf value is malformed")
+			}
+			field.varint = value
+			offset += width
+		case 2:
+			length, width, err := decodeTeslaFC100Varint(body[offset:])
+			if err != nil || length > uint64(len(body)-offset-width) {
+				return nil, fmt.Errorf("Gen3 current-limit protobuf body is malformed")
+			}
+			offset += width
+			field.bytes = append([]byte(nil), body[offset:offset+int(length)]...)
+			offset += int(length)
+		default:
+			return nil, fmt.Errorf("Gen3 current-limit protobuf wire type is unsupported")
+		}
+		fields[number] = field
+	}
+	return fields, nil
+}
+
+func requiredTeslaGen3CurrentLimitField(fields map[uint64]teslaGen3CurrentLimitWireField, number uint64) (teslaGen3CurrentLimitWireField, error) {
+	field, ok := fields[number]
+	if !ok {
+		return teslaGen3CurrentLimitWireField{}, fmt.Errorf("Gen3 current-limit protobuf field is absent")
+	}
+	return field, nil
+}
+
+func decodeTeslaGen3PersistentCurrentLimitBody(body []byte) (uint32, error) {
+	outer, err := decodeTeslaGen3CurrentLimitFields(body, map[uint64]uint8{1: 2})
+	if err != nil {
+		return 0, err
+	}
+	settings, err := requiredTeslaGen3CurrentLimitField(outer, 1)
+	if err != nil {
+		return 0, err
+	}
+	inner, err := decodeTeslaGen3CurrentLimitFields(settings.bytes, map[uint64]uint8{1: 0})
+	if err != nil {
+		return 0, err
+	}
+	amps, err := requiredTeslaGen3CurrentLimitField(inner, 1)
+	if err != nil || amps.varint > math.MaxInt32 {
+		return 0, fmt.Errorf("Gen3 persistent current limit is invalid")
+	}
+	return uint32(amps.varint), nil
+}
+
+type teslaGen3ProvisionalCurrentLimitWire struct {
+	amps, timeout, configured uint32
+	inhibit                   bool
+}
+
+func decodeTeslaGen3ProvisionalCurrentLimitBody(body []byte, requireConfigured bool) (teslaGen3ProvisionalCurrentLimitWire, error) {
+	known := map[uint64]uint8{1: 2}
+	if requireConfigured {
+		known[2] = 0
+	}
+	outer, err := decodeTeslaGen3CurrentLimitFields(body, known)
+	if err != nil {
+		return teslaGen3ProvisionalCurrentLimitWire{}, err
+	}
+	provisional, err := requiredTeslaGen3CurrentLimitField(outer, 1)
+	if err != nil {
+		return teslaGen3ProvisionalCurrentLimitWire{}, err
+	}
+	inner, err := decodeTeslaGen3CurrentLimitFields(provisional.bytes, map[uint64]uint8{1: 0, 2: 0, 3: 0})
+	if err != nil {
+		return teslaGen3ProvisionalCurrentLimitWire{}, err
+	}
+	amps, ampsErr := requiredTeslaGen3CurrentLimitField(inner, 1)
+	timeout, timeoutErr := requiredTeslaGen3CurrentLimitField(inner, 2)
+	inhibit, inhibitErr := requiredTeslaGen3CurrentLimitField(inner, 3)
+	if ampsErr != nil || timeoutErr != nil || inhibitErr != nil || amps.varint > math.MaxUint32 || timeout.varint > math.MaxUint32 || inhibit.varint > 1 {
+		return teslaGen3ProvisionalCurrentLimitWire{}, fmt.Errorf("Gen3 provisional current limit is invalid")
+	}
+	result := teslaGen3ProvisionalCurrentLimitWire{amps: uint32(amps.varint), timeout: uint32(timeout.varint), inhibit: inhibit.varint == 1}
+	if requireConfigured {
+		configured, err := requiredTeslaGen3CurrentLimitField(outer, 2)
+		if err != nil || configured.varint > math.MaxUint32 {
+			return teslaGen3ProvisionalCurrentLimitWire{}, fmt.Errorf("Gen3 configured current limit is invalid")
+		}
+		result.configured = uint32(configured.varint)
+	}
+	return result, nil
+}

--- a/tesla_gen3_evse_current_limit_test.go
+++ b/tesla_gen3_evse_current_limit_test.go
@@ -25,21 +25,59 @@ func currentLimitTerminal(operation TeslaFC100Operation, body []byte) []byte {
 	return append([]byte{byte(len(message))}, message...)
 }
 
+func currentLimitVarint(value uint64) []byte {
+	return appendTeslaFC100Varint(nil, value)
+}
+
+func currentLimitField(field uint64, body []byte) []byte {
+	result := appendTeslaFC100Varint(nil, field<<3|2)
+	result = appendTeslaFC100Varint(result, uint64(len(body)))
+	return append(result, body...)
+}
+
+func persistentCurrentLimitBody(amps uint32) []byte {
+	settings := appendTeslaFC100Varint(nil, 1<<3)
+	settings = append(settings, currentLimitVarint(uint64(amps))...)
+	return currentLimitField(1, settings)
+}
+
+func provisionalCurrentLimitFields(amps, timeout uint32, inhibit bool) []byte {
+	result := appendTeslaFC100Varint(nil, 1<<3)
+	result = append(result, currentLimitVarint(uint64(amps))...)
+	result = appendTeslaFC100Varint(result, 2<<3)
+	result = append(result, currentLimitVarint(uint64(timeout))...)
+	result = appendTeslaFC100Varint(result, 3<<3)
+	if inhibit {
+		return append(result, 1)
+	}
+	return append(result, 0)
+}
+
+func provisionalCurrentLimitBody(amps, timeout uint32, inhibit bool) []byte {
+	return currentLimitField(1, provisionalCurrentLimitFields(amps, timeout, inhibit))
+}
+
+func provisionalCurrentLimitReadbackBody(amps, timeout, configured uint32, inhibit bool) []byte {
+	result := provisionalCurrentLimitBody(amps, timeout, inhibit)
+	result = appendTeslaFC100Varint(result, 2<<3)
+	return append(result, currentLimitVarint(uint64(configured))...)
+}
+
 func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *testing.T) {
 	persistent, err := NewTeslaGen3PersistentCurrentLimit(TeslaGen3PersistentCurrentLimitSpec{
 		OperationVersion:     TeslaGen3CurrentLimitOperationVersion24443,
 		MaxOutputCurrentAmps: 16,
-		RequestPayload:       currentLimitRequest(t, TeslaFC100OperationWCConfigureSettings, []byte{0x08, 0x10}),
-		TerminalPayload:      currentLimitTerminal(TeslaFC100OperationWCConfigureSettings, []byte{0x08, 0x10}),
+		RequestPayload:       currentLimitRequest(t, TeslaFC100OperationWCConfigureSettings, persistentCurrentLimitBody(16)),
+		TerminalPayload:      currentLimitTerminal(TeslaFC100OperationWCConfigureSettings, persistentCurrentLimitBody(16)),
 	})
 	if err != nil || persistent.MaxOutputCurrentAmps() != 16 || persistent.OperationVersion() != TeslaGen3CurrentLimitOperationVersion24443 {
 		t.Fatalf("persistent record = %#v, %v", persistent, err)
 	}
 
-	setRequest := currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10})
+	setRequest := currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, provisionalCurrentLimitBody(16, 600, false))
 	ack := currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil)
 	readbackRequest := currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil)
-	readbackTerminal := currentLimitTerminal(TeslaFC100OperationWCGetProvisional, []byte{0x08, 0x10})
+	readbackTerminal := currentLimitTerminal(TeslaFC100OperationWCGetProvisional, provisionalCurrentLimitReadbackBody(16, 600, 32, false))
 	setRequestWant := append([]byte(nil), setRequest...)
 	ackWant := append([]byte(nil), ack...)
 	readbackRequestWant := append([]byte(nil), readbackRequest...)
@@ -54,7 +92,7 @@ func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *test
 		ReadbackRequestPayload:  readbackRequest,
 		ReadbackTerminalPayload: readbackTerminal,
 	})
-	if err != nil || provisional.LimitCurrentMaxAmps() != 16 || provisional.LimitTimeoutSeconds() != 600 || provisional.InhibitCharging() {
+	if err != nil || provisional.LimitCurrentMaxAmps() != 16 || provisional.LimitTimeoutSeconds() != 600 || provisional.ConfiguredCurrentAmps() != 32 || provisional.InhibitCharging() {
 		t.Fatalf("provisional record = %#v, %v", provisional, err)
 	}
 	for _, source := range [][]byte{setRequest, ack, readbackRequest, readbackTerminal} {
@@ -78,6 +116,67 @@ func TestTeslaGen3EVSECurrentLimitRetainsPersistentAndProvisionalRecords(t *test
 		if bytes.Equal(got, evidence.get()) {
 			t.Fatalf("%s getter did not defensively copy", evidence.name)
 		}
+	}
+}
+
+func TestTeslaGen3CurrentLimitRetainsUnknownWireMembersAsRawEvidence(t *testing.T) {
+	setBody := append(provisionalCurrentLimitBody(16, 600, false), 0x28, 0x2a)
+	readbackBody := append(provisionalCurrentLimitReadbackBody(16, 600, 32, false), 0x28, 0x2a)
+	setRequest := currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, setBody)
+	readbackTerminal := currentLimitTerminal(TeslaFC100OperationWCGetProvisional, readbackBody)
+	limit, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
+		OperationVersion:    TeslaGen3CurrentLimitOperationVersion24443,
+		LimitCurrentMaxAmps: 16, LimitTimeoutSeconds: 600,
+		SetRequestPayload:       setRequest,
+		AckPayload:              currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil),
+		ReadbackRequestPayload:  currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil),
+		ReadbackTerminalPayload: readbackTerminal,
+	})
+	if err != nil || !bytes.Equal(limit.SetRequestPayload(), setRequest) || !bytes.Equal(limit.ReadbackTerminalPayload(), readbackTerminal) {
+		t.Fatalf("unknown wire evidence = %#v, %v", limit, err)
+	}
+}
+
+func TestTeslaGen3CurrentLimitRejectsForgedTypedValuesAndMalformedBodies(t *testing.T) {
+	persistentRequest := currentLimitRequest(t, TeslaFC100OperationWCConfigureSettings, persistentCurrentLimitBody(16))
+	persistentTerminal := currentLimitTerminal(TeslaFC100OperationWCConfigureSettings, persistentCurrentLimitBody(16))
+	setRequest := currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, provisionalCurrentLimitBody(16, 600, false))
+	readbackRequest := currentLimitRequest(t, TeslaFC100OperationWCGetProvisional, nil)
+	readbackTerminal := currentLimitTerminal(TeslaFC100OperationWCGetProvisional, provisionalCurrentLimitReadbackBody(16, 600, 32, false))
+
+	if _, err := NewTeslaGen3PersistentCurrentLimit(TeslaGen3PersistentCurrentLimitSpec{
+		OperationVersion: TeslaGen3CurrentLimitOperationVersion24443, MaxOutputCurrentAmps: 32,
+		RequestPayload: persistentRequest, TerminalPayload: persistentTerminal,
+	}); err == nil {
+		t.Fatal("persistent typed value detached from retained bodies was accepted")
+	}
+	for _, tc := range []struct {
+		name, setBody, readbackBody string
+		ack                         []byte
+	}{
+		{"typed", string(provisionalCurrentLimitBody(16, 600, false)), string(provisionalCurrentLimitReadbackBody(16, 600, 32, false)), currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil)},
+		{"ack body", string(provisionalCurrentLimitBody(16, 600, false)), string(provisionalCurrentLimitReadbackBody(16, 600, 32, false)), currentLimitTerminal(TeslaFC100OperationWCSetProvisional, []byte{0x08, 0x10})},
+		{"mismatch", string(provisionalCurrentLimitBody(16, 600, false)), string(provisionalCurrentLimitReadbackBody(15, 600, 32, false)), currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil)},
+		{"duplicate", string(append(provisionalCurrentLimitBody(16, 600, false), currentLimitField(1, provisionalCurrentLimitFields(16, 600, false))...)), string(provisionalCurrentLimitReadbackBody(16, 600, 32, false)), currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil)},
+		{"malformed", string([]byte{0x0a, 0x01, 0x08}), string(provisionalCurrentLimitReadbackBody(16, 600, 32, false)), currentLimitTerminal(TeslaFC100OperationWCSetProvisional, nil)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := setRequest
+			if tc.name != "typed" {
+				request = currentLimitRequest(t, TeslaFC100OperationWCSetProvisional, []byte(tc.setBody))
+			}
+			terminal := readbackTerminal
+			if tc.name == "mismatch" || tc.name == "duplicate" || tc.name == "malformed" {
+				terminal = currentLimitTerminal(TeslaFC100OperationWCGetProvisional, []byte(tc.readbackBody))
+			}
+			_, err := NewTeslaGen3ProvisionalCurrentLimit(TeslaGen3ProvisionalCurrentLimitSpec{
+				OperationVersion: TeslaGen3CurrentLimitOperationVersion24443, LimitCurrentMaxAmps: 32, LimitTimeoutSeconds: 600,
+				SetRequestPayload: request, AckPayload: tc.ack, ReadbackRequestPayload: readbackRequest, ReadbackTerminalPayload: terminal,
+			})
+			if err == nil {
+				t.Fatal("invalid provisional context was accepted")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Scope

Closes #190. Decodes the documented `wc3_24_44_3` FC100 t7/t8 and t25/t26/t27/t28 bodies only, then accepts typed native records only when constructor fields match the retained request and terminal bodies.

`t8` is parsed as returned persistent settings; empty `t26` is enforced as an acknowledgement; t28 configured current is retained separately from provisional current. The decoder rejects malformed, duplicate known singular, wrong-wire, incomplete, mismatched, and out-of-range typed bodies while retaining raw evidence, including unknown well-formed members.

## Documentation gate

The public field contract was independently accepted in docs PR Project-Helianthus/helianthus-docs-modbus#138 at reviewed HEAD `a2c85d75de1b8b70182b7555743e2324f2a6cb68` and merged to main as `16b3d9b4716ff96c7e0678be492572155ed6de8b`. The documentation gate is satisfied. This registry PR still requires its own fresh independent exact-HEAD code review before merge.

## Validation

- RED: `GOWORK=off go test -run 'TestTeslaGen3(CurrentLimitRejectsForgedTypedValuesAndMalformedBodies|EVSECurrentLimitRetainsPersistentAndProvisionalRecords)' -count=1 .` failed before implementation because a forged persistent typed value was accepted.
- GREEN: `GOWORK=off go test -run '^TestTeslaGen3' -count=1 .` passed.
- Full local gate: `./scripts/ci_local.sh` passed: 14 Python mutation tests, Go vet/build, race tests, and golangci-lint (0 issues).

## Residual risk

The version-qualified decoder makes no transport, dispatcher, sender, write, applied-current, hardware, or causal claim. t28 has no nonce, timestamp, or generation counter; matching retained values remain only a constructor acceptance condition. FC101 and FC102 remain opaque.
