### PR TITLE
REG-TESLA: bind legacy dynamic current to frames

### DIFF
--- a/tesla_legacy_fbe0_fde0.go
+++ b/tesla_legacy_fbe0_fde0.go
@@ -3,8 +3,11 @@ package modbusreg
 import "fmt"
 
 const (
-	teslaLegacyFBE0PayloadLength = 7
-	teslaLegacyFDE0PayloadLength = 9
+	teslaLegacyHeartbeatDataProtocol1Length = 7
+	teslaLegacyHeartbeatDataProtocol2Length = 9
+	teslaLegacyAddressContextLength         = 4
+	teslaLegacyDynamicCurrentPayload1Length = teslaLegacyAddressContextLength + teslaLegacyHeartbeatDataProtocol1Length
+	teslaLegacyDynamicCurrentPayload2Length = teslaLegacyAddressContextLength + teslaLegacyHeartbeatDataProtocol2Length
 )
 
 // TeslaLegacyQualification states the evidence tier for a legacy Tesla record.
@@ -57,7 +60,7 @@ type TeslaLegacyFBE0Observation struct {
 func NewTeslaLegacyFBE0Observation(spec TeslaLegacyFBE0ObservationSpec) (TeslaLegacyFBE0Observation, error) {
 	payload, qualification, err := teslaLegacyDynamicCurrentPayload(
 		spec.Profile, spec.Direction, spec.Raw,
-		TeslaLegacyWallConnectorRequest, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, teslaLegacyFBE0PayloadLength, teslaLegacyFDE0PayloadLength,
+		TeslaLegacyWallConnectorRequest, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, teslaLegacyDynamicCurrentPayload1Length, teslaLegacyDynamicCurrentPayload2Length,
 	)
 	if err != nil {
 		return TeslaLegacyFBE0Observation{}, err
@@ -132,7 +135,7 @@ type TeslaLegacyFDE0Observation struct {
 func NewTeslaLegacyFDE0Observation(spec TeslaLegacyFDE0ObservationSpec) (TeslaLegacyFDE0Observation, error) {
 	payload, qualification, err := teslaLegacyDynamicCurrentPayload(
 		spec.Profile, spec.Direction, spec.Raw,
-		TeslaLegacyWallConnectorResponse, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, teslaLegacyFDE0PayloadLength,
+		TeslaLegacyWallConnectorResponse, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, teslaLegacyDynamicCurrentPayload1Length, teslaLegacyDynamicCurrentPayload2Length,
 	)
 	if err != nil {
 		return TeslaLegacyFDE0Observation{}, err

--- a/tesla_legacy_fbe0_fde0.go
+++ b/tesla_legacy_fbe0_fde0.go
@@ -2,6 +2,11 @@ package modbusreg
 
 import "fmt"
 
+const (
+	teslaLegacyFBE0PayloadLength = 7
+	teslaLegacyFDE0PayloadLength = 9
+)
+
 // TeslaLegacyQualification states the evidence tier for a legacy Tesla record.
 type TeslaLegacyQualification string
 
@@ -24,8 +29,84 @@ func (state TeslaLegacyFDE0State) IsAbsoluteOffer() bool {
 	return state == TeslaLegacyFDE0StatePreCharge || state == TeslaLegacyFDE0StateCharging
 }
 
-// TeslaLegacyFDE0ObservationSpec contains a bounded legacy FDE0 observation.
+// TeslaLegacyFBE0ObservationSpec binds an FBE0 request to one explicitly
+// selected legacy profile and its complete encoded wire frame.
+type TeslaLegacyFBE0ObservationSpec struct {
+	Profile        TeslaLegacyWallConnectorProfile
+	Direction      TeslaLegacyDirection
+	Qualification  TeslaLegacyQualification
+	State          TeslaLegacyFDE0State
+	AllocatedMaxCA uint16
+	Raw            []byte
+}
+
+// TeslaLegacyFBE0Observation retains one native allocation request. It does
+// not establish that an allocation was applied by a device.
+type TeslaLegacyFBE0Observation struct {
+	qualification  TeslaLegacyQualification
+	sourceID       uint16
+	destinationID  uint16
+	state          TeslaLegacyFDE0State
+	allocatedMaxCA uint16
+	raw            []byte
+}
+
+// NewTeslaLegacyFBE0Observation validates and parses one complete FBE0
+// request. The caller-supplied typed fields are checked against the validated
+// wire frame, so no typed observation can be detached from its native bytes.
+func NewTeslaLegacyFBE0Observation(spec TeslaLegacyFBE0ObservationSpec) (TeslaLegacyFBE0Observation, error) {
+	payload, qualification, err := teslaLegacyDynamicCurrentPayload(
+		spec.Profile, spec.Direction, spec.Raw,
+		TeslaLegacyWallConnectorRequest, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, teslaLegacyFBE0PayloadLength, teslaLegacyFDE0PayloadLength,
+	)
+	if err != nil {
+		return TeslaLegacyFBE0Observation{}, err
+	}
+	state, allocatedMaxCA := teslaLegacyAllocationFields(payload)
+	if spec.Qualification != qualification || spec.State != state || spec.AllocatedMaxCA != allocatedMaxCA {
+		return TeslaLegacyFBE0Observation{}, fmt.Errorf("legacy Tesla FBE0 typed fields do not match validated raw frame")
+	}
+	return TeslaLegacyFBE0Observation{
+		qualification:  qualification,
+		sourceID:       teslaLegacyID(payload[0:2]),
+		destinationID:  teslaLegacyID(payload[2:4]),
+		state:          state,
+		allocatedMaxCA: allocatedMaxCA,
+		raw:            append([]byte(nil), spec.Raw...),
+	}, nil
+}
+
+func (observation TeslaLegacyFBE0Observation) Qualification() TeslaLegacyQualification {
+	return observation.qualification
+}
+func (observation TeslaLegacyFBE0Observation) SourceID() uint16 { return observation.sourceID }
+func (observation TeslaLegacyFBE0Observation) DestinationID() uint16 {
+	return observation.destinationID
+}
+func (observation TeslaLegacyFBE0Observation) State() TeslaLegacyFDE0State { return observation.state }
+func (observation TeslaLegacyFBE0Observation) AllocatedMaxCA() uint16 {
+	return observation.allocatedMaxCA
+}
+
+// AbsoluteOfferCA exposes an absolute native allocation only for the two
+// documented absolute-offer states. Relative and unknown states stay raw-only.
+func (observation TeslaLegacyFBE0Observation) AbsoluteOfferCA() (uint16, bool) {
+	if !observation.state.IsAbsoluteOffer() {
+		return 0, false
+	}
+	return observation.allocatedMaxCA, true
+}
+
+// Raw returns an independent copy of the complete validated encoded frame.
+func (observation TeslaLegacyFBE0Observation) Raw() []byte {
+	return append([]byte(nil), observation.raw...)
+}
+
+// TeslaLegacyFDE0ObservationSpec binds an FDE0 response to one explicitly
+// selected legacy profile and its complete encoded wire frame.
 type TeslaLegacyFDE0ObservationSpec struct {
+	Profile         TeslaLegacyWallConnectorProfile
+	Direction       TeslaLegacyDirection
 	Qualification   TeslaLegacyQualification
 	State           TeslaLegacyFDE0State
 	AllocatedMaxCA  uint16
@@ -37,26 +118,47 @@ type TeslaLegacyFDE0ObservationSpec struct {
 // inferring device limits, EVSE control, or a protocol-neutral fact.
 type TeslaLegacyFDE0Observation struct {
 	qualification   TeslaLegacyQualification
+	sourceID        uint16
+	destinationID   uint16
 	state           TeslaLegacyFDE0State
 	allocatedMaxCA  uint16
 	actualCurrentCA uint16
 	raw             []byte
 }
 
-// NewTeslaLegacyFDE0Observation validates and defensively retains a bounded
-// native FDE0 observation.
+// NewTeslaLegacyFDE0Observation validates and parses one complete FDE0
+// response. The caller-supplied typed fields are checked against the validated
+// wire frame, so no typed observation can be detached from its native bytes.
 func NewTeslaLegacyFDE0Observation(spec TeslaLegacyFDE0ObservationSpec) (TeslaLegacyFDE0Observation, error) {
-	if spec.Qualification != TeslaLegacyFamilyCompatible && spec.Qualification != TeslaLegacyBuildConfirmed {
-		return TeslaLegacyFDE0Observation{}, fmt.Errorf("legacy Tesla qualification is unsupported")
+	payload, qualification, err := teslaLegacyDynamicCurrentPayload(
+		spec.Profile, spec.Direction, spec.Raw,
+		TeslaLegacyWallConnectorResponse, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, teslaLegacyFDE0PayloadLength,
+	)
+	if err != nil {
+		return TeslaLegacyFDE0Observation{}, err
 	}
-	if len(spec.Raw) == 0 || len(spec.Raw) > 256 {
-		return TeslaLegacyFDE0Observation{}, fmt.Errorf("legacy Tesla FDE0 raw observation is out of bounds")
+	state, allocatedMaxCA := teslaLegacyAllocationFields(payload)
+	actualCurrentCA := teslaLegacyID(payload[7:9])
+	if spec.Qualification != qualification || spec.State != state || spec.AllocatedMaxCA != allocatedMaxCA || spec.ActualCurrentCA != actualCurrentCA {
+		return TeslaLegacyFDE0Observation{}, fmt.Errorf("legacy Tesla FDE0 typed fields do not match validated raw frame")
 	}
-	return TeslaLegacyFDE0Observation{qualification: spec.Qualification, state: spec.State, allocatedMaxCA: spec.AllocatedMaxCA, actualCurrentCA: spec.ActualCurrentCA, raw: append([]byte(nil), spec.Raw...)}, nil
+	return TeslaLegacyFDE0Observation{
+		qualification:   qualification,
+		sourceID:        teslaLegacyID(payload[0:2]),
+		destinationID:   teslaLegacyID(payload[2:4]),
+		state:           state,
+		allocatedMaxCA:  allocatedMaxCA,
+		actualCurrentCA: actualCurrentCA,
+		raw:             append([]byte(nil), spec.Raw...),
+	}, nil
 }
 
 func (observation TeslaLegacyFDE0Observation) Qualification() TeslaLegacyQualification {
 	return observation.qualification
+}
+func (observation TeslaLegacyFDE0Observation) SourceID() uint16 { return observation.sourceID }
+func (observation TeslaLegacyFDE0Observation) DestinationID() uint16 {
+	return observation.destinationID
 }
 func (observation TeslaLegacyFDE0Observation) State() TeslaLegacyFDE0State { return observation.state }
 func (observation TeslaLegacyFDE0Observation) AllocatedMaxCA() uint16 {
@@ -65,6 +167,63 @@ func (observation TeslaLegacyFDE0Observation) AllocatedMaxCA() uint16 {
 func (observation TeslaLegacyFDE0Observation) ActualCurrentCA() uint16 {
 	return observation.actualCurrentCA
 }
+
+// AbsoluteOfferCA exposes an absolute native allocation only for the two
+// documented absolute-offer states. Relative and unknown states stay raw-only.
+func (observation TeslaLegacyFDE0Observation) AbsoluteOfferCA() (uint16, bool) {
+	if !observation.state.IsAbsoluteOffer() {
+		return 0, false
+	}
+	return observation.allocatedMaxCA, true
+}
+
+// Raw returns an independent copy of the complete validated encoded frame.
 func (observation TeslaLegacyFDE0Observation) Raw() []byte {
 	return append([]byte(nil), observation.raw...)
+}
+
+func teslaLegacyDynamicCurrentPayload(
+	profile TeslaLegacyWallConnectorProfile,
+	direction TeslaLegacyDirection,
+	raw []byte,
+	wantDirection TeslaLegacyDirection,
+	wantCommand TeslaLegacyCommand,
+	wantLengths ...int,
+) ([]byte, TeslaLegacyQualification, error) {
+	if !profile.config.Enabled {
+		return nil, "", fmt.Errorf("tesla legacy Wall Connector profile is disabled")
+	}
+	qualification := TeslaLegacyQualification(profile.Compatibility())
+	if qualification != TeslaLegacyFamilyCompatible && qualification != TeslaLegacyBuildConfirmed {
+		return nil, "", fmt.Errorf("legacy Tesla qualification is unsupported")
+	}
+	if direction != wantDirection {
+		return nil, "", fmt.Errorf("legacy Tesla dynamic-current direction is invalid")
+	}
+	frame, err := DecodeTeslaLegacyWallConnectorFrame(raw)
+	if err != nil {
+		return nil, "", err
+	}
+	record, err := profile.NativeRecord(direction, frame)
+	if err != nil {
+		return nil, "", err
+	}
+	if record.Command() != wantCommand {
+		return nil, "", fmt.Errorf("legacy Tesla dynamic-current command is invalid")
+	}
+	payload := record.Payload()
+	for _, wantLength := range wantLengths {
+		if len(payload) == wantLength {
+			return payload, qualification, nil
+		}
+	}
+	return nil, "", fmt.Errorf("legacy Tesla dynamic-current payload length is unsupported")
+}
+
+func teslaLegacyAllocationFields(payload []byte) (TeslaLegacyFDE0State, uint16) {
+	return TeslaLegacyFDE0State(payload[4]), teslaLegacyID(payload[5:7])
+}
+
+func teslaLegacyID(bytes []byte) uint16 {
+	return uint16(bytes[0])<<8 | uint16(bytes[1])
 }

--- a/tesla_legacy_fbe0_fde0_test.go
+++ b/tesla_legacy_fbe0_fde0_test.go
@@ -1,38 +1,158 @@
 package modbusreg
 
-import "testing"
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
 
-func TestTeslaLegacyFDE0CandidateObservationRetainsCurrentRoles(t *testing.T) {
-	raw := []byte{0xfd, 0xe0, 0x09, 0x07, 0xd0, 0x03, 0xe8}
-	observation, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
-		Qualification:   TeslaLegacyFamilyCompatible,
-		State:           TeslaLegacyFDE0StateCharging,
-		AllocatedMaxCA:  2000,
-		ActualCurrentCA: 1000,
-		Raw:             raw,
+func TestTeslaLegacyFDE0ObservationRejectsCallerSuppliedRawMismatch(t *testing.T) {
+	profile := teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible)
+	raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0x00, 0x01, 0x00, 0x02, 0x09, 0x07, 0xd0, 0x03, 0xe8})
+	got, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
+		Profile: profile, Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible,
+		State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 1, ActualCurrentCA: 2, Raw: raw,
+	})
+	if err == nil {
+		t.Fatal("caller-supplied values that disagree with the complete raw FDE0 frame were accepted")
+	}
+	if !reflect.DeepEqual(got, TeslaLegacyFDE0Observation{}) {
+		t.Fatalf("rejection retained a partial observation: %#v", got)
+	}
+}
+
+func TestTeslaLegacyDynamicCurrentFramesBindFBE0AndFDE0NativeFields(t *testing.T) {
+	profile := teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible)
+	fbe0Raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0x00, 0x01, 0x00, 0x02, 0x09, 0x07, 0xd0, 0xaa, 0xbb})
+	wantFBE0Raw := append([]byte(nil), fbe0Raw...)
+	fbe0, err := NewTeslaLegacyFBE0Observation(TeslaLegacyFBE0ObservationSpec{
+		Profile: profile, Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible,
+		State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 2000, Raw: fbe0Raw,
+	})
+	if err != nil {
+		t.Fatalf("NewTeslaLegacyFBE0Observation() error = %v", err)
+	}
+	if fbe0.SourceID() != 1 || fbe0.DestinationID() != 2 || fbe0.State() != TeslaLegacyFDE0StateCharging || fbe0.AllocatedMaxCA() != 2000 {
+		t.Fatalf("FBE0 fields=%#v", fbe0)
+	}
+	fbe0Raw[1] = 0
+	if !bytes.Equal(fbe0.Raw(), wantFBE0Raw) {
+		t.Fatal("FBE0 did not retain opaque padding bytes")
+	}
+
+	fde0Raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0x00, 0x02, 0x00, 0x01, 0x09, 0x07, 0xd0, 0x03, 0xe8})
+	fde0, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
+		Profile: profile, Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible,
+		State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: fde0Raw,
 	})
 	if err != nil {
 		t.Fatalf("NewTeslaLegacyFDE0Observation() error = %v", err)
 	}
-	if observation.Qualification() != TeslaLegacyFamilyCompatible || observation.State() != TeslaLegacyFDE0StateCharging || observation.AllocatedMaxCA() != 2000 || observation.ActualCurrentCA() != 1000 {
-		t.Fatalf("observation did not retain the candidate FDE0 roles: %#v", observation)
+	if fde0.SourceID() != 2 || fde0.DestinationID() != 1 || fde0.AllocatedMaxCA() != 2000 || fde0.ActualCurrentCA() != 1000 {
+		t.Fatalf("FDE0 fields=%#v", fde0)
 	}
-	copy := observation.Raw()
+	if fde0.AllocatedMaxCA() == fde0.ActualCurrentCA() {
+		t.Fatal("allocated and actual current roles collapsed")
+	}
+	copy := fde0.Raw()
 	copy[0] = 0
-	if observation.Raw()[0] != 0xfd {
-		t.Fatal("Raw() did not defensively copy native evidence")
+	if !bytes.Equal(fde0.Raw(), fde0Raw) {
+		t.Fatal("Raw() did not defensively copy the validated frame")
 	}
 }
 
-func TestTeslaLegacyFDE0OnlyMapsAbsoluteOfferStates(t *testing.T) {
-	for _, state := range []TeslaLegacyFDE0State{TeslaLegacyFDE0StatePreCharge, TeslaLegacyFDE0StateCharging} {
-		if !state.IsAbsoluteOffer() {
-			t.Fatalf("state %x must be an absolute offer", state)
+func TestTeslaLegacyFBE0RejectsInvalidContextAtomically(t *testing.T) {
+	valid := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0, 1, 0, 2, 0x05, 0x02, 0x58})
+	for _, test := range []struct {
+		name string
+		spec TeslaLegacyFBE0ObservationSpec
+	}{
+		{"wrong direction", TeslaLegacyFBE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x05, AllocatedMaxCA: 600, Raw: valid}},
+		{"unsupported length", TeslaLegacyFBE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible, State: 0x05, AllocatedMaxCA: 600, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0, 1, 0, 2, 5, 2, 88, 0, 0, 0})}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NewTeslaLegacyFBE0Observation(test.spec)
+			if err == nil {
+				t.Fatal("invalid context was accepted")
+			}
+			if !reflect.DeepEqual(got, TeslaLegacyFBE0Observation{}) {
+				t.Fatalf("rejection retained a partial observation: %#v", got)
+			}
+		})
+	}
+}
+
+func TestTeslaLegacyDynamicCurrentAbsoluteOfferBoundary(t *testing.T) {
+	profile := teslaLegacyProfile(t, true, TeslaLegacyWallConnectorBuildConfirmed)
+	for _, test := range []struct {
+		state TeslaLegacyFDE0State
+		want  bool
+	}{
+		{TeslaLegacyFDE0StatePreCharge, true},
+		{TeslaLegacyFDE0StateCharging, true},
+		{0x06, false},
+		{0x07, false},
+		{0x08, false},
+	} {
+		raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0, 2, 0, 1, byte(test.state), 0x07, 0xd0, 0x03, 0xe8})
+		observation, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
+			Profile: profile, Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyBuildConfirmed,
+			State: test.state, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: raw,
+		})
+		if err != nil {
+			t.Fatalf("state=%#x: %v", test.state, err)
+		}
+		got, ok := observation.AbsoluteOfferCA()
+		if ok != test.want || (ok && got != 2000) {
+			t.Fatalf("state=%#x absolute offer=(%d,%t)", test.state, got, ok)
 		}
 	}
