### PR TITLE
REG: decode Growatt Protocol II v1.24 TL3-X FC04 monitoring foundation

### DIFF
--- a/growatt_protocol_ii_fc04.go
+++ b/growatt_protocol_ii_fc04.go
@@ -1,0 +1,71 @@
+package modbusreg
+
+import "fmt"
+
+// GrowattProtocolIIFC04Slice retains the sole bounded FC04 acquisition. Words
+// outside the typed fields remain native evidence only.
+type GrowattProtocolIIFC04Slice struct {
+	Offset uint16
+	Words  []uint16
+}
+
+type GrowattProtocolIIInverterState string
+
+const (
+	GrowattProtocolIIStateWaiting GrowattProtocolIIInverterState = "waiting"
+	GrowattProtocolIIStateNormal  GrowattProtocolIIInverterState = "normal"
+	GrowattProtocolIIStateFault   GrowattProtocolIIInverterState = "fault"
+)
+
+// GrowattProtocolIIFC04Telemetry is an immutable, read-only subset from the
+// exact selected identity. It deliberately omits fields whose signedness or
+// interpretation is not established by the pinned source.
+type GrowattProtocolIIFC04Telemetry struct {
+	identity                                                          GrowattProtocolIIIdentityObservation
+	raw                                                               GrowattProtocolIIFC04Slice
+	InverterState                                                     GrowattProtocolIIInverterState
+	PVInputPowerWatts, OutputPowerWatts, GridFrequencyHz              float64
+	Phase1VoltageVolts, Phase1CurrentAmps                             float64
+	Phase2VoltageVolts, Phase2CurrentAmps                             float64
+	Phase3VoltageVolts, Phase3CurrentAmps                             float64
+	TodayGeneratedEnergyKWh, TotalGeneratedEnergyKWh, WorkTimeSeconds float64
+}
+
+func (t GrowattProtocolIIFC04Telemetry) Identity() GrowattProtocolIIIdentityObservation {
+	return t.identity
+}
+func (t GrowattProtocolIIFC04Telemetry) RawSlice() GrowattProtocolIIFC04Slice {
+	return GrowattProtocolIIFC04Slice{Offset: t.raw.Offset, Words: append([]uint16(nil), t.raw.Words...)}
+}
+func (GrowattProtocolIIFC04Telemetry) OutboundAllowed() bool { return false }
+
+// DecodeGrowattProtocolIIFC04Telemetry accepts exactly offsets 0 through 58
+// following a qualified caller-selected Protocol II v1.24 TL3-X identity.
+func DecodeGrowattProtocolIIFC04Telemetry(identity GrowattProtocolIIIdentityObservation, raw GrowattProtocolIIFC04Slice) (GrowattProtocolIIFC04Telemetry, error) {
+	if !validGrowattProtocolIIIdentityProfile(identity.Profile()) || identity.UnitID() == 0 || raw.Offset != 0 || len(raw.Words) != 59 {
+		return GrowattProtocolIIFC04Telemetry{}, fmt.Errorf("growatt Protocol II FC04 telemetry is invalid")
+	}
+	state, ok := growattProtocolIIState(raw.Words[0])
+	if !ok {
+		return GrowattProtocolIIFC04Telemetry{}, fmt.Errorf("growatt Protocol II FC04 inverter state is invalid")
+	}
+	u32 := func(high, low uint16) uint32 { return uint32(high)<<16 | uint32(low) }
+	return GrowattProtocolIIFC04Telemetry{
+		identity: identity, raw: GrowattProtocolIIFC04Slice{Offset: raw.Offset, Words: append([]uint16(nil), raw.Words...)}, InverterState: state,
+		PVInputPowerWatts: float64(u32(raw.Words[1], raw.Words[2])) / 10, OutputPowerWatts: float64(u32(raw.Words[35], raw.Words[36])) / 10, GridFrequencyHz: float64(raw.Words[37]) / 100,
+		Phase1VoltageVolts: float64(raw.Words[38]) / 10, Phase1CurrentAmps: float64(raw.Words[39]) / 10, Phase2VoltageVolts: float64(raw.Words[42]) / 10, Phase2CurrentAmps: float64(raw.Words[43]) / 10, Phase3VoltageVolts: float64(raw.Words[46]) / 10, Phase3CurrentAmps: float64(raw.Words[47]) / 10,
+		TodayGeneratedEnergyKWh: float64(u32(raw.Words[53], raw.Words[54])) / 10, TotalGeneratedEnergyKWh: float64(u32(raw.Words[55], raw.Words[56])) / 10, WorkTimeSeconds: float64(u32(raw.Words[57], raw.Words[58])) / 2,
+	}, nil
+}
+func growattProtocolIIState(word uint16) (GrowattProtocolIIInverterState, bool) {
+	switch word {
+	case 0:
+		return GrowattProtocolIIStateWaiting, true
+	case 1:
+		return GrowattProtocolIIStateNormal, true
+	case 3:
+		return GrowattProtocolIIStateFault, true
+	default:
+		return "", false
+	}
+}

--- a/growatt_protocol_ii_fc04.go
+++ b/growatt_protocol_ii_fc04.go
@@ -2,7 +2,6 @@ package modbusreg
 
 import (
 	"fmt"
-	"strings"
 )
 
 // GrowattProtocolIIFC04Slice retains the sole bounded FC04 acquisition. Words