-	for _, state := range []TeslaLegacyFDE0State{0x06, 0x07, 0x08} {
-		if state.IsAbsoluteOffer() {
-			t.Fatalf("state %x must remain native-only or unknown", state)
-		}
+}
+
+func TestTeslaLegacyDynamicCurrentRejectsEveryInvalidContextAtomically(t *testing.T) {
+	validFBE0 := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0, 1, 0, 2, 0x05, 0x02, 0x58})
+	validFDE0 := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0, 2, 0, 1, 0x09, 0x07, 0xd0, 0x03, 0xe8})
+	badChecksum := append([]byte(nil), validFDE0...)
+	badChecksum[len(badChecksum)-2] ^= 1
+	for _, test := range []struct {
+		name string
+		spec TeslaLegacyFDE0ObservationSpec
+	}{
+		{"wrong direction", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0}},
+		{"wrong command", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFBE0}},
+		{"unsupported length", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0, 2, 0, 1, 9, 7, 208, 3})}},
+		{"invalid checksum", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: badChecksum}},
+		{"truncated frame", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0[:len(validFDE0)-1]}},
+		{"disabled profile", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, false, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0}},
+		{"unknown profile", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorUnknown), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0}},
+		{"qualification mismatch", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorBuildConfirmed), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NewTeslaLegacyFDE0Observation(test.spec)
+			if err == nil {
+				t.Fatal("invalid context was accepted")
+			}
+			if !reflect.DeepEqual(got, TeslaLegacyFDE0Observation{}) {
+				t.Fatalf("rejection retained a partial observation: %#v", got)
+			}
+		})
 	}
+}
+
+func teslaLegacyProfile(t *testing.T, enabled bool, compatibility TeslaLegacyWallConnectorCompatibility) TeslaLegacyWallConnectorProfile {
+	t.Helper()
+	profile, err := NewTeslaLegacyWallConnectorProfile(TeslaLegacyWallConnectorProfileConfig{Enabled: enabled, Compatibility: compatibility})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return profile
+}
+
+func teslaLegacyDynamicFrame(t *testing.T, command TeslaLegacyCommand, payload []byte) []byte {
+	t.Helper()
+	raw, err := EncodeTeslaLegacyWallConnectorFrame(command, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
 }

--- a/tesla_legacy_fbe0_fde0_test.go
+++ b/tesla_legacy_fbe0_fde0_test.go
@@ -2,13 +2,14 @@ package modbusreg
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 )
 
 func TestTeslaLegacyFDE0ObservationRejectsCallerSuppliedRawMismatch(t *testing.T) {
 	profile := teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible)
-	raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0x00, 0x01, 0x00, 0x02, 0x09, 0x07, 0xd0, 0x03, 0xe8})
+	raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, teslaLegacyFDE0Payload(false, 0x09, 2000, 1000))
 	got, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
 		Profile: profile, Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible,
 		State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 1, ActualCurrentCA: 2, Raw: raw,