@@ -12,32 +11,19 @@ type GrowattProtocolIIFC04Slice struct {
 	Words  []uint16
 }
 
-// GrowattProtocolIIFC04Applicability is an immutable, caller-supplied exact
-// mapping admission for typed FC04 monitoring. Protocol II v1.24 names the
-// MAX/MID/MAC family but does not publish a device/model-build/protocol tuple
-// mapping, so this package deliberately contains no built-in tuple allowlist.
-// The caller must obtain a mapping from its own accepted source-backed evidence
-// before constructing this value; a raw FC03 identity observation cannot create
-// one implicitly.
+// GrowattProtocolIIFC04Applicability is an opaque typed-FC04 admission value.
+// The pinned Protocol II v1.24 source does not establish an admissible exact
+// device-type/model-build/protocol tuple, so this package intentionally exposes
+// no public successful constructor. Its zero value and every externally
+// constructible form fail closed. A raw FC03 identity observation cannot create
+// an admission implicitly.
 type GrowattProtocolIIFC04Applicability struct {
-	profile           GrowattProtocolIIIdentityProfile
-	evidenceReference string
-}
-
-// NewGrowattProtocolIIFC04Applicability seals one already-accepted exact
-// mapping for the FC04 schema. evidenceReference identifies the caller-owned
-// source-backed mapping record; it is not inferred from the Protocol II manual
-// revision or from an observed identity tuple.
-func NewGrowattProtocolIIFC04Applicability(profile GrowattProtocolIIIdentityProfile, evidenceReference string) (GrowattProtocolIIFC04Applicability, error) {
-	if !validGrowattProtocolIIIdentityProfile(profile) || profile.DeviceType == 0 ||
-		profile.ModelBuild == [2]uint16{} || profile.ProtocolVersion == 0 || strings.TrimSpace(evidenceReference) == "" {
-		return GrowattProtocolIIFC04Applicability{}, fmt.Errorf("growatt Protocol II FC04 applicability is invalid")
-	}
-	return GrowattProtocolIIFC04Applicability{profile: profile, evidenceReference: evidenceReference}, nil
+	profile          GrowattProtocolIIIdentityProfile
+	syntheticFixture bool
 }
 
 func (a GrowattProtocolIIFC04Applicability) matches(identity GrowattProtocolIIIdentityObservation) bool {
-	return a.evidenceReference != "" && a.profile == identity.Profile() &&
+	return a.syntheticFixture && a.profile == identity.Profile() &&
 		a.profile.DeviceType == identity.DeviceType() && a.profile.ModelBuild == identity.ModelBuild() &&
 		a.profile.ProtocolVersion == identity.ProtocolVersion()
 }