@@ -21,62 +22,57 @@ func TestTeslaLegacyFDE0ObservationRejectsCallerSuppliedRawMismatch(t *testing.T
 	}
 }
 
-func TestTeslaLegacyDynamicCurrentFramesBindFBE0AndFDE0NativeFields(t *testing.T) {
+func TestTeslaLegacyDynamicCurrentFramesBindCompleteProtocol1AndProtocol2Records(t *testing.T) {
 	profile := teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible)
-	fbe0Raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0x00, 0x01, 0x00, 0x02, 0x09, 0x07, 0xd0, 0xaa, 0xbb})
-	wantFBE0Raw := append([]byte(nil), fbe0Raw...)
-	fbe0, err := NewTeslaLegacyFBE0Observation(TeslaLegacyFBE0ObservationSpec{
-		Profile: profile, Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible,
-		State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 2000, Raw: fbe0Raw,
-	})
-	if err != nil {
-		t.Fatalf("NewTeslaLegacyFBE0Observation() error = %v", err)
-	}
-	if fbe0.SourceID() != 1 || fbe0.DestinationID() != 2 || fbe0.State() != TeslaLegacyFDE0StateCharging || fbe0.AllocatedMaxCA() != 2000 {
-		t.Fatalf("FBE0 fields=%#v", fbe0)
-	}
-	fbe0Raw[1] = 0
-	if !bytes.Equal(fbe0.Raw(), wantFBE0Raw) {
-		t.Fatal("FBE0 did not retain opaque padding bytes")
-	}
-
-	fde0Raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0x00, 0x02, 0x00, 0x01, 0x09, 0x07, 0xd0, 0x03, 0xe8})
-	fde0, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
-		Profile: profile, Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible,
-		State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: fde0Raw,
-	})
-	if err != nil {
-		t.Fatalf("NewTeslaLegacyFDE0Observation() error = %v", err)
-	}
-	if fde0.SourceID() != 2 || fde0.DestinationID() != 1 || fde0.AllocatedMaxCA() != 2000 || fde0.ActualCurrentCA() != 1000 {
-		t.Fatalf("FDE0 fields=%#v", fde0)
-	}
-	if fde0.AllocatedMaxCA() == fde0.ActualCurrentCA() {
-		t.Fatal("allocated and actual current roles collapsed")
-	}
-	copy := fde0.Raw()
-	copy[0] = 0
-	if !bytes.Equal(fde0.Raw(), fde0Raw) {
-		t.Fatal("Raw() did not defensively copy the validated frame")
-	}
-}
-
-func TestTeslaLegacyFBE0RejectsInvalidContextAtomically(t *testing.T) {
-	valid := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0, 1, 0, 2, 0x05, 0x02, 0x58})
 	for _, test := range []struct {
-		name string
-		spec TeslaLegacyFBE0ObservationSpec
+		name      string
+		command   TeslaLegacyCommand
+		direction TeslaLegacyDirection
+		payload   []byte
+		actual    uint16
 	}{
-		{"wrong direction", TeslaLegacyFBE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x05, AllocatedMaxCA: 600, Raw: valid}},
-		{"unsupported length", TeslaLegacyFBE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible, State: 0x05, AllocatedMaxCA: 600, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0, 1, 0, 2, 5, 2, 88, 0, 0, 0})}},
+		{"FBE0 protocol 1", TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, TeslaLegacyWallConnectorRequest, teslaLegacyFBE0Payload(false, 0x09, 2000), 0},
+		{"FBE0 protocol 2", TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, TeslaLegacyWallConnectorRequest, teslaLegacyFBE0Payload(true, 0x09, 2000), 0},
+		{"FDE0 protocol 1", TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, TeslaLegacyWallConnectorResponse, teslaLegacyFDE0Payload(false, 0x09, 2000, 1000), 1000},
+		{"FDE0 protocol 2", TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, TeslaLegacyWallConnectorResponse, teslaLegacyFDE0Payload(true, 0x09, 2000, 1000), 1000},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := NewTeslaLegacyFBE0Observation(test.spec)
-			if err == nil {
-				t.Fatal("invalid context was accepted")
+			raw := teslaLegacyDynamicFrame(t, test.command, test.payload)
+			wantRaw := append([]byte(nil), raw...)
+			if test.direction == TeslaLegacyWallConnectorRequest {
+				observation, err := NewTeslaLegacyFBE0Observation(TeslaLegacyFBE0ObservationSpec{
+					Profile: profile, Direction: test.direction, Qualification: TeslaLegacyFamilyCompatible,
+					State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 2000, Raw: raw,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if observation.SourceID() != 1 || observation.DestinationID() != 2 || observation.AllocatedMaxCA() != 2000 {
+					t.Fatalf("FBE0 fields=%#v", observation)
+				}
+				raw[1] = 0
+				if !bytes.Equal(observation.Raw(), wantRaw) {
+					t.Fatal("FBE0 did not defensively retain the complete opaque heartbeat record")
+				}
+				return
 			}
-			if !reflect.DeepEqual(got, TeslaLegacyFBE0Observation{}) {
-				t.Fatalf("rejection retained a partial observation: %#v", got)
+			observation, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
+				Profile: profile, Direction: test.direction, Qualification: TeslaLegacyFamilyCompatible,
+				State: TeslaLegacyFDE0StateCharging, AllocatedMaxCA: 2000, ActualCurrentCA: test.actual, Raw: raw,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if observation.SourceID() != 2 || observation.DestinationID() != 1 || observation.AllocatedMaxCA() != 2000 || observation.ActualCurrentCA() != test.actual {
+				t.Fatalf("FDE0 fields=%#v", observation)
+			}
+			if observation.AllocatedMaxCA() == observation.ActualCurrentCA() {
+				t.Fatal("allocated and actual current roles collapsed")
+			}
+			copy := observation.Raw()
+			copy[0] = 0
+			if !bytes.Equal(observation.Raw(), wantRaw) {
+				t.Fatal("FDE0 did not defensively retain the complete opaque heartbeat record")
 			}
 		})
 	}
@@ -94,7 +90,7 @@ func TestTeslaLegacyDynamicCurrentAbsoluteOfferBoundary(t *testing.T) {
 		{0x07, false},
 		{0x08, false},
 	} {
-		raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0, 2, 0, 1, byte(test.state), 0x07, 0xd0, 0x03, 0xe8})
+		raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, teslaLegacyFDE0Payload(false, byte(test.state), 2000, 1000))
 		observation, err := NewTeslaLegacyFDE0Observation(TeslaLegacyFDE0ObservationSpec{
 			Profile: profile, Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyBuildConfirmed,
 			State: test.state, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: raw,
@@ -109,9 +105,28 @@ func TestTeslaLegacyDynamicCurrentAbsoluteOfferBoundary(t *testing.T) {
 	}
 }
 
-func TestTeslaLegacyDynamicCurrentRejectsEveryInvalidContextAtomically(t *testing.T) {
-	validFBE0 := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, []byte{0, 1, 0, 2, 0x05, 0x02, 0x58})
-	validFDE0 := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0, 2, 0, 1, 0x09, 0x07, 0xd0, 0x03, 0xe8})
+func TestTeslaLegacyFBE0RejectsPostCommandTruncationAtomically(t *testing.T) {
+	profile := teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible)
+	for _, length := range []int{7, 9, 10, 12, 14} {
+		t.Run(fmt.Sprintf("length-%d", length), func(t *testing.T) {
+			raw := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, make([]byte, length))
+			got, err := NewTeslaLegacyFBE0Observation(TeslaLegacyFBE0ObservationSpec{
+				Profile: profile, Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible,
+				State: 0, AllocatedMaxCA: 0, Raw: raw,
+			})
+			if err == nil {
+				t.Fatalf("post-command length %d was accepted", length)
+			}
+			if !reflect.DeepEqual(got, TeslaLegacyFBE0Observation{}) {
+				t.Fatalf("post-command length %d retained a partial observation: %#v", length, got)
+			}
+		})
+	}
+}
+
+func TestTeslaLegacyDynamicCurrentRejectsInvalidContextAtomically(t *testing.T) {
+	validFBE0 := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfb, Opcode: 0xe0}, teslaLegacyFBE0Payload(false, 0x05, 600))
+	validFDE0 := teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, teslaLegacyFDE0Payload(false, 0x09, 2000, 1000))
 	badChecksum := append([]byte(nil), validFDE0...)
 	badChecksum[len(badChecksum)-2] ^= 1
 	for _, test := range []struct {
@@ -120,7 +135,11 @@ func TestTeslaLegacyDynamicCurrentRejectsEveryInvalidContextAtomically(t *testin
 	}{
 		{"wrong direction", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorRequest, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0}},
 		{"wrong command", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFBE0}},