@@ -73,8 +59,9 @@ func (t GrowattProtocolIIFC04Telemetry) RawSlice() GrowattProtocolIIFC04Slice {
 func (GrowattProtocolIIFC04Telemetry) OutboundAllowed() bool { return false }
 
 // DecodeGrowattProtocolIIFC04Telemetry accepts exactly offsets 0 through 58
-// only when an independent exact applicability selection admits the FC03
-// identity. A caller-selected raw identity alone is insufficient.
+// only when an opaque applicability value admits the FC03 identity. No public
+// admitted value currently exists; a caller-selected raw identity alone is
+// insufficient.
 func DecodeGrowattProtocolIIFC04Telemetry(identity GrowattProtocolIIIdentityObservation, applicability GrowattProtocolIIFC04Applicability, raw GrowattProtocolIIFC04Slice) (GrowattProtocolIIFC04Telemetry, error) {
 	if !validGrowattProtocolIIIdentityProfile(identity.Profile()) || !applicability.matches(identity) || identity.UnitID() == 0 || raw.Offset != 0 || len(raw.Words) != 59 {
 		return GrowattProtocolIIFC04Telemetry{}, fmt.Errorf("growatt Protocol II FC04 telemetry is invalid")

--- a/growatt_protocol_ii_fc04.go
+++ b/growatt_protocol_ii_fc04.go
@@ -1,12 +1,45 @@
 package modbusreg
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // GrowattProtocolIIFC04Slice retains the sole bounded FC04 acquisition. Words
 // outside the typed fields remain native evidence only.
 type GrowattProtocolIIFC04Slice struct {
 	Offset uint16
 	Words  []uint16
+}
+
+// GrowattProtocolIIFC04Applicability is an immutable, caller-supplied exact
+// mapping admission for typed FC04 monitoring. Protocol II v1.24 names the
+// MAX/MID/MAC family but does not publish a device/model-build/protocol tuple
+// mapping, so this package deliberately contains no built-in tuple allowlist.
+// The caller must obtain a mapping from its own accepted source-backed evidence
+// before constructing this value; a raw FC03 identity observation cannot create
+// one implicitly.
+type GrowattProtocolIIFC04Applicability struct {
+	profile           GrowattProtocolIIIdentityProfile
+	evidenceReference string
+}
+
+// NewGrowattProtocolIIFC04Applicability seals one already-accepted exact
+// mapping for the FC04 schema. evidenceReference identifies the caller-owned
+// source-backed mapping record; it is not inferred from the Protocol II manual
+// revision or from an observed identity tuple.
+func NewGrowattProtocolIIFC04Applicability(profile GrowattProtocolIIIdentityProfile, evidenceReference string) (GrowattProtocolIIFC04Applicability, error) {
+	if !validGrowattProtocolIIIdentityProfile(profile) || profile.DeviceType == 0 ||
+		profile.ModelBuild == [2]uint16{} || profile.ProtocolVersion == 0 || strings.TrimSpace(evidenceReference) == "" {
+		return GrowattProtocolIIFC04Applicability{}, fmt.Errorf("growatt Protocol II FC04 applicability is invalid")
+	}
+	return GrowattProtocolIIFC04Applicability{profile: profile, evidenceReference: evidenceReference}, nil
+}
+
+func (a GrowattProtocolIIFC04Applicability) matches(identity GrowattProtocolIIIdentityObservation) bool {
+	return a.evidenceReference != "" && a.profile == identity.Profile() &&
+		a.profile.DeviceType == identity.DeviceType() && a.profile.ModelBuild == identity.ModelBuild() &&
+		a.profile.ProtocolVersion == identity.ProtocolVersion()
 }
 
 type GrowattProtocolIIInverterState string
@@ -40,9 +73,10 @@ func (t GrowattProtocolIIFC04Telemetry) RawSlice() GrowattProtocolIIFC04Slice {
 func (GrowattProtocolIIFC04Telemetry) OutboundAllowed() bool { return false }
 
 // DecodeGrowattProtocolIIFC04Telemetry accepts exactly offsets 0 through 58
-// following a qualified caller-selected Protocol II v1.24 TL3-X identity.
-func DecodeGrowattProtocolIIFC04Telemetry(identity GrowattProtocolIIIdentityObservation, raw GrowattProtocolIIFC04Slice) (GrowattProtocolIIFC04Telemetry, error) {
-	if !validGrowattProtocolIIIdentityProfile(identity.Profile()) || identity.UnitID() == 0 || raw.Offset != 0 || len(raw.Words) != 59 {
+// only when an independent exact applicability selection admits the FC03
+// identity. A caller-selected raw identity alone is insufficient.
+func DecodeGrowattProtocolIIFC04Telemetry(identity GrowattProtocolIIIdentityObservation, applicability GrowattProtocolIIFC04Applicability, raw GrowattProtocolIIFC04Slice) (GrowattProtocolIIFC04Telemetry, error) {
+	if !validGrowattProtocolIIIdentityProfile(identity.Profile()) || !applicability.matches(identity) || identity.UnitID() == 0 || raw.Offset != 0 || len(raw.Words) != 59 {
 		return GrowattProtocolIIFC04Telemetry{}, fmt.Errorf("growatt Protocol II FC04 telemetry is invalid")
 	}
 	state, ok := growattProtocolIIState(raw.Words[0])

--- a/growatt_protocol_ii_fc04_public_api_test.go
+++ b/growatt_protocol_ii_fc04_public_api_test.go
@@ -1,0 +1,92 @@
+package modbusreg_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	reg "github.com/Project-Helianthus/helianthus-modbusreg"
+)
+
+// TestGrowattProtocolIIFC04HasNoPublicAdmissionPath keeps the source-backed
+// qualification boundary at the public-package boundary. The pinned manual has
+// no admissible device/model-build/protocol tuple, so raw FC03 observations may
+// be retained but no public value, including a caller string, may admit FC04.
+func TestGrowattProtocolIIFC04HasNoPublicAdmissionPath(t *testing.T) {
+	command := exec.Command("go", "doc", ".", "NewGrowattProtocolIIFC04Applicability")
+	command.Env = append(command.Environ(), "GOWORK=off")
+	if output, err := command.CombinedOutput(); err == nil || !strings.Contains(string(output), "no symbol") {
+		t.Fatalf("public FC04 applicability constructor remains reachable: output=%q err=%v", output, err)
+	}
+
+	words := make([]uint16, 59)
+	words[0] = 1
+	for name, mutate := range map[string]func(*reg.GrowattProtocolIIIdentityInput){
+		"combined tuple": func(input *reg.GrowattProtocolIIIdentityInput) {
+			input.Profile.DeviceType = 0xbeef
+			input.Profile.ModelBuild = [2]uint16{0x1111, 0x2222}
+			input.Profile.ProtocolVersion = 0x9999
+			input.Slices[2].Words[0] = 0xbeef
+			input.Slices[3].Words = []uint16{0x1111, 0x2222}
+			input.Slices[4].Words[0] = 0x9999
+		},
+		"device type": func(input *reg.GrowattProtocolIIIdentityInput) {
+			input.Profile.DeviceType = 0xbeef
+			input.Slices[2].Words[0] = 0xbeef
+		},
+		"model build": func(input *reg.GrowattProtocolIIIdentityInput) {
+			input.Profile.ModelBuild = [2]uint16{0x1111, 0x2222}
+			input.Slices[3].Words = []uint16{0x1111, 0x2222}
+		},
+		"protocol version": func(input *reg.GrowattProtocolIIIdentityInput) {
+			input.Profile.ProtocolVersion = 0x9999
+			input.Slices[4].Words[0] = 0x9999
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := publicGrowattProtocolIIIdentityInput()
+			mutate(&input)
+			identity, err := reg.DecodeGrowattProtocolIIIdentity(input)
+			if err != nil {
+				t.Fatalf("raw FC03 identity was not retained: %v", err)
+			}
+
+			var unadmitted reg.GrowattProtocolIIFC04Applicability
+			if telemetry, err := reg.DecodeGrowattProtocolIIFC04Telemetry(identity, unadmitted, reg.GrowattProtocolIIFC04Slice{Words: words}); err == nil || telemetry.Identity().UnitID() != 0 {
+				t.Fatalf("unadmitted tuple produced typed telemetry: telemetry=%#v err=%v", telemetry, err)
+			}
+			if observer, err := reg.NewGrowattProtocolIIFC04RTUObserver(identity, unadmitted, publicGrowattProtocolIIFC04Session{}); err == nil || observer != nil {
+				t.Fatalf("unadmitted tuple created observer: observer=%#v err=%v", observer, err)
+			}
+		})
+	}
+}
+
+func publicGrowattProtocolIIIdentityInput() reg.GrowattProtocolIIIdentityInput {
+	return reg.GrowattProtocolIIIdentityInput{
+		UnitID:   1,
+		Function: reg.FunctionReadHoldingRegisters,
+		Profile: reg.GrowattProtocolIIIdentityProfile{
+			Schema:          "Protocol II v1.24 TL3-X",
+			Family:          "MAX",
+			DeviceType:      0x1234,
+			ModelBuild:      [2]uint16{0x0102, 0x0304},
+			ProtocolVersion: 0x0100,
+		},
+		Slices: []reg.GrowattProtocolIIIdentitySlice{
+			{Offset: 9, Words: []uint16{0x4657, 0, 0, 0, 0, 0}},
+			{Offset: 23, Words: []uint16{0x534e, 0, 0, 0, 0}},
+			{Offset: 43, Words: []uint16{0x1234}},
+			{Offset: 82, Words: []uint16{0x0102, 0x0304}},
+			{Offset: 88, Words: []uint16{0x0100}},
+		},
+	}
+}
+
+type publicGrowattProtocolIIFC04Session struct{}
+
+func (publicGrowattProtocolIIFC04Session) ReadInput(context.Context, byte, modbus.ReadRegistersRequest) (modbus.ReadRegistersResponse, error) {
+	return modbus.ReadRegistersResponse{}, nil
+}

--- a/growatt_protocol_ii_fc04_rtu_observer.go
+++ b/growatt_protocol_ii_fc04_rtu_observer.go
@@ -15,15 +15,16 @@ type GrowattProtocolIIFC04RTUObserverSession interface {
 // GrowattProtocolIIFC04RTUObserver executes one exact bounded FC04 read after
 // its caller has qualified the FC03 identity. It owns neither discovery nor retries.
 type GrowattProtocolIIFC04RTUObserver struct {
-	identity GrowattProtocolIIIdentityObservation
-	session  GrowattProtocolIIFC04RTUObserverSession
+	identity      GrowattProtocolIIIdentityObservation
+	applicability GrowattProtocolIIFC04Applicability
+	session       GrowattProtocolIIFC04RTUObserverSession
 }
 
-func NewGrowattProtocolIIFC04RTUObserver(identity GrowattProtocolIIIdentityObservation, session GrowattProtocolIIFC04RTUObserverSession) (*GrowattProtocolIIFC04RTUObserver, error) {
-	if session == nil || identity.UnitID() == 0 || !validGrowattProtocolIIIdentityProfile(identity.Profile()) {
+func NewGrowattProtocolIIFC04RTUObserver(identity GrowattProtocolIIIdentityObservation, applicability GrowattProtocolIIFC04Applicability, session GrowattProtocolIIFC04RTUObserverSession) (*GrowattProtocolIIFC04RTUObserver, error) {
+	if session == nil || identity.UnitID() == 0 || !validGrowattProtocolIIIdentityProfile(identity.Profile()) || !applicability.matches(identity) {
 		return nil, ErrGrowattProtocolIIFC04RTUObserverInvalid
 	}
-	return &GrowattProtocolIIFC04RTUObserver{identity: identity, session: session}, nil
+	return &GrowattProtocolIIFC04RTUObserver{identity: identity, applicability: applicability, session: session}, nil
 }
 func (o *GrowattProtocolIIFC04RTUObserver) Observe(ctx context.Context) (GrowattProtocolIIFC04Telemetry, error) {
 	if o == nil || o.session == nil || ctx == nil {
@@ -40,5 +41,5 @@ func (o *GrowattProtocolIIFC04RTUObserver) Observe(ctx context.Context) (Growatt
 	if response.Provenance != (modbus.ReadProvenance{Function: modbus.FunctionReadInputRegisters, Table: modbus.InputRegisters, Offset: 0, Quantity: 59}) || len(response.Words) != 59 {
 		return GrowattProtocolIIFC04Telemetry{}, ErrGrowattProtocolIIFC04RTUObserverInvalid
 	}
-	return DecodeGrowattProtocolIIFC04Telemetry(o.identity, GrowattProtocolIIFC04Slice{Words: append([]uint16(nil), response.Words...)})
+	return DecodeGrowattProtocolIIFC04Telemetry(o.identity, o.applicability, GrowattProtocolIIFC04Slice{Words: append([]uint16(nil), response.Words...)})
 }

--- a/growatt_protocol_ii_fc04_rtu_observer.go
+++ b/growatt_protocol_ii_fc04_rtu_observer.go
@@ -1,0 +1,44 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+)
+
+var ErrGrowattProtocolIIFC04RTUObserverInvalid = errors.New("growatt Protocol II FC04 RTU observer is invalid")
+
+type GrowattProtocolIIFC04RTUObserverSession interface {
+	ReadInput(context.Context, byte, modbus.ReadRegistersRequest) (modbus.ReadRegistersResponse, error)
+}
+
+// GrowattProtocolIIFC04RTUObserver executes one exact bounded FC04 read after
+// its caller has qualified the FC03 identity. It owns neither discovery nor retries.
+type GrowattProtocolIIFC04RTUObserver struct {
+	identity GrowattProtocolIIIdentityObservation
+	session  GrowattProtocolIIFC04RTUObserverSession
+}
+
+func NewGrowattProtocolIIFC04RTUObserver(identity GrowattProtocolIIIdentityObservation, session GrowattProtocolIIFC04RTUObserverSession) (*GrowattProtocolIIFC04RTUObserver, error) {
+	if session == nil || identity.UnitID() == 0 || !validGrowattProtocolIIIdentityProfile(identity.Profile()) {
+		return nil, ErrGrowattProtocolIIFC04RTUObserverInvalid
+	}
+	return &GrowattProtocolIIFC04RTUObserver{identity: identity, session: session}, nil
+}
+func (o *GrowattProtocolIIFC04RTUObserver) Observe(ctx context.Context) (GrowattProtocolIIFC04Telemetry, error) {
+	if o == nil || o.session == nil || ctx == nil {
+		return GrowattProtocolIIFC04Telemetry{}, ErrGrowattProtocolIIFC04RTUObserverInvalid
+	}
+	request, err := modbus.NewReadRegistersRequest(modbus.FunctionReadInputRegisters, 0, 59)
+	if err != nil {
+		return GrowattProtocolIIFC04Telemetry{}, err
+	}
+	response, err := o.session.ReadInput(ctx, o.identity.UnitID(), request)
+	if err != nil {
+		return GrowattProtocolIIFC04Telemetry{}, err
+	}
+	if response.Provenance != (modbus.ReadProvenance{Function: modbus.FunctionReadInputRegisters, Table: modbus.InputRegisters, Offset: 0, Quantity: 59}) || len(response.Words) != 59 {
+		return GrowattProtocolIIFC04Telemetry{}, ErrGrowattProtocolIIFC04RTUObserverInvalid
+	}
+	return DecodeGrowattProtocolIIFC04Telemetry(o.identity, GrowattProtocolIIFC04Slice{Words: append([]uint16(nil), response.Words...)})
+}

--- a/growatt_protocol_ii_fc04_rtu_observer_test.go
+++ b/growatt_protocol_ii_fc04_rtu_observer_test.go
@@ -12,9 +12,13 @@ func TestGrowattProtocolIIFC04RTUObserverUsesOneExactInputRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
 	s := &growattProtocolIIFC04Fake{words: make([]uint16, 59)}
 	s.words[0] = 1
-	o, err := NewGrowattProtocolIIFC04RTUObserver(identity, s)
+	o, err := NewGrowattProtocolIIFC04RTUObserver(identity, admission, s)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,10 +32,32 @@ func TestGrowattProtocolIIFC04RTUObserverRejectsShortOrFailedRead(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
+	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, s := range []*growattProtocolIIFC04Fake{{words: make([]uint16, 58)}, {err: errors.New("timeout")}} {
-		o, _ := NewGrowattProtocolIIFC04RTUObserver(identity, s)
+		o, _ := NewGrowattProtocolIIFC04RTUObserver(identity, admission, s)
 		if status, err := o.Observe(context.Background()); err == nil || status.Identity().UnitID() != 0 {
 			t.Fatalf("status/err=%#v/%v", status, err)
+		}
+	}
+}
+
+func TestGrowattProtocolIIFC04RTUObserverRejectsMissingOrMismatchedApplicability(t *testing.T) {
+	identity, err := DecodeGrowattProtocolIIIdentity(validGrowattProtocolIIIdentityInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mismatch := validGrowattProtocolIIIdentityInput().Profile
+	mismatch.ModelBuild = [2]uint16{0x1111, 0x2222}
+	admission, err := NewGrowattProtocolIIFC04Applicability(mismatch, "test-exact-mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, candidate := range []GrowattProtocolIIFC04Applicability{{}, admission} {
+		if observer, err := NewGrowattProtocolIIFC04RTUObserver(identity, candidate, &growattProtocolIIFC04Fake{}); err == nil || observer != nil {
+			t.Fatalf("observer/err=%#v/%v", observer, err)
 		}
 	}
 }

--- a/growatt_protocol_ii_fc04_rtu_observer_test.go
+++ b/growatt_protocol_ii_fc04_rtu_observer_test.go
@@ -1,0 +1,58 @@
+package modbusreg
+
+import (
+	"context"
+	"errors"
+	modbus "github.com/Project-Helianthus/helianthus-modbus"
+	"testing"
+)
+
+func TestGrowattProtocolIIFC04RTUObserverUsesOneExactInputRead(t *testing.T) {
+	identity, err := DecodeGrowattProtocolIIIdentity(validGrowattProtocolIIIdentityInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &growattProtocolIIFC04Fake{words: make([]uint16, 59)}
+	s.words[0] = 1
+	o, err := NewGrowattProtocolIIFC04RTUObserver(identity, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := o.Observe(context.Background())
+	if err != nil || status.InverterState != GrowattProtocolIIStateNormal || s.offset != 0 || s.quantity != 59 || s.function != modbus.FunctionReadInputRegisters {
+		t.Fatalf("status/err/session=%#v/%v/%#v", status, err, s)
+	}
+}
+func TestGrowattProtocolIIFC04RTUObserverRejectsShortOrFailedRead(t *testing.T) {
+	identity, err := DecodeGrowattProtocolIIIdentity(validGrowattProtocolIIIdentityInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []*growattProtocolIIFC04Fake{{words: make([]uint16, 58)}, {err: errors.New("timeout")}} {
+		o, _ := NewGrowattProtocolIIFC04RTUObserver(identity, s)
+		if status, err := o.Observe(context.Background()); err == nil || status.Identity().UnitID() != 0 {
+			t.Fatalf("status/err=%#v/%v", status, err)
+		}
+	}
+}
+
+type growattProtocolIIFC04Fake struct {
+	words            []uint16
+	err              error
+	offset, quantity uint16
+	function         modbus.FunctionCode
+}
+
+func (s *growattProtocolIIFC04Fake) ReadInput(_ context.Context, _ byte, r modbus.ReadRegistersRequest) (modbus.ReadRegistersResponse, error) {
+	s.offset, s.quantity, s.function = r.Offset(), r.Quantity(), r.Function()
+	if s.err != nil {
+		return modbus.ReadRegistersResponse{}, s.err
+	}
+	p := make([]byte, 2+len(s.words)*2)
+	p[0] = byte(modbus.FunctionReadInputRegisters)
+	p[1] = byte(len(s.words) * 2)
+	for i, w := range s.words {
+		p[2+i*2], p[3+i*2] = byte(w>>8), byte(w)
+	}
+	return modbus.DecodeReadRegistersResponse(r, p)
+}

--- a/growatt_protocol_ii_fc04_rtu_observer_test.go
+++ b/growatt_protocol_ii_fc04_rtu_observer_test.go
@@ -12,10 +12,7 @@ func TestGrowattProtocolIIFC04RTUObserverUsesOneExactInputRead(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
-	if err != nil {
-		t.Fatal(err)
-	}
+	admission := syntheticGrowattProtocolIIFC04FixtureAdmission(validGrowattProtocolIIIdentityInput().Profile)
 	s := &growattProtocolIIFC04Fake{words: make([]uint16, 59)}
 	s.words[0] = 1
 	o, err := NewGrowattProtocolIIFC04RTUObserver(identity, admission, s)
@@ -32,10 +29,7 @@ func TestGrowattProtocolIIFC04RTUObserverRejectsShortOrFailedRead(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
-	if err != nil {
-		t.Fatal(err)
-	}
+	admission := syntheticGrowattProtocolIIFC04FixtureAdmission(validGrowattProtocolIIIdentityInput().Profile)
 	for _, s := range []*growattProtocolIIFC04Fake{{words: make([]uint16, 58)}, {err: errors.New("timeout")}} {
 		o, _ := NewGrowattProtocolIIFC04RTUObserver(identity, admission, s)
 		if status, err := o.Observe(context.Background()); err == nil || status.Identity().UnitID() != 0 {
@@ -51,10 +45,7 @@ func TestGrowattProtocolIIFC04RTUObserverRejectsMissingOrMismatchedApplicability
 	}
 	mismatch := validGrowattProtocolIIIdentityInput().Profile
 	mismatch.ModelBuild = [2]uint16{0x1111, 0x2222}
-	admission, err := NewGrowattProtocolIIFC04Applicability(mismatch, "test-exact-mapping")
-	if err != nil {
-		t.Fatal(err)
-	}
+	admission := syntheticGrowattProtocolIIFC04FixtureAdmission(mismatch)
 	for _, candidate := range []GrowattProtocolIIFC04Applicability{{}, admission} {
 		if observer, err := NewGrowattProtocolIIFC04RTUObserver(identity, candidate, &growattProtocolIIFC04Fake{}); err == nil || observer != nil {
 			t.Fatalf("observer/err=%#v/%v", observer, err)

--- a/growatt_protocol_ii_fc04_test.go
+++ b/growatt_protocol_ii_fc04_test.go
@@ -7,6 +7,10 @@ func TestDecodeGrowattProtocolIIFC04TelemetryKeepsRawAndProducesBoundedFacts(t *
 	if err != nil {
 		t.Fatal(err)
 	}
+	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
 	words := make([]uint16, 59)
 	words[0] = 1
 	words[1], words[2] = 0, 1234
@@ -17,7 +21,7 @@ func TestDecodeGrowattProtocolIIFC04TelemetryKeepsRawAndProducesBoundedFacts(t *
 	words[53], words[54] = 0, 123
 	words[55], words[56] = 1, 2
 	words[57], words[58] = 0, 8
-	status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, GrowattProtocolIIFC04Slice{Offset: 0, Words: words})
+	status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, admission, GrowattProtocolIIFC04Slice{Offset: 0, Words: words})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,6 +40,10 @@ func TestDecodeGrowattProtocolIIFC04TelemetryFailsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
 	for name, mutate := range map[string]func(*GrowattProtocolIIFC04Slice){
 		"short":  func(s *GrowattProtocolIIFC04Slice) { s.Words = s.Words[:58] },
 		"extra":  func(s *GrowattProtocolIIFC04Slice) { s.Words = append(s.Words, 0) },
@@ -45,9 +53,64 @@ func TestDecodeGrowattProtocolIIFC04TelemetryFailsClosed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			s := GrowattProtocolIIFC04Slice{Words: make([]uint16, 59)}
 			mutate(&s)
-			if status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, s); err == nil || status.Identity().UnitID() != 0 {
+			if status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, admission, s); err == nil || status.Identity().UnitID() != 0 {
 				t.Fatalf("status/err=%#v/%v", status, err)
 			}
 		})
+	}
+}
+
+func TestGrowattProtocolIIFC04TelemetryRequiresSeparateExactApplicability(t *testing.T) {
+	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	words := make([]uint16, 59)
+	words[0] = 1
+
+	for name, mutate := range map[string]func(*GrowattProtocolIIIdentityInput){
+		"unknown exact tuple": func(input *GrowattProtocolIIIdentityInput) {
+			input.Profile.DeviceType = 0xbeef
+			input.Profile.ModelBuild = [2]uint16{0x1111, 0x2222}
+			input.Profile.ProtocolVersion = 0x9999
+			input.Slices[2].Words[0] = 0xbeef
+			input.Slices[3].Words = []uint16{0x1111, 0x2222}
+			input.Slices[4].Words[0] = 0x9999
+		},
+		"unknown device type": func(input *GrowattProtocolIIIdentityInput) {
+			input.Profile.DeviceType = 0xbeef
+			input.Slices[2].Words[0] = 0xbeef
+		},
+		"unknown model build": func(input *GrowattProtocolIIIdentityInput) {
+			input.Profile.ModelBuild = [2]uint16{0x1111, 0x2222}
+			input.Slices[3].Words = []uint16{0x1111, 0x2222}
+		},
+		"unknown protocol version": func(input *GrowattProtocolIIIdentityInput) {
+			input.Profile.ProtocolVersion = 0x9999
+			input.Slices[4].Words[0] = 0x9999
+		},
+		"profile mismatch": func(input *GrowattProtocolIIIdentityInput) {
+			input.Profile.Family = "MID"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := validGrowattProtocolIIIdentityInput()
+			mutate(&input)
+			identity, err := DecodeGrowattProtocolIIIdentity(input)
+			if err != nil {
+				t.Fatalf("raw identity observation should remain available: %v", err)
+			}
+			if status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, admission, GrowattProtocolIIFC04Slice{Words: words}); err == nil || status.Identity().UnitID() != 0 {
+				t.Fatalf("status/err=%#v/%v", status, err)
+			}
+		})
+	}
+
+	identity, err := DecodeGrowattProtocolIIIdentity(validGrowattProtocolIIIdentityInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, GrowattProtocolIIFC04Applicability{}, GrowattProtocolIIFC04Slice{Words: words}); err == nil || status.Identity().UnitID() != 0 {
+		t.Fatalf("missing admission status/err=%#v/%v", status, err)
 	}
 }

--- a/growatt_protocol_ii_fc04_test.go
+++ b/growatt_protocol_ii_fc04_test.go
@@ -7,10 +7,7 @@ func TestDecodeGrowattProtocolIIFC04TelemetryKeepsRawAndProducesBoundedFacts(t *
 	if err != nil {
 		t.Fatal(err)
 	}
-	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
-	if err != nil {
-		t.Fatal(err)
-	}
+	admission := syntheticGrowattProtocolIIFC04FixtureAdmission(validGrowattProtocolIIIdentityInput().Profile)
 	words := make([]uint16, 59)
 	words[0] = 1
 	words[1], words[2] = 0, 1234
@@ -40,10 +37,7 @@ func TestDecodeGrowattProtocolIIFC04TelemetryFailsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
-	if err != nil {
-		t.Fatal(err)
-	}
+	admission := syntheticGrowattProtocolIIFC04FixtureAdmission(validGrowattProtocolIIIdentityInput().Profile)
 	for name, mutate := range map[string]func(*GrowattProtocolIIFC04Slice){
 		"short":  func(s *GrowattProtocolIIFC04Slice) { s.Words = s.Words[:58] },
 		"extra":  func(s *GrowattProtocolIIFC04Slice) { s.Words = append(s.Words, 0) },
@@ -61,10 +55,7 @@ func TestDecodeGrowattProtocolIIFC04TelemetryFailsClosed(t *testing.T) {
 }
 
 func TestGrowattProtocolIIFC04TelemetryRequiresSeparateExactApplicability(t *testing.T) {
-	admission, err := NewGrowattProtocolIIFC04Applicability(validGrowattProtocolIIIdentityInput().Profile, "test-exact-mapping")
-	if err != nil {
-		t.Fatal(err)
-	}
+	admission := syntheticGrowattProtocolIIFC04FixtureAdmission(validGrowattProtocolIIIdentityInput().Profile)
 	words := make([]uint16, 59)
 	words[0] = 1
 
@@ -113,4 +104,11 @@ func TestGrowattProtocolIIFC04TelemetryRequiresSeparateExactApplicability(t *tes
 	if status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, GrowattProtocolIIFC04Applicability{}, GrowattProtocolIIFC04Slice{Words: words}); err == nil || status.Identity().UnitID() != 0 {
 		t.Fatalf("missing admission status/err=%#v/%v", status, err)
 	}
+}
+
+// syntheticGrowattProtocolIIFC04FixtureAdmission exercises the source-backed
+// FC04 schema in package tests only. It cannot establish real-build
+// qualification and is deliberately unavailable to public callers.
+func syntheticGrowattProtocolIIFC04FixtureAdmission(profile GrowattProtocolIIIdentityProfile) GrowattProtocolIIFC04Applicability {
+	return GrowattProtocolIIFC04Applicability{profile: profile, syntheticFixture: true}
 }

--- a/growatt_protocol_ii_fc04_test.go
+++ b/growatt_protocol_ii_fc04_test.go
@@ -1,0 +1,53 @@
+package modbusreg
+
+import "testing"
+
+func TestDecodeGrowattProtocolIIFC04TelemetryKeepsRawAndProducesBoundedFacts(t *testing.T) {
+	identity, err := DecodeGrowattProtocolIIIdentity(validGrowattProtocolIIIdentityInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	words := make([]uint16, 59)
+	words[0] = 1
+	words[1], words[2] = 0, 1234
+	words[35], words[36] = 0, 567
+	words[37], words[38], words[39] = 5000, 2301, 42
+	words[42], words[43] = 2302, 43
+	words[46], words[47] = 2303, 44
+	words[53], words[54] = 0, 123
+	words[55], words[56] = 1, 2
+	words[57], words[58] = 0, 8
+	status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, GrowattProtocolIIFC04Slice{Offset: 0, Words: words})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.InverterState != GrowattProtocolIIStateNormal || status.PVInputPowerWatts != 123.4 || status.OutputPowerWatts != 56.7 || status.GridFrequencyHz != 50 || status.Phase1VoltageVolts != 230.1 || status.Phase3CurrentAmps != 4.4 || status.TodayGeneratedEnergyKWh != 12.3 || status.TotalGeneratedEnergyKWh != 6553.8 || status.WorkTimeSeconds != 4 {
+		t.Fatalf("status=%#v", status)
+	}
+	raw := status.RawSlice()
+	raw.Words[1] = 0
+	if status.RawSlice().Words[1] != 0 {
+		t.Fatal("raw slice aliases typed observation")
+	}
+}
+
+func TestDecodeGrowattProtocolIIFC04TelemetryFailsClosed(t *testing.T) {
+	identity, err := DecodeGrowattProtocolIIIdentity(validGrowattProtocolIIIdentityInput())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*GrowattProtocolIIFC04Slice){
+		"short":  func(s *GrowattProtocolIIFC04Slice) { s.Words = s.Words[:58] },
+		"extra":  func(s *GrowattProtocolIIFC04Slice) { s.Words = append(s.Words, 0) },
+		"offset": func(s *GrowattProtocolIIFC04Slice) { s.Offset = 1 },
+		"enum":   func(s *GrowattProtocolIIFC04Slice) { s.Words[0] = 2 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := GrowattProtocolIIFC04Slice{Words: make([]uint16, 59)}
+			mutate(&s)
+			if status, err := DecodeGrowattProtocolIIFC04Telemetry(identity, s); err == nil || status.Identity().UnitID() != 0 {
+				t.Fatalf("status/err=%#v/%v", status, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #194

This supersedes the P1-blocked review head
`70dbcfe0bb564d5aa59953abac02c1b0225026d3`. The corrected head exposes no
public successful constructor or other public admission path for a typed
Growatt Protocol II FC04 profile. The supplied v1.24 manual establishes no
admissible exact device-type/model-build/protocol tuple. The opaque applicability
value therefore fails closed in all externally constructible forms.

The existing caller-selected FC03 identity remains a raw/native observation.
The source-backed FC04 schema, 59-word fixture decoder, field/scaling/state
mechanics, defensive raw retention, and deterministic read seam remain covered
through an unexported in-package synthetic fixture helper. That helper cannot
establish real-build qualification. An external-package regression proves that
the reviewed `0xbeef` / `1111,2222` / `9999` combined tuple and each independent
mutation retain raw FC03 identity but cannot create typed telemetry or an
observer; it also proves the old public constructor symbol is unavailable.

The authorized Protocol II v1.24 manual does not provide a tuple mapping, so
this PR adds no built-in tuple, does not infer wire value `1.24`, and does not
introduce a trust/attestation runtime. Public typed admission remains disabled
until an owning source establishes one exact device-type, model-build, and
protocol-value tuple tied to the FC04 schema.

Validation: RED `GOWORK=off go test -run TestGrowattProtocolIIFC04HasNoPublicAdmissionPath ./...` failed before the change because the public constructor existed. GREEN focused external API regression, `./scripts/ci_local.sh` (scope policy, 14 mutation tests, gofmt, vet, build, race tests, and golangci-lint with zero issues), and `GOWORK=off go test -race -count=1 ./...` all pass.

Docs gate: required companion #142 at `1ce9af9e8d8f52d565a9077775618ffed837b245`, which supersedes the P1-blocked companion head `5c30a726f42c5b877f260f8dc071829c2c97f842`. No detector, automatic admission, write, gateway/semantic import, consumer activation, live claim, or provider closure is added. Fresh independent exact-HEAD review remains required before merge; do not merge this PR yet.