-		{"unsupported length", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, []byte{0, 2, 0, 1, 9, 7, 208, 3})}},
+		{"post-command length 7", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, make([]byte, 7))}},
+		{"post-command length 9", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, make([]byte, 9))}},
+		{"post-command length 10", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, make([]byte, 10))}},
+		{"post-command length 12", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, make([]byte, 12))}},
+		{"post-command length 14", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: teslaLegacyDynamicFrame(t, TeslaLegacyCommand{Prefix: 0xfd, Opcode: 0xe0}, make([]byte, 14))}},
 		{"invalid checksum", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: badChecksum}},
 		{"truncated frame", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, true, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0[:len(validFDE0)-1]}},
 		{"disabled profile", TeslaLegacyFDE0ObservationSpec{Profile: teslaLegacyProfile(t, false, TeslaLegacyWallConnectorFamilyCompatible), Direction: TeslaLegacyWallConnectorResponse, Qualification: TeslaLegacyFamilyCompatible, State: 0x09, AllocatedMaxCA: 2000, ActualCurrentCA: 1000, Raw: validFDE0}},
@@ -137,6 +156,22 @@ func TestTeslaLegacyDynamicCurrentRejectsEveryInvalidContextAtomically(t *testin
 			}
 		})
 	}
+}
+
+func teslaLegacyFBE0Payload(protocol2 bool, state byte, allocated uint16) []byte {
+	payload := []byte{0, 1, 0, 2, state, byte(allocated >> 8), byte(allocated), 0xaa, 0xbb, 0xcc, 0xdd}
+	if protocol2 {
+		return append(payload, 0xee, 0xff)
+	}
+	return payload
+}
+
+func teslaLegacyFDE0Payload(protocol2 bool, state byte, allocated, actual uint16) []byte {
+	payload := []byte{0, 2, 0, 1, state, byte(allocated >> 8), byte(allocated), byte(actual >> 8), byte(actual), 0xaa, 0xbb}
+	if protocol2 {
+		return append(payload, 0xcc, 0xdd)
+	}
+	return payload
 }
 
 func teslaLegacyProfile(t *testing.T, enabled bool, compatibility TeslaLegacyWallConnectorCompatibility) TeslaLegacyWallConnectorProfile {


### PR DESCRIPTION
Closes #192. Corrects the legacy decoder to match the existing native frame API: the post-command record payload includes source ID and destination ID before the heartbeat data. FBE0 requests and FDE0 responses now accept only complete 11-byte protocol-1 or 13-byte protocol-2 post-command payloads: IDs at 0..3, state at 4, allocation at 5..6, FDE0 actual current at 7..8, and every remaining heartbeat/padding byte retained only in raw evidence. The decoder rejects legacy 7/9-byte truncations, 10/12/14-byte payloads, wrong direction or command, malformed/truncated/checksum-invalid frames, disabled/unknown qualification, qualification mismatch, and caller typed/raw mismatch atomically. RED remains the prior raw/typed mismatch failure. GREEN covers both protocol variants for FBE0 and FDE0, retained opaque bytes, proof tiers, native-only relative/unknown states, and all rejection classes. Full CI: ./scripts/ci_local.sh passed (14 scope-policy mutations, gofmt, vet, build, race tests, golangci-lint 0 issues). Required docs PR #140 now has pinned public locators and the matching full-record boundary; it must merge before or with this PR. No sender, transport activation, device-limit/power/applied-effect inference, FC101/FC102 interpretation, semantic projection, or hardware claim is added. Residual scope remains provider-local offline decoding only.